### PR TITLE
Fix prod Prisma migration connectivity

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -152,10 +152,13 @@ jobs:
           set -euo pipefail
 
           SERVICE_JSON="$(aws ecs describe-services --cluster "$ECS_CLUSTER" --services "$ECS_SERVICE" --query 'services[0]' --output json)"
+          CURRENT_TD_ARN="$(jq -r '.taskDefinition' <<<"$SERVICE_JSON")"
+          CURRENT_TD_JSON="$(aws ecs describe-task-definition --task-definition "$CURRENT_TD_ARN" --query 'taskDefinition' --output json)"
           LAUNCH_TYPE="$(jq -r '.launchType // empty' <<<"$SERVICE_JSON")"
           CAPACITY_PROVIDER_STRATEGY="$(jq -c '.capacityProviderStrategy // []' <<<"$SERVICE_JSON")"
           PLATFORM_VERSION="$(jq -r '.platformVersion // "LATEST"' <<<"$SERVICE_JSON")"
           ASSIGN_PUBLIC_IP="$(jq -r '.networkConfiguration.awsvpcConfiguration.assignPublicIp // "DISABLED"' <<<"$SERVICE_JSON")"
+          DATABASE_URL_SECRET_ARN="$(jq -r '.containerDefinitions[] | select(.name == "drasil") | .secrets[]? | select(.name == "DATABASE_URL") | .valueFrom // empty' <<<"$CURRENT_TD_JSON")"
 
           mapfile -t SUBNETS < <(jq -r '(.networkConfiguration.awsvpcConfiguration.subnets // [])[]' <<<"$SERVICE_JSON")
           mapfile -t SECURITY_GROUPS < <(jq -r '(.networkConfiguration.awsvpcConfiguration.securityGroups // [])[]' <<<"$SERVICE_JSON")
@@ -164,6 +167,17 @@ jobs:
             echo "Service $ECS_SERVICE does not define awsvpc subnets; cannot run migration task." >&2
             exit 1
           fi
+
+          if [ -z "$DATABASE_URL_SECRET_ARN" ]; then
+            echo "Could not resolve DATABASE_URL secret ARN from task definition $CURRENT_TD_ARN." >&2
+            exit 1
+          fi
+
+          DATABASE_URL="$(aws secretsmanager get-secret-value --secret-id "$DATABASE_URL_SECRET_ARN" --query 'SecretString' --output text)"
+          MIGRATION_DATABASE_URL="${DATABASE_URL/:6543\//:5432/}"
+          MIGRATION_DATABASE_URL="${MIGRATION_DATABASE_URL/pgbouncer=true&/}"
+          MIGRATION_DATABASE_URL="${MIGRATION_DATABASE_URL/?pgbouncer=true/}"
+          MIGRATION_DATABASE_URL="${MIGRATION_DATABASE_URL/&pgbouncer=true/}"
 
           SUBNET_CSV="$(IFS=,; echo "${SUBNETS[*]}")"
           SECURITY_GROUP_CSV="$(IFS=,; echo "${SECURITY_GROUPS[*]}")"
@@ -174,7 +188,7 @@ jobs:
             --task-definition "$NEW_TD_ARN"
             --count 1
             --network-configuration "$NETWORK_CONFIG"
-            --overrides '{"containerOverrides":[{"name":"drasil","command":["npm","run","prisma:migrate:deploy"]}]}'
+            --overrides "$(jq -cn --arg url \"$MIGRATION_DATABASE_URL\" '{containerOverrides:[{name:\"drasil\",command:[\"node\",\"-e\",\"const {execSync}=require(\\\"child_process\\\");execSync(\\\"npm run prisma:migrate:deploy\\\",{stdio:\\\"inherit\\\",env:{...process.env,DATABASE_URL:process.argv[1]}})\",$url]}]}')"
           )
 
           if [ -n "$LAUNCH_TYPE" ]; then

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -165,7 +165,7 @@ jobs:
             exit 1
           fi
 
-          MIGRATION_OVERRIDES_JSON='{"containerOverrides":[{"name":"drasil","command":["node","-e","const {execSync}=require(\"child_process\");let url=process.env.DATABASE_URL||\"\";url=url.replace(\":6543/\",\":5432/\").replace(\"pgbouncer=true&\",\"\").replace(\"?pgbouncer=true\",\"\").replace(\"&pgbouncer=true\",\"\");execSync(\"npm run prisma:migrate:deploy\",{stdio:\"inherit\",env:{...process.env,DATABASE_URL:url}})"]}]}'
+          MIGRATION_OVERRIDES_JSON='{"containerOverrides":[{"name":"drasil","command":["node","scripts/prisma-migrate-session.js"]}]}'
 
           SUBNET_CSV="$(IFS=,; echo "${SUBNETS[*]}")"
           SECURITY_GROUP_CSV="$(IFS=,; echo "${SECURITY_GROUPS[*]}")"

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -152,13 +152,10 @@ jobs:
           set -euo pipefail
 
           SERVICE_JSON="$(aws ecs describe-services --cluster "$ECS_CLUSTER" --services "$ECS_SERVICE" --query 'services[0]' --output json)"
-          CURRENT_TD_ARN="$(jq -r '.taskDefinition' <<<"$SERVICE_JSON")"
-          CURRENT_TD_JSON="$(aws ecs describe-task-definition --task-definition "$CURRENT_TD_ARN" --query 'taskDefinition' --output json)"
           LAUNCH_TYPE="$(jq -r '.launchType // empty' <<<"$SERVICE_JSON")"
           CAPACITY_PROVIDER_STRATEGY="$(jq -c '.capacityProviderStrategy // []' <<<"$SERVICE_JSON")"
           PLATFORM_VERSION="$(jq -r '.platformVersion // "LATEST"' <<<"$SERVICE_JSON")"
           ASSIGN_PUBLIC_IP="$(jq -r '.networkConfiguration.awsvpcConfiguration.assignPublicIp // "DISABLED"' <<<"$SERVICE_JSON")"
-          DATABASE_URL_SECRET_ARN="$(jq -r '.containerDefinitions[] | select(.name == "drasil") | .secrets[]? | select(.name == "DATABASE_URL") | .valueFrom // empty' <<<"$CURRENT_TD_JSON")"
 
           mapfile -t SUBNETS < <(jq -r '(.networkConfiguration.awsvpcConfiguration.subnets // [])[]' <<<"$SERVICE_JSON")
           mapfile -t SECURITY_GROUPS < <(jq -r '(.networkConfiguration.awsvpcConfiguration.securityGroups // [])[]' <<<"$SERVICE_JSON")
@@ -168,20 +165,7 @@ jobs:
             exit 1
           fi
 
-          if [ -z "$DATABASE_URL_SECRET_ARN" ]; then
-            echo "Could not resolve DATABASE_URL secret ARN from task definition $CURRENT_TD_ARN." >&2
-            exit 1
-          fi
-
-          DATABASE_URL="$(aws secretsmanager get-secret-value --secret-id "$DATABASE_URL_SECRET_ARN" --query 'SecretString' --output text)"
-          MIGRATION_DATABASE_URL="${DATABASE_URL/:6543\//:5432/}"
-          MIGRATION_DATABASE_URL="${MIGRATION_DATABASE_URL/pgbouncer=true&/}"
-          MIGRATION_DATABASE_URL="${MIGRATION_DATABASE_URL/?pgbouncer=true/}"
-          MIGRATION_DATABASE_URL="${MIGRATION_DATABASE_URL/&pgbouncer=true/}"
-          MIGRATION_OVERRIDES_JSON="$(jq -cn \
-            --arg database_url "$MIGRATION_DATABASE_URL" \
-            '{containerOverrides:[{name:"drasil",command:["node","-e","const {execSync}=require(\"child_process\");execSync(\"npm run prisma:migrate:deploy\",{stdio:\"inherit\",env:{...process.env,DATABASE_URL:process.argv[1]}})",$database_url]}]}'
-          )"
+          MIGRATION_OVERRIDES_JSON='{"containerOverrides":[{"name":"drasil","command":["node","-e","const {execSync}=require(\"child_process\");let url=process.env.DATABASE_URL||\"\";url=url.replace(\":6543/\",\":5432/\").replace(\"pgbouncer=true&\",\"\").replace(\"?pgbouncer=true\",\"\").replace(\"&pgbouncer=true\",\"\");execSync(\"npm run prisma:migrate:deploy\",{stdio:\"inherit\",env:{...process.env,DATABASE_URL:url}})"]}]}'
 
           SUBNET_CSV="$(IFS=,; echo "${SUBNETS[*]}")"
           SECURITY_GROUP_CSV="$(IFS=,; echo "${SECURITY_GROUPS[*]}")"

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -178,6 +178,10 @@ jobs:
           MIGRATION_DATABASE_URL="${MIGRATION_DATABASE_URL/pgbouncer=true&/}"
           MIGRATION_DATABASE_URL="${MIGRATION_DATABASE_URL/?pgbouncer=true/}"
           MIGRATION_DATABASE_URL="${MIGRATION_DATABASE_URL/&pgbouncer=true/}"
+          MIGRATION_OVERRIDES_JSON="$(jq -cn \
+            --arg database_url "$MIGRATION_DATABASE_URL" \
+            '{containerOverrides:[{name:"drasil",command:["node","-e","const {execSync}=require(\"child_process\");execSync(\"npm run prisma:migrate:deploy\",{stdio:\"inherit\",env:{...process.env,DATABASE_URL:process.argv[1]}})",$database_url]}]}'
+          )"
 
           SUBNET_CSV="$(IFS=,; echo "${SUBNETS[*]}")"
           SECURITY_GROUP_CSV="$(IFS=,; echo "${SECURITY_GROUPS[*]}")"
@@ -188,7 +192,7 @@ jobs:
             --task-definition "$NEW_TD_ARN"
             --count 1
             --network-configuration "$NETWORK_CONFIG"
-            --overrides "$(jq -cn --arg url \"$MIGRATION_DATABASE_URL\" '{containerOverrides:[{name:\"drasil\",command:[\"node\",\"-e\",\"const {execSync}=require(\\\"child_process\\\");execSync(\\\"npm run prisma:migrate:deploy\\\",{stdio:\\\"inherit\\\",env:{...process.env,DATABASE_URL:process.argv[1]}})\",$url]}]}')"
+            --overrides "$MIGRATION_OVERRIDES_JSON"
           )
 
           if [ -n "$LAUNCH_TYPE" ]; then

--- a/infra/aws/prod/main.tf
+++ b/infra/aws/prod/main.tf
@@ -411,9 +411,7 @@ data "aws_iam_policy_document" "github_deploy" {
       "ecs:DescribeTaskDefinition",
       "ecs:RegisterTaskDefinition"
     ]
-    resources = [
-      "arn:aws:ecs:${var.aws_region}:${data.aws_caller_identity.current.account_id}:task-definition/${local.name_prefix}:*"
-    ]
+    resources = ["*"]
   }
 
   statement {

--- a/scripts/prisma-migrate-session.js
+++ b/scripts/prisma-migrate-session.js
@@ -1,0 +1,23 @@
+const { execSync } = require('child_process');
+
+const databaseUrl = process.env.DATABASE_URL;
+
+if (!databaseUrl) {
+  throw new Error('DATABASE_URL is required for Prisma migrations.');
+}
+
+const migrationUrl = new URL(databaseUrl);
+
+if (migrationUrl.port === '6543') {
+  migrationUrl.port = '5432';
+}
+
+migrationUrl.searchParams.delete('pgbouncer');
+
+execSync('npm run prisma:migrate:deploy', {
+  stdio: 'inherit',
+  env: {
+    ...process.env,
+    DATABASE_URL: migrationUrl.toString(),
+  },
+});


### PR DESCRIPTION
## Summary
- use a session-mode `:5432` database URL for the one-off Prisma migration task instead of the pooled `:6543` runtime URL
- widen prod deploy IAM for task-definition registration/describe calls to match actual ECS authorization behavior
- preserve the runtime app secret path while making deploy-time migrations fail less often in prod

## Why
The prod recovery showed two separate issues in the deploy path:
- the GitHub deploy role was too narrowly scoped for `ecs:DescribeTaskDefinition` and `ecs:RegisterTaskDefinition`
- Prisma Migrate hung against the Supabase pooled connection on port `6543`, while the equivalent session-mode connection on `5432` applied the pending migrations successfully

## Testing
- terraform fmt -check infra/aws/prod
- manual prod verification: one-off ECS migration task succeeded with session-mode connection and applied pending migrations
- manual prod verification: ECS service updated to `drasil-prod:21` and current task started cleanly

## Notes
- `actionlint` was not available in the local environment, so I could not run it here
- the failed GitHub Actions run during recovery was expected because the original hung migration task was intentionally stopped after the root cause was confirmed