### PR TITLE
[AGENT] Treat verification events as moderation cases

### DIFF
--- a/docs/cases.md
+++ b/docs/cases.md
@@ -1,0 +1,44 @@
+# Moderation Cases
+
+Drasil currently treats `verification_events` as local moderation cases. A
+separate `cases` table is not needed yet because the existing model already
+captures the near-term lifecycle for one user in one server.
+
+## Current Model
+
+- `verification_events` is the case record for a user in a server.
+- `detection_events` records why the case was opened or updated.
+- `admin_actions` records moderator lifecycle actions against the case.
+- Discord verification threads and admin notifications are case surfaces.
+
+## Statuses
+
+- `pending`: the case is open and needs moderator review.
+- `verified`: the case was resolved as legitimate, and the user was unrestricted.
+- `banned`: the case was resolved by banning the user.
+
+Additional product labels such as `duplicate`, `needs_more_info`,
+`resolved_no_action`, or `false_report` should be added only when a concrete UI
+or moderation workflow requires them.
+
+## Case Entry Points
+
+- Suspicious message or join: creates or reuses a pending case based on the
+  detection result.
+- User report: creates a `user_report` detection event and creates or reuses a
+  pending case.
+- Manual flag: creates a detection event with `metadata.type = "admin_flag"` and
+  creates or reuses a pending case.
+
+If the target user already has a pending case in that server, Drasil records the
+new detection event, links it to the existing `verification_event`, and updates
+the existing admin notification instead of opening a duplicate case. If the
+previous case is resolved, a later report or flag opens a new pending case.
+
+## Schema Decision
+
+Use `verification_events` as the local case model for now. A separate `cases`
+table should be considered only if Drasil needs richer case types that do not
+map to a user/server verification lifecycle, such as cross-server intelligence
+cases, multi-user incidents, evidence-only investigations, or global review
+workflows.

--- a/docs/test-cases.md
+++ b/docs/test-cases.md
@@ -8,8 +8,11 @@ For a real-server walkthrough, use `docs/manual-qa.md`.
 - Additional suspicious message while pending: no new verification event; notification updated.
 - New suspicious message after verification resolved: new verification event and new notification message.
 - Suspicious join: same flow as suspicious message.
-- Manual flag: creates a detection event and follows the same flow.
-- User report: creates a detection event with `USER_REPORT` and follows the same flow.
+- Manual flag: creates a detection event with admin flag metadata and follows the same case flow.
+- User report: creates a detection event with `USER_REPORT` and follows the same case flow.
+- User report or manual flag while pending: records a new detection event but reuses the existing case.
+- Repeated pending-case reports/flags link the new detection event to the reused case.
+- User report or manual flag after resolution: opens a new pending case.
 - Verify button: restricted role removed, thread resolved, notification updated, admin action logged.
 - Ban button: member banned, verification status set to BANNED (if present), thread resolved, admin action logged.
 - Reopen button: verification returns to PENDING, thread reopened, user restricted again.
@@ -25,6 +28,13 @@ For a real-server walkthrough, use `docs/manual-qa.md`.
   - Updates the admin notification only.
 - `SecurityActionService.handleUserReport`
   - Creates `detection_event` with `detection_type = USER_REPORT` and reporter metadata.
+  - Reuses an existing pending `verification_event` instead of creating a duplicate case.
+  - Links repeated reports to the reused pending `verification_event`.
+  - Opens a new pending `verification_event` after a previous case was resolved.
+- `SecurityActionService.handleManualFlag`
+  - Creates `detection_event` with admin flag metadata.
+  - Reuses an existing pending `verification_event` instead of creating a duplicate case.
+  - Links repeated manual flags to the reused pending `verification_event`.
 - `UserModerationService.verifyUser`
   - Updates `verification_event` to VERIFIED with `resolved_by` and `resolved_at`.
   - Removes restricted role and updates `server_member`.

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -3,6 +3,10 @@
 This project uses direct orchestration (no internal EventBus). Controllers call
 services, and services handle side effects in a single flow.
 
+`verification_events` are Drasil's current local moderation cases. See
+`docs/cases.md` for the product-language mapping between cases, detection
+events, admin actions, and Discord surfaces.
+
 ## Suspicious message or join
 
 1. `EventHandler` receives a guild message or a new member join (DMs are ignored).
@@ -13,32 +17,32 @@ services, and services handle side effects in a single flow.
 4. `SecurityActionService`:
    - Ensures `server`, `user`, and `server_member` records exist.
    - Ensures a `detection_event` record exists (creates one if needed).
-   - If an active verification exists, updates the admin notification only.
-   - Otherwise creates a `verification_event` (PENDING), restricts the user,
+   - If an active case exists, updates the admin notification only.
+   - Otherwise creates a `verification_event` case (PENDING), restricts the user,
      creates a verification thread, and upserts the admin notification.
 
 ## Manual flag
 
 1. Admin initiates a manual flag.
 2. `SecurityActionService.handleManualFlag` creates a `detection_event` with
-   `detection_type = GPT_ANALYSIS` and follows the same flow as above.
+   `metadata.type = "admin_flag"` and follows the same case flow as above.
 
 ## User report
 
 1. A user submits the report modal.
 2. `SecurityActionService.handleUserReport` creates a `detection_event` with
-   `detection_type = USER_REPORT` and follows the same flow as above.
+   `detection_type = USER_REPORT` and follows the same case flow as above.
 
 ## Admin verify or ban
 
 1. `InteractionHandler` or `CommandHandler` calls `UserModerationService`.
 2. Verify:
-   - Update `verification_event` to VERIFIED with `resolved_by` and `resolved_at`.
+   - Update the case to VERIFIED with `resolved_by` and `resolved_at`.
    - Remove restricted role and update `server_member`.
    - Resolve the verification thread and update the admin notification.
    - Record the admin action.
 3. Ban:
-   - Update `verification_event` to BANNED if one exists.
+   - Update the case to BANNED if one exists.
    - Ban the member in Discord.
    - Update `server_member`.
    - Resolve the thread, update the admin notification, and record the admin action.

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -17,7 +17,8 @@ events, admin actions, and Discord surfaces.
 4. `SecurityActionService`:
    - Ensures `server`, `user`, and `server_member` records exist.
    - Ensures a `detection_event` record exists (creates one if needed).
-   - If an active case exists, updates the admin notification only.
+   - If an active case exists, links the detection event to that case and
+     updates the admin notification.
    - Otherwise creates a `verification_event` case (PENDING), restricts the user,
      creates a verification thread, and upserts the admin notification.
 

--- a/src/__tests__/fakes/inMemoryRepositories.ts
+++ b/src/__tests__/fakes/inMemoryRepositories.ts
@@ -74,6 +74,7 @@ export class InMemoryDetectionEventsRepository implements IDetectionEventsReposi
       thread_id: data.thread_id ?? null,
       message_id: data.message_id ?? null,
       channel_id: data.channel_id ?? null,
+      latest_verification_event_id: data.latest_verification_event_id ?? null,
       metadata: data.metadata ?? {},
     };
 
@@ -130,6 +131,23 @@ export class InMemoryDetectionEventsRepository implements IDetectionEventsReposi
   async findById(id: string): Promise<DetectionEvent | null> {
     const event = this.events.find((item) => item.id === id);
     return event ? { ...event } : null;
+  }
+
+  async linkToVerificationEvent(
+    detectionEventId: string,
+    verificationEventId: string
+  ): Promise<DetectionEvent | null> {
+    const eventIndex = this.events.findIndex((item) => item.id === detectionEventId);
+    if (eventIndex === -1) {
+      return null;
+    }
+
+    const updated = {
+      ...this.events[eventIndex],
+      latest_verification_event_id: verificationEventId,
+    };
+    this.events[eventIndex] = updated;
+    return { ...updated };
   }
 }
 

--- a/src/__tests__/unit/DetectionHistoryFormatter.unit.test.ts
+++ b/src/__tests__/unit/DetectionHistoryFormatter.unit.test.ts
@@ -15,6 +15,7 @@ describe('DetectionHistoryFormatter (unit)', () => {
         thread_id: null,
         message_id: null,
         channel_id: null,
+        latest_verification_event_id: null,
         metadata: {},
       },
       {
@@ -28,6 +29,7 @@ describe('DetectionHistoryFormatter (unit)', () => {
         thread_id: null,
         message_id: 'msg-1',
         channel_id: 'chan-1',
+        latest_verification_event_id: null,
         metadata: { content: 'free discord nitro' },
       },
     ];

--- a/src/__tests__/unit/SecurityActionService.unit.test.ts
+++ b/src/__tests__/unit/SecurityActionService.unit.test.ts
@@ -132,6 +132,7 @@ describe('SecurityActionService (unit)', () => {
     expect(verificationEvents).toHaveLength(1);
     expect(verificationEvents[0].status).toBe(VerificationStatus.PENDING);
     expect(verificationEvents[0].notification_message_id).toBe('notif-1');
+    expect(detectionEvents[0].latest_verification_event_id).toBe(verificationEvents[0].id);
 
     expect(userModerationService.restrictUser).toHaveBeenCalledWith(member);
     expect(threadManager.createVerificationThread).toHaveBeenCalledTimes(1);
@@ -152,7 +153,7 @@ describe('SecurityActionService (unit)', () => {
       detected_at: new Date(),
     });
 
-    await verificationEventRepository.createFromDetection(
+    const activeCase = await verificationEventRepository.createFromDetection(
       detectionEvent.id,
       guildId,
       userId,
@@ -165,7 +166,6 @@ describe('SecurityActionService (unit)', () => {
       reasons: ['Follow-up detection'],
       triggerSource: DetectionType.SUSPICIOUS_CONTENT,
       triggerContent: 'suspicious follow-up',
-      detectionEventId: detectionEvent.id,
     };
 
     const service = new SecurityActionService(
@@ -188,6 +188,12 @@ describe('SecurityActionService (unit)', () => {
       guildId
     );
     expect(verificationEvents).toHaveLength(1);
+
+    const detectionEvents = await detectionEventsRepository.findByServerAndUser(guildId, userId);
+    expect(detectionEvents).toHaveLength(2);
+    const followUpDetection = detectionEvents.find((event) => event.id !== detectionEvent.id);
+    expect(followUpDetection?.latest_verification_event_id).toBe(activeCase.id);
+
     expect(threadManager.createVerificationThread).not.toHaveBeenCalled();
     expect(userModerationService.restrictUser).not.toHaveBeenCalled();
     expect(notificationManager.upsertSuspiciousUserNotification).toHaveBeenCalledTimes(1);

--- a/src/__tests__/unit/SecurityActionService.unit.test.ts
+++ b/src/__tests__/unit/SecurityActionService.unit.test.ts
@@ -77,6 +77,20 @@ describe('SecurityActionService (unit)', () => {
     } as unknown as jest.Mocked<IAdminActionService>;
   });
 
+  const buildService = (client: Client = {} as Client): SecurityActionService =>
+    new SecurityActionService(
+      notificationManager,
+      detectionEventsRepository,
+      serverMemberRepository,
+      verificationEventRepository,
+      userRepository,
+      serverRepository,
+      adminActionService,
+      threadManager,
+      userModerationService,
+      client
+    );
+
   it('creates detection and verification when none exists', async () => {
     const guildId = 'guild-1';
     const userId = 'user-1';
@@ -207,6 +221,15 @@ describe('SecurityActionService (unit)', () => {
       type: 'user_report',
       reporterId,
     });
+
+    const verificationEvents = await verificationEventRepository.findByUserAndServer(
+      userId,
+      guildId
+    );
+    expect(verificationEvents).toHaveLength(1);
+    expect(verificationEvents[0].status).toBe(VerificationStatus.PENDING);
+    expect(userModerationService.restrictUser).toHaveBeenCalled();
+    expect(threadManager.createVerificationThread).toHaveBeenCalled();
   });
 
   it('creates detection event for manual flag', async () => {
@@ -239,6 +262,162 @@ describe('SecurityActionService (unit)', () => {
     });
     expect(userModerationService.restrictUser).toHaveBeenCalled();
     expect(threadManager.createVerificationThread).toHaveBeenCalled();
+  });
+
+  it('adds a user report to an existing pending case without creating a duplicate case', async () => {
+    const guildId = 'guild-4a';
+    const userId = 'user-4a';
+    const reporterId = 'reporter-2';
+    const member = buildMember(guildId, userId);
+
+    const initialDetection = await detectionEventsRepository.create({
+      server_id: guildId,
+      user_id: userId,
+      detection_type: DetectionType.SUSPICIOUS_CONTENT,
+      confidence: 0.8,
+      reasons: ['Initial detection'],
+      detected_at: new Date(),
+    });
+    const activeCase = await verificationEventRepository.createFromDetection(
+      initialDetection.id,
+      guildId,
+      userId,
+      VerificationStatus.PENDING
+    );
+
+    await buildService().handleUserReport(member, { id: reporterId } as User, 'follow-up report');
+
+    const detectionEvents = await detectionEventsRepository.findByServerAndUser(guildId, userId);
+    expect(detectionEvents).toHaveLength(2);
+    const reportEvent = detectionEvents.find(
+      (event) => event.detection_type === DetectionType.USER_REPORT
+    );
+    expect(reportEvent?.latest_verification_event_id).toBe(activeCase.id);
+
+    const verificationEvents = await verificationEventRepository.findByUserAndServer(
+      userId,
+      guildId
+    );
+    expect(verificationEvents).toHaveLength(1);
+    expect(verificationEvents[0].status).toBe(VerificationStatus.PENDING);
+    expect(userModerationService.restrictUser).not.toHaveBeenCalled();
+    expect(threadManager.createVerificationThread).not.toHaveBeenCalled();
+    expect(notificationManager.upsertSuspiciousUserNotification).toHaveBeenCalledTimes(1);
+  });
+
+  it('adds a manual flag to an existing pending case without creating a duplicate case', async () => {
+    const guildId = 'guild-4b';
+    const userId = 'user-4b';
+    const moderatorId = 'admin-2';
+    const member = buildMember(guildId, userId);
+
+    const initialDetection = await detectionEventsRepository.create({
+      server_id: guildId,
+      user_id: userId,
+      detection_type: DetectionType.USER_REPORT,
+      confidence: 1.0,
+      reasons: ['Initial report'],
+      detected_at: new Date(),
+    });
+    const activeCase = await verificationEventRepository.createFromDetection(
+      initialDetection.id,
+      guildId,
+      userId,
+      VerificationStatus.PENDING
+    );
+
+    await buildService().handleManualFlag(member, { id: moderatorId } as User, 'admin follow-up');
+
+    const detectionEvents = await detectionEventsRepository.findByServerAndUser(guildId, userId);
+    expect(detectionEvents).toHaveLength(2);
+    const manualFlagEvent = detectionEvents.find((event) => event.metadata?.type === 'admin_flag');
+    expect(manualFlagEvent?.metadata).toMatchObject({
+      type: 'admin_flag',
+      adminId: moderatorId,
+    });
+    expect(manualFlagEvent?.latest_verification_event_id).toBe(activeCase.id);
+
+    const verificationEvents = await verificationEventRepository.findByUserAndServer(
+      userId,
+      guildId
+    );
+    expect(verificationEvents).toHaveLength(1);
+    expect(verificationEvents[0].status).toBe(VerificationStatus.PENDING);
+    expect(userModerationService.restrictUser).not.toHaveBeenCalled();
+    expect(threadManager.createVerificationThread).not.toHaveBeenCalled();
+    expect(notificationManager.upsertSuspiciousUserNotification).toHaveBeenCalledTimes(1);
+  });
+
+  it('opens a new pending case when a user report follows a resolved case', async () => {
+    const guildId = 'guild-4c';
+    const userId = 'user-4c';
+    const reporterId = 'reporter-3';
+    const member = buildMember(guildId, userId);
+
+    const initialDetection = await detectionEventsRepository.create({
+      server_id: guildId,
+      user_id: userId,
+      detection_type: DetectionType.SUSPICIOUS_CONTENT,
+      confidence: 0.8,
+      reasons: ['Initial detection'],
+      detected_at: new Date(),
+    });
+    await verificationEventRepository.createFromDetection(
+      initialDetection.id,
+      guildId,
+      userId,
+      VerificationStatus.VERIFIED
+    );
+
+    await buildService().handleUserReport(member, { id: reporterId } as User, 'new report');
+
+    const verificationEvents = await verificationEventRepository.findByUserAndServer(
+      userId,
+      guildId
+    );
+    expect(verificationEvents).toHaveLength(2);
+    expect(verificationEvents.map((event) => event.status).sort()).toEqual([
+      VerificationStatus.PENDING,
+      VerificationStatus.VERIFIED,
+    ]);
+    expect(userModerationService.restrictUser).toHaveBeenCalledWith(member);
+    expect(threadManager.createVerificationThread).toHaveBeenCalledTimes(1);
+  });
+
+  it('opens a new pending case when a manual flag follows a resolved case', async () => {
+    const guildId = 'guild-4d';
+    const userId = 'user-4d';
+    const moderatorId = 'admin-3';
+    const member = buildMember(guildId, userId);
+
+    const initialDetection = await detectionEventsRepository.create({
+      server_id: guildId,
+      user_id: userId,
+      detection_type: DetectionType.USER_REPORT,
+      confidence: 1.0,
+      reasons: ['Initial report'],
+      detected_at: new Date(),
+    });
+    await verificationEventRepository.createFromDetection(
+      initialDetection.id,
+      guildId,
+      userId,
+      VerificationStatus.BANNED
+    );
+
+    await buildService().handleManualFlag(member, { id: moderatorId } as User, 'new admin flag');
+
+    const verificationEvents = await verificationEventRepository.findByUserAndServer(
+      userId,
+      guildId
+    );
+    expect(verificationEvents).toHaveLength(2);
+    expect(verificationEvents.map((event) => event.status).sort()).toEqual([
+      VerificationStatus.BANNED,
+      VerificationStatus.PENDING,
+    ]);
+    expect(userModerationService.restrictUser).toHaveBeenCalledWith(member);
+    expect(threadManager.createVerificationThread).toHaveBeenCalledTimes(1);
   });
 
   it('reopens verification and re-restricts the user', async () => {

--- a/src/repositories/DetectionEventsRepository.ts
+++ b/src/repositories/DetectionEventsRepository.ts
@@ -16,6 +16,10 @@ export interface IDetectionEventsRepository {
     action: 'Verified' | 'Banned' | 'Ignored', // Keep string literal type for now
     adminId: string
   ): Promise<DetectionEvent | null>;
+  linkToVerificationEvent(
+    detectionEventId: string,
+    verificationEventId: string
+  ): Promise<DetectionEvent | null>;
   cleanupOldEvents(retentionDays: number): Promise<number>;
   findById(id: string): Promise<DetectionEvent | null>; // Add findById for consistency
 }
@@ -162,6 +166,28 @@ export class DetectionEventsRepository implements IDetectionEventsRepository {
         return null;
       }
       this.handleError(error, 'recordAdminAction');
+    }
+  }
+
+  /**
+   * Link a detection event to the case it most recently updated.
+   */
+  async linkToVerificationEvent(
+    detectionEventId: string,
+    verificationEventId: string
+  ): Promise<DetectionEvent | null> {
+    try {
+      const updatedEvent = await this.prisma.detection_events.update({
+        where: { id: detectionEventId },
+        data: { latest_verification_event_id: verificationEventId },
+      });
+      return updatedEvent as DetectionEvent | null;
+    } catch (error) {
+      if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2025') {
+        console.warn(`Attempted to link non-existent detection event: ${detectionEventId}`);
+        return null;
+      }
+      this.handleError(error, 'linkToVerificationEvent');
     }
   }
 

--- a/src/repositories/types.ts
+++ b/src/repositories/types.ts
@@ -101,7 +101,7 @@ export interface DetectionEvent {
   confidence: number; // 0.0 to 1.0
   reasons: string[];
   detected_at: string | Date;
-  latest_verification_event_id?: string | null;
+  latest_verification_event_id: string | null;
   metadata?: Record<string, unknown>;
 }
 

--- a/src/repositories/types.ts
+++ b/src/repositories/types.ts
@@ -101,6 +101,7 @@ export interface DetectionEvent {
   confidence: number; // 0.0 to 1.0
   reasons: string[];
   detected_at: string | Date;
+  latest_verification_event_id?: string | null;
   metadata?: Record<string, unknown>;
 }
 

--- a/src/services/SecurityActionService.ts
+++ b/src/services/SecurityActionService.ts
@@ -273,6 +273,16 @@ export class SecurityActionService implements ISecurityActionService {
       VerificationStatus.PENDING
     );
 
+    const linkedDetectionEvent = await this.detectionEventsRepository.linkToVerificationEvent(
+      detectionEventId,
+      newVerificationEvent.id
+    );
+    if (!linkedDetectionEvent) {
+      throw new Error(
+        `Failed to link detection event ${detectionEventId} to verification event ${newVerificationEvent.id}`
+      );
+    }
+
     const restricted = await this.userModerationService.restrictUser(member);
     if (!restricted) {
       throw new Error(`Failed to restrict user ${member.user.tag}`);

--- a/src/services/SecurityActionService.ts
+++ b/src/services/SecurityActionService.ts
@@ -244,6 +244,15 @@ export class SecurityActionService implements ISecurityActionService {
       console.log(
         `Active verification ${activeVerificationEvent.id} found for user ${member.user.tag}. Updating notification.`
       );
+      const linkedDetectionEvent = await this.detectionEventsRepository.linkToVerificationEvent(
+        detectionEventId,
+        activeVerificationEvent.id
+      );
+      if (!linkedDetectionEvent) {
+        throw new Error(
+          `Failed to link detection event ${detectionEventId} to verification event ${activeVerificationEvent.id}`
+        );
+      }
       await this.upsertNotification(
         member,
         detectionResult,


### PR DESCRIPTION
## Summary
- Documents verification_events as Drasil's current local moderation case model and records the no-new-cases-table decision for now.
- Links repeated detections to the reused pending verification event so report/manual flag context stays attached to the active case.
- Adds unit coverage for report/manual flag case creation, pending-case reuse, detection linking, and new-case creation after resolution.

## Test plan
- npm run format:check
- npm run lint
- npm run build
- npm test
- npx jest src/__tests__/unit/SecurityActionService.unit.test.ts
- git diff --check

Closes #44