### PR TITLE
Fix observed dismiss popup interaction ack

### DIFF
--- a/src/__tests__/unit/InteractionHandler.unit.test.ts
+++ b/src/__tests__/unit/InteractionHandler.unit.test.ts
@@ -437,8 +437,8 @@ describe('InteractionHandler (unit)', () => {
 
     await handler.handleButtonInteraction(interaction);
 
-    expect(interaction.deferUpdate).toHaveBeenCalledTimes(1);
-    expect((interaction.deferUpdate as jest.Mock).mock.invocationCallOrder[0]).toBeLessThan(
+    expect(interaction.deferReply).toHaveBeenCalledWith({ flags: MessageFlags.Ephemeral });
+    expect((interaction.deferReply as jest.Mock).mock.invocationCallOrder[0]).toBeLessThan(
       (client.guilds.fetch as jest.Mock).mock.invocationCallOrder[0]
     );
     expect(securityActionService.dismissObservedDetection).toHaveBeenCalledWith(
@@ -448,6 +448,38 @@ describe('InteractionHandler (unit)', () => {
       interaction.user,
       AdminActionType.FALSE_POSITIVE
     );
+  });
+
+  it('keeps observed popup permission denial private after acknowledgement', async () => {
+    (client.guilds.fetch as jest.Mock).mockResolvedValue({
+      members: {
+        fetch: jest.fn().mockResolvedValue({
+          permissions: { has: jest.fn().mockReturnValue(false) },
+        }),
+      },
+    });
+    const handler = new InteractionHandler(
+      client,
+      notificationManager,
+      userModerationService,
+      securityActionService,
+      configService,
+      verificationEventRepository,
+      threadManager,
+      adminActionRepository
+    );
+    const interaction = buildInteraction('observed:dismiss:user-1:det-1', 'guild-1', {
+      id: 'viewer-1',
+    } as User);
+
+    await handler.handleButtonInteraction(interaction);
+
+    expect(interaction.deferReply).toHaveBeenCalledWith({ flags: MessageFlags.Ephemeral });
+    expect(interaction.editReply).toHaveBeenCalledWith({
+      content: 'You need moderation permissions to dismiss an alert.',
+      components: [],
+    });
+    expect(securityActionService.dismissObservedDetection).not.toHaveBeenCalled();
   });
 
   it('handles report modal submission', async () => {

--- a/src/__tests__/unit/InteractionHandler.unit.test.ts
+++ b/src/__tests__/unit/InteractionHandler.unit.test.ts
@@ -35,17 +35,28 @@ const buildMember = (guildId: string, userId: string): GuildMember =>
     } as User,
   }) as unknown as GuildMember;
 
-const buildInteraction = (customId: string, guildId: string, user: User): ButtonInteraction =>
-  ({
+const buildInteraction = (customId: string, guildId: string, user: User): ButtonInteraction => {
+  const interaction = {
     customId,
     guildId,
     user,
-    deferUpdate: jest.fn().mockResolvedValue(undefined),
+    deferred: false,
+    replied: false,
+    deferUpdate: jest.fn().mockImplementation(async () => {
+      interaction.deferred = true;
+    }),
+    deferReply: jest.fn().mockImplementation(async () => {
+      interaction.deferred = true;
+    }),
     editReply: jest.fn().mockResolvedValue(undefined),
     followUp: jest.fn().mockResolvedValue(undefined),
-    reply: jest.fn().mockResolvedValue(undefined),
+    reply: jest.fn().mockImplementation(async () => {
+      interaction.replied = true;
+    }),
     showModal: jest.fn().mockResolvedValue(undefined),
-  }) as unknown as ButtonInteraction;
+  };
+  return interaction as unknown as ButtonInteraction;
+};
 
 const grantInteractionPermissions = (interaction: ButtonInteraction): void => {
   Object.assign(interaction, {
@@ -365,6 +376,78 @@ describe('InteractionHandler (unit)', () => {
       components: [],
     });
     expect(interaction.followUp).not.toHaveBeenCalled();
+  });
+
+  it('acknowledges observed dismiss menu before fetching permissions', async () => {
+    (client.guilds.fetch as jest.Mock).mockResolvedValue({
+      members: {
+        fetch: jest.fn().mockResolvedValue({
+          permissions: { has: jest.fn().mockReturnValue(true) },
+        }),
+      },
+    });
+    const handler = new InteractionHandler(
+      client,
+      notificationManager,
+      userModerationService,
+      securityActionService,
+      configService,
+      verificationEventRepository,
+      threadManager,
+      adminActionRepository
+    );
+    const interaction = buildInteraction('observed:dismiss_menu:user-1:det-1', 'guild-1', {
+      id: 'admin-1',
+    } as User);
+
+    await handler.handleButtonInteraction(interaction);
+
+    expect(interaction.deferReply).toHaveBeenCalledWith({ flags: MessageFlags.Ephemeral });
+    expect((interaction.deferReply as jest.Mock).mock.invocationCallOrder[0]).toBeLessThan(
+      (client.guilds.fetch as jest.Mock).mock.invocationCallOrder[0]
+    );
+    expect(interaction.editReply).toHaveBeenCalledWith({
+      content:
+        'Dismiss only closes this alert. False Positive records that this specific detection was incorrect; future independent detections can still notify.',
+      components: expect.any(Array),
+    });
+  });
+
+  it('acknowledges observed popup action before fetching permissions', async () => {
+    (client.guilds.fetch as jest.Mock).mockResolvedValue({
+      members: {
+        fetch: jest.fn().mockResolvedValue({
+          permissions: { has: jest.fn().mockReturnValue(true) },
+        }),
+      },
+    });
+    const handler = new InteractionHandler(
+      client,
+      notificationManager,
+      userModerationService,
+      securityActionService,
+      configService,
+      verificationEventRepository,
+      threadManager,
+      adminActionRepository
+    );
+    const interaction = buildInteraction('observed:false_positive:user-1:det-1', 'guild-1', {
+      id: 'admin-1',
+    } as User);
+
+    await handler.handleButtonInteraction(interaction);
+
+    expect(interaction.deferUpdate).toHaveBeenCalledTimes(1);
+    expect((interaction.deferUpdate as jest.Mock).mock.invocationCallOrder[0]).toBeLessThan(
+      (client.guilds.fetch as jest.Mock).mock.invocationCallOrder[0]
+    );
+    expect(securityActionService.dismissObservedDetection).toHaveBeenCalledWith(
+      'guild-1',
+      'user-1',
+      'det-1',
+      interaction.user,
+      AdminActionType.FALSE_POSITIVE
+    );
   });
 
   it('handles report modal submission', async () => {

--- a/src/__tests__/unit/InteractionHandler.unit.test.ts
+++ b/src/__tests__/unit/InteractionHandler.unit.test.ts
@@ -48,7 +48,9 @@ const buildInteraction = (customId: string, guildId: string, user: User): Button
     deferReply: jest.fn().mockImplementation(async () => {
       interaction.deferred = true;
     }),
-    editReply: jest.fn().mockResolvedValue(undefined),
+    editReply: jest.fn().mockImplementation(async () => {
+      interaction.replied = true;
+    }),
     followUp: jest.fn().mockResolvedValue(undefined),
     reply: jest.fn().mockImplementation(async () => {
       interaction.replied = true;

--- a/src/controllers/InteractionHandler.ts
+++ b/src/controllers/InteractionHandler.ts
@@ -524,7 +524,10 @@ export class InteractionHandler implements IInteractionHandler {
       await interaction.editReply(response);
       return;
     }
-    await interaction.reply({ content: message, flags: MessageFlags.Ephemeral });
+    await interaction.reply({
+      ...response,
+      flags: MessageFlags.Ephemeral,
+    });
   }
 
   private async getObservedTargetMember(guildId: string, userId: string): Promise<GuildMember> {
@@ -623,7 +626,22 @@ export class InteractionHandler implements IInteractionHandler {
           );
           return;
         }
-        await this.showObservedDismissOptions(interaction, parsed.userId, parsed.detectionEventId);
+        await interaction.editReply({
+          content:
+            'Dismiss only closes this alert. False Positive records that this specific detection was incorrect; future independent detections can still notify.',
+          components: [
+            new ActionRowBuilder<ButtonBuilder>().addComponents(
+              new ButtonBuilder()
+                .setCustomId(`observed:dismiss:${parsed.userId}:${parsed.detectionEventId}`)
+                .setLabel('Dismiss Alert')
+                .setStyle(ButtonStyle.Secondary),
+              new ButtonBuilder()
+                .setCustomId(`observed:false_positive:${parsed.userId}:${parsed.detectionEventId}`)
+                .setLabel('False Positive')
+                .setStyle(ButtonStyle.Success)
+            ),
+          ],
+        });
         return;
 
       case 'dismiss':
@@ -799,28 +817,6 @@ export class InteractionHandler implements IInteractionHandler {
         await interaction.reply(response);
       }
     }
-  }
-
-  private async showObservedDismissOptions(
-    interaction: ButtonInteraction,
-    userId: string,
-    detectionEventId: string
-  ): Promise<void> {
-    const row = new ActionRowBuilder<ButtonBuilder>().addComponents(
-      new ButtonBuilder()
-        .setCustomId(`observed:dismiss:${userId}:${detectionEventId}`)
-        .setLabel('Dismiss Alert')
-        .setStyle(ButtonStyle.Secondary),
-      new ButtonBuilder()
-        .setCustomId(`observed:false_positive:${userId}:${detectionEventId}`)
-        .setLabel('False Positive')
-        .setStyle(ButtonStyle.Success)
-    );
-    await interaction.editReply({
-      content:
-        'Dismiss only closes this alert. False Positive records that this specific detection was incorrect; future independent detections can still notify.',
-      components: [row],
-    });
   }
 
   private async dismissObservedDetection(

--- a/src/controllers/InteractionHandler.ts
+++ b/src/controllers/InteractionHandler.ts
@@ -628,7 +628,7 @@ export class InteractionHandler implements IInteractionHandler {
 
       case 'dismiss':
       case 'false_positive':
-        await interaction.deferUpdate();
+        await interaction.deferReply({ flags: MessageFlags.Ephemeral });
         if (!(await hasModerationPermission())) {
           await this.replyPermissionDenied(
             interaction,

--- a/src/controllers/InteractionHandler.ts
+++ b/src/controllers/InteractionHandler.ts
@@ -605,11 +605,12 @@ export class InteractionHandler implements IInteractionHandler {
         return;
 
       case 'dismiss_menu':
+        await interaction.deferReply({ flags: MessageFlags.Ephemeral });
         if (!(await hasModerationPermission())) {
-          await this.replyPermissionDenied(
-            interaction,
-            'You need moderation permissions to dismiss an alert.'
-          );
+          await interaction.editReply({
+            content: 'You need moderation permissions to dismiss an alert.',
+            components: [],
+          });
           return;
         }
         await this.showObservedDismissOptions(interaction, parsed.userId, parsed.detectionEventId);
@@ -617,14 +618,14 @@ export class InteractionHandler implements IInteractionHandler {
 
       case 'dismiss':
       case 'false_positive':
+        await interaction.deferUpdate();
         if (!(await hasModerationPermission())) {
-          await this.replyPermissionDenied(
-            interaction,
-            'You need moderation permissions to dismiss an alert.'
-          );
+          await interaction.editReply({
+            content: 'You need moderation permissions to dismiss an alert.',
+            components: [],
+          });
           return;
         }
-        await interaction.deferUpdate();
         await this.dismissObservedDetection(
           interaction,
           guildId,
@@ -804,9 +805,17 @@ export class InteractionHandler implements IInteractionHandler {
         .setLabel('False Positive')
         .setStyle(ButtonStyle.Success)
     );
+    const content =
+      'Dismiss only closes this alert. False Positive records that this specific detection was incorrect; future independent detections can still notify.';
+    if (interaction.deferred || interaction.replied) {
+      await interaction.editReply({
+        content,
+        components: [row],
+      });
+      return;
+    }
     await interaction.reply({
-      content:
-        'Dismiss only closes this alert. False Positive records that this specific detection was incorrect; future independent detections can still notify.',
+      content,
       components: [row],
       flags: MessageFlags.Ephemeral,
     });

--- a/src/controllers/InteractionHandler.ts
+++ b/src/controllers/InteractionHandler.ts
@@ -513,8 +513,17 @@ export class InteractionHandler implements IInteractionHandler {
 
   private async replyPermissionDenied(
     interaction: ButtonInteraction | ModalSubmitInteraction,
-    message: string
+    message: string,
+    options?: { clearComponents?: boolean }
   ): Promise<void> {
+    const response = {
+      content: message,
+      ...(options?.clearComponents ? { components: [] } : {}),
+    };
+    if (interaction.deferred || interaction.replied) {
+      await interaction.editReply(response);
+      return;
+    }
     await interaction.reply({ content: message, flags: MessageFlags.Ephemeral });
   }
 
@@ -607,10 +616,11 @@ export class InteractionHandler implements IInteractionHandler {
       case 'dismiss_menu':
         await interaction.deferReply({ flags: MessageFlags.Ephemeral });
         if (!(await hasModerationPermission())) {
-          await interaction.editReply({
-            content: 'You need moderation permissions to dismiss an alert.',
-            components: [],
-          });
+          await this.replyPermissionDenied(
+            interaction,
+            'You need moderation permissions to dismiss an alert.',
+            { clearComponents: true }
+          );
           return;
         }
         await this.showObservedDismissOptions(interaction, parsed.userId, parsed.detectionEventId);
@@ -620,10 +630,11 @@ export class InteractionHandler implements IInteractionHandler {
       case 'false_positive':
         await interaction.deferUpdate();
         if (!(await hasModerationPermission())) {
-          await interaction.editReply({
-            content: 'You need moderation permissions to dismiss an alert.',
-            components: [],
-          });
+          await this.replyPermissionDenied(
+            interaction,
+            'You need moderation permissions to dismiss an alert.',
+            { clearComponents: true }
+          );
           return;
         }
         await this.dismissObservedDetection(
@@ -805,19 +816,10 @@ export class InteractionHandler implements IInteractionHandler {
         .setLabel('False Positive')
         .setStyle(ButtonStyle.Success)
     );
-    const content =
-      'Dismiss only closes this alert. False Positive records that this specific detection was incorrect; future independent detections can still notify.';
-    if (interaction.deferred || interaction.replied) {
-      await interaction.editReply({
-        content,
-        components: [row],
-      });
-      return;
-    }
-    await interaction.reply({
-      content,
+    await interaction.editReply({
+      content:
+        'Dismiss only closes this alert. False Positive records that this specific detection was incorrect; future independent detections can still notify.',
       components: [row],
-      flags: MessageFlags.Ephemeral,
     });
   }
 


### PR DESCRIPTION
## Summary
- acknowledge the observed dismiss popup immediately before permission/member fetches
- open the dismiss submenu via deferred ephemeral reply so Discord does not time out the popup flow
- add unit coverage that asserts the interaction is acknowledged before any permission lookup

## Validation
- npm test -- --runInBand
- npm run build
- npm run lint
- npm run format:check
- git diff --check