### PR TITLE
[AGENT] Skip automatic detection for moderators

### DIFF
--- a/src/__tests__/unit/EventHandler.unit.test.ts
+++ b/src/__tests__/unit/EventHandler.unit.test.ts
@@ -1,4 +1,4 @@
-import { GuildMember, Message } from 'discord.js';
+import { GuildMember, Message, PermissionFlagsBits, PermissionsBitField } from 'discord.js';
 import { EventHandler } from '../../controllers/EventHandler';
 import { DetectionType } from '../../repositories/types';
 
@@ -15,7 +15,13 @@ describe('EventHandler (unit)', () => {
         triggerSource: DetectionType.SUSPICIOUS_CONTENT,
         triggerContent: 'hello',
       }),
-      detectNewJoin: jest.fn(),
+      detectNewJoin: jest.fn().mockResolvedValue({
+        label: 'OK',
+        confidence: 0,
+        reasons: [],
+        triggerSource: DetectionType.NEW_ACCOUNT,
+        triggerContent: 'Server Join',
+      }),
     };
 
     const configService = overrides?.configService ?? {
@@ -44,22 +50,27 @@ describe('EventHandler (unit)', () => {
     );
   }
 
-  function buildMessage(hasModerationPermission: boolean): Message {
-    const member = {
+  function buildMember(permissions: PermissionsBitField): GuildMember {
+    return {
       id: 'user-1',
       nickname: null,
       joinedAt: new Date('2024-01-01T00:00:00.000Z'),
       guild: { id: 'guild-1' },
       user: {
         id: 'user-1',
+        tag: 'test-user#0001',
         username: 'test-user',
         discriminator: '0001',
         createdTimestamp: new Date('2020-01-01T00:00:00.000Z').getTime(),
       },
-      permissions: {
-        has: jest.fn().mockReturnValue(hasModerationPermission),
-      },
+      permissions,
     } as unknown as GuildMember;
+  }
+
+  function buildMessage(permissions: PermissionsBitField): Message {
+    const member = {
+      ...buildMember(permissions),
+    } as GuildMember;
 
     return {
       author: { bot: false, id: 'user-1' },
@@ -82,7 +93,9 @@ describe('EventHandler (unit)', () => {
     };
     const handler = buildHandler({ detectionOrchestrator, configService });
 
-    await (handler as any).handleMessage(buildMessage(true));
+    await (handler as any).handleMessage(
+      buildMessage(new PermissionsBitField(PermissionFlagsBits.KickMembers))
+    );
 
     expect(configService.initialize).not.toHaveBeenCalled();
     expect(detectionOrchestrator.detectMessage).not.toHaveBeenCalled();
@@ -101,12 +114,59 @@ describe('EventHandler (unit)', () => {
     };
     const handler = buildHandler({ detectionOrchestrator });
 
-    await (handler as any).handleMessage(buildMessage(false));
+    await (handler as any).handleMessage(buildMessage(new PermissionsBitField()));
 
     expect(detectionOrchestrator.detectMessage).toHaveBeenCalledWith(
       'guild-1',
       'user-1',
       'free nitro',
+      expect.objectContaining({
+        serverId: 'guild-1',
+        userId: 'user-1',
+        username: 'test-user',
+      })
+    );
+  });
+
+  it('skips automatic join detection for moderation members before config lookup', async () => {
+    const detectionOrchestrator = {
+      detectMessage: jest.fn(),
+      detectNewJoin: jest.fn(),
+    };
+    const configService = {
+      initialize: jest.fn(),
+      getCachedServerConfig: jest.fn(),
+      getServerConfig: jest.fn(),
+    };
+    const handler = buildHandler({ detectionOrchestrator, configService });
+
+    await (handler as any).handleGuildMemberAdd(
+      buildMember(new PermissionsBitField(PermissionFlagsBits.ModerateMembers))
+    );
+
+    expect(configService.initialize).not.toHaveBeenCalled();
+    expect(configService.getServerConfig).not.toHaveBeenCalled();
+    expect(detectionOrchestrator.detectNewJoin).not.toHaveBeenCalled();
+  });
+
+  it('runs automatic join detection for regular members', async () => {
+    const detectionOrchestrator = {
+      detectMessage: jest.fn(),
+      detectNewJoin: jest.fn().mockResolvedValue({
+        label: 'OK',
+        confidence: 0,
+        reasons: [],
+        triggerSource: DetectionType.NEW_ACCOUNT,
+        triggerContent: 'Server Join',
+      }),
+    };
+    const handler = buildHandler({ detectionOrchestrator });
+
+    await (handler as any).handleGuildMemberAdd(buildMember(new PermissionsBitField()));
+
+    expect(detectionOrchestrator.detectNewJoin).toHaveBeenCalledWith(
+      'guild-1',
+      'user-1',
       expect.objectContaining({
         serverId: 'guild-1',
         userId: 'user-1',

--- a/src/__tests__/unit/EventHandler.unit.test.ts
+++ b/src/__tests__/unit/EventHandler.unit.test.ts
@@ -1,0 +1,117 @@
+import { GuildMember, Message } from 'discord.js';
+import { EventHandler } from '../../controllers/EventHandler';
+import { DetectionType } from '../../repositories/types';
+
+describe('EventHandler (unit)', () => {
+  function buildHandler(overrides?: {
+    detectionOrchestrator?: Record<string, jest.Mock>;
+    configService?: Record<string, jest.Mock>;
+  }): EventHandler {
+    const detectionOrchestrator = overrides?.detectionOrchestrator ?? {
+      detectMessage: jest.fn().mockResolvedValue({
+        label: 'OK',
+        confidence: 0,
+        reasons: [],
+        triggerSource: DetectionType.SUSPICIOUS_CONTENT,
+        triggerContent: 'hello',
+      }),
+      detectNewJoin: jest.fn(),
+    };
+
+    const configService = overrides?.configService ?? {
+      initialize: jest.fn().mockResolvedValue(undefined),
+      getCachedServerConfig: jest.fn().mockReturnValue({}),
+      getServerConfig: jest.fn().mockResolvedValue({
+        settings: {
+          detection_response_mode: 'notify_only',
+          min_confidence_threshold: 70,
+        },
+      }),
+    };
+
+    return new EventHandler(
+      { on: jest.fn() } as any,
+      detectionOrchestrator as any,
+      {
+        upsertObservedDetectionNotification: jest.fn(),
+        setupVerificationChannel: jest.fn(),
+      } as any,
+      configService as any,
+      { handleSuspiciousMessage: jest.fn(), openCaseForSuspiciousMessage: jest.fn() } as any,
+      { handleTestCommands: jest.fn(), registerCommands: jest.fn() } as any,
+      { handleButtonInteraction: jest.fn(), handleModalSubmit: jest.fn() } as any,
+      { handleThreadMessage: jest.fn().mockResolvedValue(false) } as any
+    );
+  }
+
+  function buildMessage(hasModerationPermission: boolean): Message {
+    const member = {
+      id: 'user-1',
+      nickname: null,
+      joinedAt: new Date('2024-01-01T00:00:00.000Z'),
+      guild: { id: 'guild-1' },
+      user: {
+        id: 'user-1',
+        username: 'test-user',
+        discriminator: '0001',
+        createdTimestamp: new Date('2020-01-01T00:00:00.000Z').getTime(),
+      },
+      permissions: {
+        has: jest.fn().mockReturnValue(hasModerationPermission),
+      },
+    } as unknown as GuildMember;
+
+    return {
+      author: { bot: false, id: 'user-1' },
+      content: 'free nitro',
+      guild: { id: 'guild-1' },
+      member,
+      channel: { isThread: jest.fn().mockReturnValue(false) },
+    } as unknown as Message;
+  }
+
+  it('skips automatic message detection for moderation members', async () => {
+    const detectionOrchestrator = {
+      detectMessage: jest.fn(),
+      detectNewJoin: jest.fn(),
+    };
+    const configService = {
+      initialize: jest.fn(),
+      getCachedServerConfig: jest.fn(),
+      getServerConfig: jest.fn(),
+    };
+    const handler = buildHandler({ detectionOrchestrator, configService });
+
+    await (handler as any).handleMessage(buildMessage(true));
+
+    expect(configService.initialize).not.toHaveBeenCalled();
+    expect(detectionOrchestrator.detectMessage).not.toHaveBeenCalled();
+  });
+
+  it('runs automatic message detection for regular members', async () => {
+    const detectionOrchestrator = {
+      detectMessage: jest.fn().mockResolvedValue({
+        label: 'OK',
+        confidence: 0,
+        reasons: [],
+        triggerSource: DetectionType.SUSPICIOUS_CONTENT,
+        triggerContent: 'free nitro',
+      }),
+      detectNewJoin: jest.fn(),
+    };
+    const handler = buildHandler({ detectionOrchestrator });
+
+    await (handler as any).handleMessage(buildMessage(false));
+
+    expect(detectionOrchestrator.detectMessage).toHaveBeenCalledWith(
+      'guild-1',
+      'user-1',
+      'free nitro',
+      expect.objectContaining({
+        serverId: 'guild-1',
+        userId: 'user-1',
+        username: 'test-user',
+      })
+    );
+  });
+});

--- a/src/controllers/EventHandler.ts
+++ b/src/controllers/EventHandler.ts
@@ -1,4 +1,12 @@
-import { Client, Message, GuildMember, Interaction, Guild, MessageFlags } from 'discord.js';
+import {
+  Client,
+  Message,
+  GuildMember,
+  Interaction,
+  Guild,
+  MessageFlags,
+  PermissionFlagsBits,
+} from 'discord.js';
 import * as dotenv from 'dotenv';
 import { injectable, inject } from 'inversify';
 import { UserProfileData } from '../services/GPTService';
@@ -119,6 +127,10 @@ export class EventHandler implements IEventHandler {
     // Handle debug/test commands
     if (message.content.startsWith('!test')) {
       await this.commandHandler.handleTestCommands(message);
+      return;
+    }
+
+    if (this.isAutomaticDetectionExempt(message.member)) {
       return;
     }
 
@@ -329,6 +341,10 @@ export class EventHandler implements IEventHandler {
         return;
       }
 
+      if (this.isAutomaticDetectionExempt(member)) {
+        return;
+      }
+
       // Extract profile data
       const profileData = this.extractUserProfileData(member);
 
@@ -367,6 +383,16 @@ export class EventHandler implements IEventHandler {
       joinedServerAt: member.joinedAt ? new Date(member.joinedAt) : new Date(),
       recentMessages: [], // This might need adjustment based on how it's used
     };
+  }
+
+  private isAutomaticDetectionExempt(member: GuildMember): boolean {
+    return member.permissions.has([
+      PermissionFlagsBits.Administrator,
+      PermissionFlagsBits.ManageGuild,
+      PermissionFlagsBits.ModerateMembers,
+      PermissionFlagsBits.KickMembers,
+      PermissionFlagsBits.BanMembers,
+    ]);
   }
 
   /**

--- a/src/controllers/EventHandler.ts
+++ b/src/controllers/EventHandler.ts
@@ -330,6 +330,10 @@ export class EventHandler implements IEventHandler {
     try {
       console.log(`New member joined: ${member.user.tag} (${member.id})`);
 
+      if (this.isAutomaticDetectionExempt(member)) {
+        return;
+      }
+
       await this.ensureConfigInitialized();
 
       const serverConfig = await this.configService.getServerConfig(member.guild.id);
@@ -338,10 +342,6 @@ export class EventHandler implements IEventHandler {
         console.log(
           `Automatic detection is disabled for guild ${member.guild.id}; skipping join scan.`
         );
-        return;
-      }
-
-      if (this.isAutomaticDetectionExempt(member)) {
         return;
       }
 
@@ -386,7 +386,7 @@ export class EventHandler implements IEventHandler {
   }
 
   private isAutomaticDetectionExempt(member: GuildMember): boolean {
-    return member.permissions.has([
+    return member.permissions.any([
       PermissionFlagsBits.Administrator,
       PermissionFlagsBits.ManageGuild,
       PermissionFlagsBits.ModerateMembers,


### PR DESCRIPTION
## Summary
- Skip automatic message/join detection for members with moderation or admin permissions.
- Add EventHandler unit coverage so regular members still scan while moderators do not.

## Test Plan
- npm run format:check
- npm run lint
- npm run build
- npm test -- --runInBand