### PR TITLE
Add reversible observed dismissals

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,10 +29,10 @@ jobs:
       DATABASE_URL: postgresql://postgres:postgres@localhost:5432/drasil_test?schema=public
       POSTGRES_DB_URL: postgresql://postgres:postgres@localhost:5432/drasil_test?schema=public
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
           cache: npm
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -23,7 +23,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ inputs.ref || github.sha }}
 
@@ -44,7 +44,7 @@ jobs:
           : "${ECS_SERVICE:?Set repo variable ECS_SERVICE}"
 
       - name: Configure AWS credentials (OIDC)
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-region: ${{ vars.AWS_REGION }}
           role-to-assume: ${{ vars.AWS_ROLE_TO_ASSUME }}

--- a/.github/workflows/iac.yml
+++ b/.github/workflows/iac.yml
@@ -10,7 +10,7 @@ jobs:
   terraform:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3
@@ -36,7 +36,7 @@ jobs:
   checkov:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Checkov (Terraform)
         uses: bridgecrewio/checkov-action@v12
@@ -48,6 +48,6 @@ jobs:
   actionlint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: actionlint
         uses: rhysd/actionlint@v1.7.10

--- a/package-lock.json
+++ b/package-lock.json
@@ -1332,9 +1332,9 @@
       }
     },
     "node_modules/@babel/plugin-transform-modules-systemjs": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.0.tgz",
-      "integrity": "sha512-PrujnVFbOdUpw4UHiVwKvKRLMMic8+eC0CuNlxjsyZUiBjhFdPsewdXCkveh2KqBA9/waD0W1b4hXSOBQJezpQ==",
+      "version": "7.29.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.4.tgz",
+      "integrity": "sha512-N7QmZ0xRZfjHOfZeQLJjwgX2zS9pdGHSVl/cjSGlo4dXMqvurfxXDMKY4RqEKzPozV78VMcd0lxyG13mlbKc4w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1986,15 +1986,15 @@
       }
     },
     "node_modules/@discordjs/builders": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-1.13.1.tgz",
-      "integrity": "sha512-cOU0UDHc3lp/5nKByDxkmRiNZBpdp0kx55aarbiAfakfKJHlxv/yFW1zmIqCAmwH5CRlrH9iMFKJMpvW4DPB+w==",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-1.14.1.tgz",
+      "integrity": "sha512-gSKkhXLqs96TCzk66VZuHHl8z2bQMJFGwrXC0f33ngK+FLNau4hU1PYny3DNJfNdSH+gVMzE85/d5FQ2BpcNwQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@discordjs/formatters": "^0.6.2",
         "@discordjs/util": "^1.2.0",
         "@sapphire/shapeshift": "^4.0.0",
-        "discord-api-types": "^0.38.33",
+        "discord-api-types": "^0.38.40",
         "fast-deep-equal": "^3.1.3",
         "ts-mixer": "^6.0.4",
         "tslib": "^2.6.3"
@@ -2031,20 +2031,20 @@
       }
     },
     "node_modules/@discordjs/rest": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-2.6.0.tgz",
-      "integrity": "sha512-RDYrhmpB7mTvmCKcpj+pc5k7POKszS4E2O9TYc+U+Y4iaCP+r910QdO43qmpOja8LRr1RJ0b3U+CqVsnPqzf4w==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-2.6.1.tgz",
+      "integrity": "sha512-wwQdgjeaoYFiaG+atbqx6aJDpqW7JHAo0HrQkBTbYzM3/PJ3GweQIpgElNcGZ26DCUOXMyawYd0YF7vtr+fZXg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@discordjs/collection": "^2.1.1",
-        "@discordjs/util": "^1.1.1",
+        "@discordjs/util": "^1.2.0",
         "@sapphire/async-queue": "^1.5.3",
-        "@sapphire/snowflake": "^3.5.3",
+        "@sapphire/snowflake": "^3.5.5",
         "@vladfrangu/async_event_emitter": "^2.4.6",
-        "discord-api-types": "^0.38.16",
-        "magic-bytes.js": "^1.10.0",
+        "discord-api-types": "^0.38.40",
+        "magic-bytes.js": "^1.13.0",
         "tslib": "^2.6.3",
-        "undici": "6.21.3"
+        "undici": "6.24.1"
       },
       "engines": {
         "node": ">=18"
@@ -2063,6 +2063,16 @@
       },
       "funding": {
         "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/rest/node_modules/@sapphire/snowflake": {
+      "version": "3.5.5",
+      "resolved": "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-3.5.5.tgz",
+      "integrity": "sha512-xzvBr1Q1c4lCe7i6sRnrofxeO1QTP/LKQ6A6qy0iB4x5yfiSfARMEQEghojzTNALDTcv8En04qYNIco9/K9eZQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=v14.0.0",
+        "npm": ">=7.0.0"
       }
     },
     "node_modules/@discordjs/util": {
@@ -3189,9 +3199,9 @@
       }
     },
     "node_modules/@prisma/client": {
-      "version": "6.19.2",
-      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-6.19.2.tgz",
-      "integrity": "sha512-gR2EMvfK/aTxsuooaDA32D8v+us/8AAet+C3J1cc04SW35FPdZYgLF+iN4NDLUgAaUGTKdAB0CYenu1TAgGdMg==",
+      "version": "6.19.3",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-6.19.3.tgz",
+      "integrity": "sha512-mKq3jQFhjvko5LTJFHGilsuQs+W+T3Gm451NzuTDGQxwCzwXHYnIu2zGkRoW+Exq3Rob7yp2MfzSrdIiZVhrBg==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "engines": {
@@ -3211,34 +3221,34 @@
       }
     },
     "node_modules/@prisma/config": {
-      "version": "6.19.2",
-      "resolved": "https://registry.npmjs.org/@prisma/config/-/config-6.19.2.tgz",
-      "integrity": "sha512-kadBGDl+aUswv/zZMk9Mx0C8UZs1kjao8H9/JpI4Wh4SHZaM7zkTwiKn/iFLfRg+XtOAo/Z/c6pAYhijKl0nzQ==",
+      "version": "6.19.3",
+      "resolved": "https://registry.npmjs.org/@prisma/config/-/config-6.19.3.tgz",
+      "integrity": "sha512-CBPT44BjlQxEt8kiMEauji2WHTDoVBOKl7UlewXmUgBPnr/oPRZC3psci5chJnYmH0ivEIog2OU9PGWoki3DLQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "c12": "3.1.0",
         "deepmerge-ts": "7.1.5",
-        "effect": "3.18.4",
+        "effect": "3.21.0",
         "empathic": "2.0.0"
       }
     },
     "node_modules/@prisma/debug": {
-      "version": "6.19.2",
-      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-6.19.2.tgz",
-      "integrity": "sha512-lFnEZsLdFLmEVCVNdskLDCL8Uup41GDfU0LUfquw+ercJC8ODTuL0WNKgOKmYxCJVvFwf0OuZBzW99DuWmoH2A==",
+      "version": "6.19.3",
+      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-6.19.3.tgz",
+      "integrity": "sha512-ljkJ+SgpXNktLG0Q/n4JGYCkKf0f8oYLyjImS2I8e2q2WCfdRRtWER062ZV/ixaNP2M2VKlWXVJiGzZaUgbKZw==",
       "license": "Apache-2.0"
     },
     "node_modules/@prisma/engines": {
-      "version": "6.19.2",
-      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-6.19.2.tgz",
-      "integrity": "sha512-TTkJ8r+uk/uqczX40wb+ODG0E0icVsMgwCTyTHXehaEfb0uo80M9g1aW1tEJrxmFHeOZFXdI2sTA1j1AgcHi4A==",
+      "version": "6.19.3",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-6.19.3.tgz",
+      "integrity": "sha512-RSYxtlYFl5pJ8ZePgMv0lZ9IzVCOdTPOegrs2qcbAEFrBI1G33h6wyC9kjQvo0DnYEhEVY0X4LsuFHXLKQk88g==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "6.19.2",
+        "@prisma/debug": "6.19.3",
         "@prisma/engines-version": "7.1.1-3.c2990dca591cba766e3b7ef5d9e8a84796e47ab7",
-        "@prisma/fetch-engine": "6.19.2",
-        "@prisma/get-platform": "6.19.2"
+        "@prisma/fetch-engine": "6.19.3",
+        "@prisma/get-platform": "6.19.3"
       }
     },
     "node_modules/@prisma/engines-version": {
@@ -3248,23 +3258,23 @@
       "license": "Apache-2.0"
     },
     "node_modules/@prisma/fetch-engine": {
-      "version": "6.19.2",
-      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-6.19.2.tgz",
-      "integrity": "sha512-h4Ff4Pho+SR1S8XerMCC12X//oY2bG3Iug/fUnudfcXEUnIeRiBdXHFdGlGOgQ3HqKgosTEhkZMvGM9tWtYC+Q==",
+      "version": "6.19.3",
+      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-6.19.3.tgz",
+      "integrity": "sha512-tKtl/qco9Nt7LU5iKhpultD8O4vMCZcU2CHjNTnRrL1QvSUr5W/GcyFPjNL87GtRrwBc7ubXXD9xy4EvLvt8JA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "6.19.2",
+        "@prisma/debug": "6.19.3",
         "@prisma/engines-version": "7.1.1-3.c2990dca591cba766e3b7ef5d9e8a84796e47ab7",
-        "@prisma/get-platform": "6.19.2"
+        "@prisma/get-platform": "6.19.3"
       }
     },
     "node_modules/@prisma/get-platform": {
-      "version": "6.19.2",
-      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-6.19.2.tgz",
-      "integrity": "sha512-PGLr06JUSTqIvztJtAzIxOwtWKtJm5WwOG6xpsgD37Rc84FpfUBGLKz65YpJBGtkRQGXTYEFie7pYALocC3MtA==",
+      "version": "6.19.3",
+      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-6.19.3.tgz",
+      "integrity": "sha512-xFj1VcJ1N3MKooOQAGO0W5tsd0W2QzIvW7DD7c/8H14Zmp4jseeWAITm+w2LLoLrlhoHdPPh0NMZ8mfL6puoHA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "6.19.2"
+        "@prisma/debug": "6.19.3"
       }
     },
     "node_modules/@protobufjs/aspromise": {
@@ -3280,9 +3290,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/codegen": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
-      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/eventemitter": {
@@ -3308,9 +3318,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/inquire": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
-      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.1.tgz",
+      "integrity": "sha512-mnzgDV26ueAvk7rsbt9L7bE0SuAoqyuys/sMMrmVcN5x9VsxpcG3rqAUSgDyLp0UZlmNfIbQ4fHfCtreVBk8Ew==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/path": {
@@ -3326,9 +3336,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/utf8": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
-      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
+      "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@sapphire/async-queue": {
@@ -3891,9 +3901,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3901,13 +3911,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -4060,9 +4070,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4327,9 +4337,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4780,9 +4790,9 @@
       }
     },
     "node_modules/defu": {
-      "version": "6.1.4",
-      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.4.tgz",
-      "integrity": "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==",
+      "version": "6.1.7",
+      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.7.tgz",
+      "integrity": "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==",
       "license": "MIT"
     },
     "node_modules/delayed-stream": {
@@ -4831,33 +4841,33 @@
       }
     },
     "node_modules/discord-api-types": {
-      "version": "0.38.38",
-      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.38.38.tgz",
-      "integrity": "sha512-7qcM5IeZrfb+LXW07HvoI5L+j4PQeMZXEkSm1htHAHh4Y9JSMXBWjy/r7zmUCOj4F7zNjMcm7IMWr131MT2h0Q==",
+      "version": "0.38.47",
+      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.38.47.tgz",
+      "integrity": "sha512-XgXQodHQBAE6kfD7kMvVo30863iHX1LHSqNq6MGUTDwIFCCvHva13+rwxyxVXDqudyApMNAd32PGjgVETi5rjA==",
       "license": "MIT",
       "workspaces": [
         "scripts/actions/documentation"
       ]
     },
     "node_modules/discord.js": {
-      "version": "14.25.1",
-      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.25.1.tgz",
-      "integrity": "sha512-2l0gsPOLPs5t6GFZfQZKnL1OJNYFcuC/ETWsW4VtKVD/tg4ICa9x+jb9bkPffkMdRpRpuUaO/fKkHCBeiCKh8g==",
+      "version": "14.26.4",
+      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.26.4.tgz",
+      "integrity": "sha512-4oBp8tc6Kf8IDBwAHhbsMaAqx1b5fob9SNasZT7V6yyyUydoO5i5fGuX7TmvRtR+q/WgKRnRViRoAWnG7fNyvA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@discordjs/builders": "^1.13.0",
+        "@discordjs/builders": "^1.14.1",
         "@discordjs/collection": "1.5.3",
         "@discordjs/formatters": "^0.6.2",
-        "@discordjs/rest": "^2.6.0",
+        "@discordjs/rest": "^2.6.1",
         "@discordjs/util": "^1.2.0",
         "@discordjs/ws": "^1.2.3",
         "@sapphire/snowflake": "3.5.3",
-        "discord-api-types": "^0.38.33",
+        "discord-api-types": "^0.38.40",
         "fast-deep-equal": "3.1.3",
         "lodash.snakecase": "4.1.1",
-        "magic-bytes.js": "^1.10.0",
+        "magic-bytes.js": "^1.13.0",
         "tslib": "^2.6.3",
-        "undici": "6.21.3"
+        "undici": "6.24.1"
       },
       "engines": {
         "node": ">=18"
@@ -4903,9 +4913,9 @@
       }
     },
     "node_modules/effect": {
-      "version": "3.18.4",
-      "resolved": "https://registry.npmjs.org/effect/-/effect-3.18.4.tgz",
-      "integrity": "sha512-b1LXQJLe9D11wfnOKAk3PKxuqYshQ0Heez+y5pnkd3jLj1yx9QhM72zZ9uUrOQyNvrs2GZZd/3maL0ZV18YuDA==",
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/effect/-/effect-3.21.0.tgz",
+      "integrity": "sha512-PPN80qRokCd1f015IANNhrwOnLO7GrrMQfk4/lnZRE/8j7UPWrNNjPV0uBrZutI/nHzernbW+J0hdqQysHiSnQ==",
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.0.0",
@@ -5492,9 +5502,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },
@@ -5729,9 +5739,9 @@
       "license": "ISC"
     },
     "node_modules/handlebars": {
-      "version": "4.7.8",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
-      "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+      "version": "4.7.9",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+      "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6882,9 +6892,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
     "node_modules/lodash.debounce": {
@@ -7044,9 +7054,9 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -7189,14 +7199,14 @@
       }
     },
     "node_modules/nypm": {
-      "version": "0.6.5",
-      "resolved": "https://registry.npmjs.org/nypm/-/nypm-0.6.5.tgz",
-      "integrity": "sha512-K6AJy1GMVyfyMXRVB88700BJqNUkByijGJM8kEHpLdcAt+vSQAVfkWWHYzuRXHSY6xA2sNc5RjTj0p9rE2izVQ==",
+      "version": "0.6.6",
+      "resolved": "https://registry.npmjs.org/nypm/-/nypm-0.6.6.tgz",
+      "integrity": "sha512-vRyr0r4cbBapw07Xw8xrj9Teq3o7MUD35rSaTcanDbW+aK2XHDgJFiU6ZTj2GBw7Q12ysdsyFss+Vdz4hQ0Y6Q==",
       "license": "MIT",
       "dependencies": {
-        "citty": "^0.2.0",
+        "citty": "^0.2.2",
         "pathe": "^2.0.3",
-        "tinyexec": "^1.0.2"
+        "tinyexec": "^1.1.1"
       },
       "bin": {
         "nypm": "dist/cli.mjs"
@@ -7206,9 +7216,9 @@
       }
     },
     "node_modules/nypm/node_modules/citty": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/citty/-/citty-0.2.0.tgz",
-      "integrity": "sha512-8csy5IBFI2ex2hTVpaHN2j+LNE199AgiI7y4dMintrr8i0lQiFn+0AWMZrWdHKIgMOer65f8IThysYhoReqjWA==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/citty/-/citty-0.2.2.tgz",
+      "integrity": "sha512-+6vJA3L98yv+IdfKGZHBNiGW5KHn22e/JwID0Strsz8h4S/csAu/OuICwxrg44k5MRiZHWIo8XXuJgQTriRP4w==",
       "license": "MIT"
     },
     "node_modules/ohash": {
@@ -7546,9 +7556,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7582,13 +7592,13 @@
       }
     },
     "node_modules/pkg-types": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.3.0.tgz",
-      "integrity": "sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.3.1.tgz",
+      "integrity": "sha512-y+ichcgc2LrADuhLNAx8DFjVfgz91pRxfZdI3UDhxHvcVEZsenLO+7XaU5vOp0u/7V/wZ+plyuQxtrDlZJ+yeg==",
       "license": "MIT",
       "dependencies": {
-        "confbox": "^0.2.2",
-        "exsolve": "^1.0.7",
+        "confbox": "^0.2.4",
+        "exsolve": "^1.0.8",
         "pathe": "^2.0.3"
       }
     },
@@ -7703,14 +7713,14 @@
       }
     },
     "node_modules/prisma": {
-      "version": "6.19.2",
-      "resolved": "https://registry.npmjs.org/prisma/-/prisma-6.19.2.tgz",
-      "integrity": "sha512-XTKeKxtQElcq3U9/jHyxSPgiRgeYDKxWTPOf6NkXA0dNj5j40MfEsZkMbyNpwDWCUv7YBFUl7I2VK/6ALbmhEg==",
+      "version": "6.19.3",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-6.19.3.tgz",
+      "integrity": "sha512-++ZJ0ijLrDJF6hNB4t4uxg2br3fC4H9Yc9tcbjr2fcNFP3rh/SBNrAgjhsqBU4Ght8JPrVofG/ZkXfnSfnYsFg==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/config": "6.19.2",
-        "@prisma/engines": "6.19.2"
+        "@prisma/config": "6.19.3",
+        "@prisma/engines": "6.19.3"
       },
       "bin": {
         "prisma": "build/index.js"
@@ -7742,22 +7752,22 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
-      "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
+      "version": "7.5.8",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.8.tgz",
+      "integrity": "sha512-dvpCIeLPbXZS/Ete7yLaO7RenOdken2NHKykBXbsaGxZT0UTltcarBciw+A78SRQs9iMAAVpsYA+l8b1hTePIA==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/codegen": "^2.0.5",
         "@protobufjs/eventemitter": "^1.1.0",
         "@protobufjs/fetch": "^1.1.0",
         "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/inquire": "^1.1.1",
         "@protobufjs/path": "^1.1.2",
         "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
         "@types/node": ">=13.7.0",
         "long": "^5.0.0"
       },
@@ -8232,9 +8242,9 @@
       }
     },
     "node_modules/tinyexec": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
-      "integrity": "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.2.tgz",
+      "integrity": "sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -8276,9 +8286,9 @@
       }
     },
     "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -8695,9 +8705,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.21.3",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.3.tgz",
-      "integrity": "sha512-gBLkYIlEnSp8pFbT64yFgGE6UIB9tAkhukC23PmMDCe5Nd+cRqKxSjw5y54MK2AZMgZfJWMaNE4nYUHgi1XEOw==",
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.24.1.tgz",
+      "integrity": "sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA==",
       "license": "MIT",
       "engines": {
         "node": ">=18.17"

--- a/prisma/migrations/20260512090000_add_undo_observed_action/migration.sql
+++ b/prisma/migrations/20260512090000_add_undo_observed_action/migration.sql
@@ -1,0 +1,1 @@
+ALTER TYPE "admin_action_type" ADD VALUE 'undo_observed_action';

--- a/prisma/migrations/20260512100000_enable_rls_for_public_tables/migration.sql
+++ b/prisma/migrations/20260512100000_enable_rls_for_public_tables/migration.sql
@@ -1,0 +1,13 @@
+ALTER TABLE "public"."admin_actions" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."detection_events" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."server_members" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."servers" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."users" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."verification_events" ENABLE ROW LEVEL SECURITY;
+
+REVOKE ALL ON TABLE "public"."admin_actions" FROM anon, authenticated;
+REVOKE ALL ON TABLE "public"."detection_events" FROM anon, authenticated;
+REVOKE ALL ON TABLE "public"."server_members" FROM anon, authenticated;
+REVOKE ALL ON TABLE "public"."servers" FROM anon, authenticated;
+REVOKE ALL ON TABLE "public"."users" FROM anon, authenticated;
+REVOKE ALL ON TABLE "public"."verification_events" FROM anon, authenticated;

--- a/prisma/migrations/20260512100000_enable_rls_for_public_tables/migration.sql
+++ b/prisma/migrations/20260512100000_enable_rls_for_public_tables/migration.sql
@@ -5,9 +5,23 @@ ALTER TABLE "public"."servers" ENABLE ROW LEVEL SECURITY;
 ALTER TABLE "public"."users" ENABLE ROW LEVEL SECURITY;
 ALTER TABLE "public"."verification_events" ENABLE ROW LEVEL SECURITY;
 
-REVOKE ALL ON TABLE "public"."admin_actions" FROM anon, authenticated;
-REVOKE ALL ON TABLE "public"."detection_events" FROM anon, authenticated;
-REVOKE ALL ON TABLE "public"."server_members" FROM anon, authenticated;
-REVOKE ALL ON TABLE "public"."servers" FROM anon, authenticated;
-REVOKE ALL ON TABLE "public"."users" FROM anon, authenticated;
-REVOKE ALL ON TABLE "public"."verification_events" FROM anon, authenticated;
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'anon') THEN
+    REVOKE ALL ON TABLE "public"."admin_actions" FROM anon;
+    REVOKE ALL ON TABLE "public"."detection_events" FROM anon;
+    REVOKE ALL ON TABLE "public"."server_members" FROM anon;
+    REVOKE ALL ON TABLE "public"."servers" FROM anon;
+    REVOKE ALL ON TABLE "public"."users" FROM anon;
+    REVOKE ALL ON TABLE "public"."verification_events" FROM anon;
+  END IF;
+
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'authenticated') THEN
+    REVOKE ALL ON TABLE "public"."admin_actions" FROM authenticated;
+    REVOKE ALL ON TABLE "public"."detection_events" FROM authenticated;
+    REVOKE ALL ON TABLE "public"."server_members" FROM authenticated;
+    REVOKE ALL ON TABLE "public"."servers" FROM authenticated;
+    REVOKE ALL ON TABLE "public"."users" FROM authenticated;
+    REVOKE ALL ON TABLE "public"."verification_events" FROM authenticated;
+  END IF;
+END $$;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -174,6 +174,7 @@ enum admin_action_type {
   restrict
   dismiss
   false_positive
+  undo_observed_action
 }
 
 enum detection_type {

--- a/src/__tests__/fakes/inMemoryRepositories.ts
+++ b/src/__tests__/fakes/inMemoryRepositories.ts
@@ -233,6 +233,32 @@ export class InMemoryDetectionEventsRepository implements IDetectionEventsReposi
     this.events[eventIndex] = updated;
     return { ...updated };
   }
+
+  async clearObservedAction(
+    detectionEventId: string,
+    actionTypes: string[]
+  ): Promise<DetectionEvent | null> {
+    const eventIndex = this.events.findIndex((item) => item.id === detectionEventId);
+    if (eventIndex === -1) {
+      return null;
+    }
+
+    const existingMetadata = this.events[eventIndex].metadata ?? {};
+    if (!actionTypes.includes(String(existingMetadata.observed_action))) {
+      return null;
+    }
+
+    const metadata = { ...existingMetadata };
+    delete metadata.observed_action;
+    delete metadata.observed_action_by;
+    delete metadata.observed_action_at;
+    const updated = {
+      ...this.events[eventIndex],
+      metadata,
+    };
+    this.events[eventIndex] = updated;
+    return { ...updated };
+  }
 }
 
 export class InMemoryVerificationEventRepository implements IVerificationEventRepository {

--- a/src/__tests__/integration/SecurityActionService.integration.test.ts
+++ b/src/__tests__/integration/SecurityActionService.integration.test.ts
@@ -75,6 +75,7 @@ describeIntegration('SecurityActionService (integration)', () => {
         .fn()
         .mockResolvedValue({ id: 'observe-1' } as Message),
       markObservedDetectionActionTaken: jest.fn().mockResolvedValue(true),
+      restoreObservedDetectionActions: jest.fn().mockResolvedValue(true),
     };
     threadManager = {
       createVerificationThread: jest

--- a/src/__tests__/integration/UserModerationService.integration.test.ts
+++ b/src/__tests__/integration/UserModerationService.integration.test.ts
@@ -71,6 +71,7 @@ describeIntegration('UserModerationService (integration)', () => {
       updateVerificationThreadAnalysis: jest.fn().mockResolvedValue(true),
       upsertObservedDetectionNotification: jest.fn().mockResolvedValue({} as any),
       markObservedDetectionActionTaken: jest.fn().mockResolvedValue(true),
+      restoreObservedDetectionActions: jest.fn().mockResolvedValue(true),
     };
     threadManager = {
       createVerificationThread: jest.fn().mockResolvedValue({} as any),

--- a/src/__tests__/unit/InteractionHandler.unit.test.ts
+++ b/src/__tests__/unit/InteractionHandler.unit.test.ts
@@ -104,6 +104,7 @@ describe('InteractionHandler (unit)', () => {
       restrictObservedDetection: jest.fn().mockResolvedValue(true),
       banObservedDetection: jest.fn().mockResolvedValue(true),
       dismissObservedDetection: jest.fn().mockResolvedValue(true),
+      undoObservedDetectionAction: jest.fn().mockResolvedValue(AdminActionType.DISMISS),
       reopenVerification: jest.fn().mockResolvedValue(true),
     };
     notificationManager = {
@@ -115,6 +116,7 @@ describe('InteractionHandler (unit)', () => {
       updateVerificationThreadAnalysis: jest.fn().mockResolvedValue(true),
       upsertObservedDetectionNotification: jest.fn().mockResolvedValue(null),
       markObservedDetectionActionTaken: jest.fn().mockResolvedValue(true),
+      restoreObservedDetectionActions: jest.fn().mockResolvedValue(true),
     };
     configService = {
       initialize: jest.fn().mockResolvedValue(undefined),
@@ -482,6 +484,39 @@ describe('InteractionHandler (unit)', () => {
       components: [],
     });
     expect(securityActionService.dismissObservedDetection).not.toHaveBeenCalled();
+  });
+
+  it('handles observed false positive undo', async () => {
+    securityActionService.undoObservedDetectionAction.mockResolvedValueOnce(
+      AdminActionType.FALSE_POSITIVE
+    );
+    const handler = new InteractionHandler(
+      client,
+      notificationManager,
+      userModerationService,
+      securityActionService,
+      configService,
+      verificationEventRepository,
+      threadManager,
+      adminActionRepository
+    );
+    const interaction = buildInteraction('observed:undo_dismiss:user-1:det-1', 'guild-1', {
+      id: 'admin-1',
+    } as User);
+    grantInteractionPermissions(interaction);
+
+    await handler.handleButtonInteraction(interaction);
+
+    expect(securityActionService.undoObservedDetectionAction).toHaveBeenCalledWith(
+      'guild-1',
+      'user-1',
+      'det-1',
+      interaction.user
+    );
+    expect(interaction.editReply).toHaveBeenCalledWith({
+      content: 'Undid the dismissal and reverted the false-positive indication for <@user-1>.',
+      components: [],
+    });
   });
 
   it('handles report modal submission', async () => {

--- a/src/__tests__/unit/NotificationManager.unit.test.ts
+++ b/src/__tests__/unit/NotificationManager.unit.test.ts
@@ -404,6 +404,75 @@ describe('NotificationManager (unit)', () => {
     });
   });
 
+  it('keeps undo controls after marking an observed false positive', async () => {
+    const detectionEvent = await detectionRepository.create({
+      server_id: 'guild-1',
+      user_id: 'user-1',
+      detection_type: DetectionType.SUSPICIOUS_CONTENT,
+      confidence: 0.9,
+      reasons: ['Suspicious content'],
+      detected_at: new Date(),
+      metadata: { observed_notification_message_id: 'message-1' },
+    });
+    const message: MockMessage = {
+      id: 'message-1',
+      embeds: [new EmbedBuilder().setTitle('Observed suspicious activity')],
+      edit: jest.fn().mockResolvedValue(undefined),
+    };
+    adminChannel.messages.fetch.mockResolvedValue(message as unknown as Message<true>);
+    const manager = new NotificationManager({} as any, configService, detectionRepository);
+
+    await manager.markObservedDetectionActionTaken(
+      detectionEvent.id,
+      'marked this detection as a false positive',
+      { id: 'admin-1' } as User,
+      { undoButtonLabel: 'Undo False Positive' }
+    );
+
+    const editArgs = message.edit.mock.calls[0][0] as { components: unknown[] };
+    expect(extractLabels(editArgs.components)).toEqual(['Undo False Positive', 'History']);
+  });
+
+  it('restores observed action buttons after undo', async () => {
+    const detectionEvent = await detectionRepository.create({
+      server_id: 'guild-1',
+      user_id: 'user-1',
+      detection_type: DetectionType.SUSPICIOUS_CONTENT,
+      confidence: 0.9,
+      reasons: ['Suspicious content'],
+      detected_at: new Date(),
+      metadata: { observed_notification_message_id: 'message-1' },
+    });
+    const message: MockMessage = {
+      id: 'message-1',
+      embeds: [
+        new EmbedBuilder()
+          .setTitle('Observed suspicious activity')
+          .addFields({ name: 'Action Taken', value: 'dismissed this alert' }),
+      ],
+      edit: jest.fn().mockResolvedValue(undefined),
+    };
+    adminChannel.messages.fetch.mockResolvedValue(message as unknown as Message<true>);
+    const manager = new NotificationManager({} as any, configService, detectionRepository);
+
+    await manager.restoreObservedDetectionActions(detectionEvent.id, 'undid the dismissal', {
+      id: 'admin-1',
+    } as User);
+
+    const editArgs = message.edit.mock.calls[0][0] as {
+      components: unknown[];
+      embeds: EmbedBuilder[];
+    };
+    expect(extractLabels(editArgs.components)).toEqual([
+      'Open Case',
+      'Restrict',
+      'Ban',
+      'Dismiss...',
+      'History',
+    ]);
+    expect(editArgs.embeds[0].data.fields?.[0].name).toBe('Action Reverted');
+  });
+
   it('does not include a mention payload when editing an existing notification (even if role is configured)', async () => {
     (configService.getServerConfig as jest.Mock).mockResolvedValue({
       admin_notification_role_id: 'role-1',

--- a/src/__tests__/unit/SecurityActionService.unit.test.ts
+++ b/src/__tests__/unit/SecurityActionService.unit.test.ts
@@ -62,6 +62,7 @@ describe('SecurityActionService (unit)', () => {
         .fn()
         .mockResolvedValue({ id: 'observe-1' } as Message),
       markObservedDetectionActionTaken: jest.fn().mockResolvedValue(true),
+      restoreObservedDetectionActions: jest.fn().mockResolvedValue(true),
     };
     threadManager = {
       createVerificationThread: jest
@@ -571,6 +572,56 @@ describe('SecurityActionService (unit)', () => {
       observed_action: AdminActionType.FALSE_POSITIVE,
       observed_action_by: moderator.id,
     });
+    expect(notificationManager.markObservedDetectionActionTaken).toHaveBeenCalledWith(
+      detectionEvent.id,
+      'marked this detection as a false positive',
+      moderator,
+      { undoButtonLabel: 'Undo False Positive' }
+    );
+  });
+
+  it('undoes an observed false positive dismissal and restores actions', async () => {
+    const guildId = 'guild-observed-undo';
+    const userId = 'user-observed-undo';
+    const moderator = { id: 'admin-observed' } as User;
+    const detectionEvent = await detectionEventsRepository.create({
+      server_id: guildId,
+      user_id: userId,
+      detection_type: DetectionType.SUSPICIOUS_CONTENT,
+      confidence: 0.82,
+      reasons: ['Suspicious content'],
+      detected_at: new Date(),
+      metadata: {
+        observed_action: AdminActionType.FALSE_POSITIVE,
+        observed_action_by: 'previous-admin',
+        observed_action_at: new Date().toISOString(),
+      },
+    });
+
+    const undoneAction = await buildService().undoObservedDetectionAction(
+      guildId,
+      userId,
+      detectionEvent.id,
+      moderator
+    );
+
+    expect(undoneAction).toBe(AdminActionType.FALSE_POSITIVE);
+    const updatedDetection = await detectionEventsRepository.findById(detectionEvent.id);
+    expect(updatedDetection?.metadata?.observed_action).toBeUndefined();
+    expect(updatedDetection?.metadata?.observed_action_by).toBeUndefined();
+    expect(adminActionService.recordAction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        detection_event_id: detectionEvent.id,
+        verification_event_id: null,
+        action_type: AdminActionType.UNDO_OBSERVED_ACTION,
+        notes: 'Undid dismissal and reverted false positive indication.',
+      })
+    );
+    expect(notificationManager.restoreObservedDetectionActions).toHaveBeenCalledWith(
+      detectionEvent.id,
+      'undid the dismissal and reverted the false positive indication',
+      moderator
+    );
   });
 
   it('releases an observed ban claim when the ban fails', async () => {

--- a/src/__tests__/unit/SecurityActionService.unit.test.ts
+++ b/src/__tests__/unit/SecurityActionService.unit.test.ts
@@ -624,6 +624,39 @@ describe('SecurityActionService (unit)', () => {
     );
   });
 
+  it('restores observed dismissal metadata if undo audit recording fails', async () => {
+    const guildId = 'guild-observed-undo-fails';
+    const userId = 'user-observed-undo-fails';
+    const moderator = { id: 'admin-observed' } as User;
+    const observedActionAt = new Date().toISOString();
+    const detectionEvent = await detectionEventsRepository.create({
+      server_id: guildId,
+      user_id: userId,
+      detection_type: DetectionType.SUSPICIOUS_CONTENT,
+      confidence: 0.82,
+      reasons: ['Suspicious content'],
+      detected_at: new Date(),
+      metadata: {
+        observed_action: AdminActionType.DISMISS,
+        observed_action_by: 'previous-admin',
+        observed_action_at: observedActionAt,
+      },
+    });
+    adminActionService.recordAction.mockRejectedValueOnce(new Error('Audit write failed'));
+
+    await expect(
+      buildService().undoObservedDetectionAction(guildId, userId, detectionEvent.id, moderator)
+    ).rejects.toThrow('Audit write failed');
+
+    const updatedDetection = await detectionEventsRepository.findById(detectionEvent.id);
+    expect(updatedDetection?.metadata).toMatchObject({
+      observed_action: AdminActionType.DISMISS,
+      observed_action_by: 'previous-admin',
+      observed_action_at: observedActionAt,
+    });
+    expect(notificationManager.restoreObservedDetectionActions).not.toHaveBeenCalled();
+  });
+
   it('releases an observed ban claim when the ban fails', async () => {
     const guildId = 'guild-observed-ban-fails';
     const userId = 'user-observed-ban-fails';

--- a/src/__tests__/unit/UserModerationService.unit.test.ts
+++ b/src/__tests__/unit/UserModerationService.unit.test.ts
@@ -67,6 +67,7 @@ describe('UserModerationService (unit)', () => {
       updateVerificationThreadAnalysis: jest.fn().mockResolvedValue(true),
       upsertObservedDetectionNotification: jest.fn().mockResolvedValue({} as any),
       markObservedDetectionActionTaken: jest.fn().mockResolvedValue(true),
+      restoreObservedDetectionActions: jest.fn().mockResolvedValue(true),
     };
     threadManager = {
       createVerificationThread: jest.fn().mockResolvedValue({} as any),

--- a/src/controllers/InteractionHandler.ts
+++ b/src/controllers/InteractionHandler.ts
@@ -666,6 +666,24 @@ export class InteractionHandler implements IInteractionHandler {
         );
         return;
 
+      case 'undo_dismiss':
+        await interaction.deferReply({ flags: MessageFlags.Ephemeral });
+        if (!(await hasModerationPermission())) {
+          await this.replyPermissionDenied(
+            interaction,
+            'You need moderation permissions to undo a dismissal.',
+            { clearComponents: true }
+          );
+          return;
+        }
+        await this.undoObservedDismissal(
+          interaction,
+          guildId,
+          parsed.userId,
+          parsed.detectionEventId
+        );
+        return;
+
       case 'history':
         if (!(await hasModerationPermission())) {
           await this.replyPermissionDenied(
@@ -839,6 +857,28 @@ export class InteractionHandler implements IInteractionHandler {
         : actionType === AdminActionType.FALSE_POSITIVE
           ? `Marked the detection for <@${userId}> as a false positive.`
           : `Dismissed the observed alert for <@${userId}>.`,
+      components: [],
+    });
+  }
+
+  private async undoObservedDismissal(
+    interaction: ButtonInteraction,
+    guildId: string,
+    userId: string,
+    detectionEventId: string
+  ): Promise<void> {
+    const undoneAction = await this.securityActionService.undoObservedDetectionAction(
+      guildId,
+      userId,
+      detectionEventId,
+      interaction.user
+    );
+    await interaction.editReply({
+      content: !undoneAction
+        ? `This observed alert for <@${userId}> does not have a dismissal to undo.`
+        : undoneAction === AdminActionType.FALSE_POSITIVE
+          ? `Undid the dismissal and reverted the false-positive indication for <@${userId}>.`
+          : `Undid the dismissal for <@${userId}>.`,
       components: [],
     });
   }

--- a/src/repositories/DetectionEventsRepository.ts
+++ b/src/repositories/DetectionEventsRepository.ts
@@ -33,6 +33,10 @@ export interface IDetectionEventsRepository {
     actionType: string,
     adminId: string
   ): Promise<DetectionEvent | null>;
+  clearObservedAction(
+    detectionEventId: string,
+    actionTypes: string[]
+  ): Promise<DetectionEvent | null>;
   cleanupOldEvents(retentionDays: number): Promise<number>;
   findById(id: string): Promise<DetectionEvent | null>; // Add findById for consistency
 }
@@ -263,6 +267,27 @@ export class DetectionEventsRepository implements IDetectionEventsRepository {
       return rows[0] ?? null;
     } catch (error) {
       this.handleError(error, 'releaseObservedAction');
+    }
+  }
+
+  async clearObservedAction(
+    detectionEventId: string,
+    actionTypes: string[]
+  ): Promise<DetectionEvent | null> {
+    try {
+      const rows = await this.prisma.$queryRaw<DetectionEvent[]>`
+        UPDATE detection_events
+        SET metadata = COALESCE(metadata, '{}'::jsonb)
+          - 'observed_action'
+          - 'observed_action_by'
+          - 'observed_action_at'
+        WHERE id = ${detectionEventId}::uuid
+          AND COALESCE(metadata, '{}'::jsonb)->>'observed_action' IN (${Prisma.join(actionTypes)})
+        RETURNING *
+      `;
+      return rows[0] ?? null;
+    } catch (error) {
+      this.handleError(error, 'clearObservedAction');
     }
   }
 

--- a/src/repositories/types.ts
+++ b/src/repositories/types.ts
@@ -127,6 +127,7 @@ export enum AdminActionType {
   RESTRICT = 'restrict',
   DISMISS = 'dismiss',
   FALSE_POSITIVE = 'false_positive',
+  UNDO_OBSERVED_ACTION = 'undo_observed_action',
 }
 
 export interface VerificationEvent {

--- a/src/services/AdminActionService.ts
+++ b/src/services/AdminActionService.ts
@@ -88,6 +88,9 @@ export class AdminActionService implements IAdminActionService {
       case AdminActionType.FALSE_POSITIVE:
         summary = `Marked false positive by ${adminMention}`;
         break;
+      case AdminActionType.UNDO_OBSERVED_ACTION:
+        summary = `Observed alert action undone by ${adminMention}`;
+        break;
       default:
         summary = `Action taken by ${adminMention}`;
     }

--- a/src/services/NotificationManager.ts
+++ b/src/services/NotificationManager.ts
@@ -416,7 +416,7 @@ export class NotificationManager implements INotificationManager {
       const components = this.createObservedActionRows(detectionEvent.user_id, detectionEvent.id);
       if (!message.embeds.length) {
         await message.edit({ allowedMentions: { parse: [] }, components });
-        return false;
+        return true;
       }
 
       const updatedEmbed = EmbedBuilder.from(message.embeds[0]);

--- a/src/services/NotificationManager.ts
+++ b/src/services/NotificationManager.ts
@@ -111,6 +111,13 @@ export interface INotificationManager {
   markObservedDetectionActionTaken(
     detectionEventId: string,
     actionDescription: string,
+    admin: User,
+    options?: { undoButtonLabel?: string }
+  ): Promise<boolean>;
+
+  restoreObservedDetectionActions(
+    detectionEventId: string,
+    actionDescription: string,
     admin: User
   ): Promise<boolean>;
 }
@@ -305,7 +312,8 @@ export class NotificationManager implements INotificationManager {
   public async markObservedDetectionActionTaken(
     detectionEventId: string,
     actionDescription: string,
-    admin: User
+    admin: User,
+    options?: { undoButtonLabel?: string }
   ): Promise<boolean> {
     try {
       const detectionEvent = await this.detectionEventsRepository.findById(detectionEventId);
@@ -346,23 +354,93 @@ export class NotificationManager implements INotificationManager {
         value: `<@${admin.id}> ${actionDescription} <t:${timestamp}:R>`,
         inline: false,
       };
-      const fieldIndex = updatedEmbed.data.fields?.findIndex(
-        (existingField) => existingField.name === field.name
-      );
-      if (fieldIndex !== undefined && fieldIndex > -1) {
-        updatedEmbed.spliceFields(fieldIndex, 1, field);
-      } else {
-        updatedEmbed.addFields(field);
-      }
+      const existingFields =
+        updatedEmbed.data.fields?.filter(
+          (existingField) =>
+            existingField.name !== field.name && existingField.name !== 'Action Reverted'
+        ) ?? [];
+      updatedEmbed.setFields(...existingFields, field);
+
+      const components = options?.undoButtonLabel
+        ? this.createObservedUndoRows(
+            detectionEvent.user_id,
+            detectionEvent.id,
+            options.undoButtonLabel
+          )
+        : [];
 
       await message.edit({
         allowedMentions: { parse: [] },
         embeds: [updatedEmbed],
-        components: [],
+        components,
       });
       return true;
     } catch (error) {
       console.error('Failed to mark observed detection action:', error);
+      return false;
+    }
+  }
+
+  public async restoreObservedDetectionActions(
+    detectionEventId: string,
+    actionDescription: string,
+    admin: User
+  ): Promise<boolean> {
+    try {
+      const detectionEvent = await this.detectionEventsRepository.findById(detectionEventId);
+      if (!detectionEvent?.server_id) {
+        return false;
+      }
+
+      const metadata = this.metadataToRecord(detectionEvent.metadata) as ObservedDetectionMetadata;
+      if (!metadata.observed_notification_message_id) {
+        return false;
+      }
+
+      const serverConfig = await this.configService.getServerConfig(detectionEvent.server_id);
+      const notificationChannel = await this.getObservedDetectionNotificationChannel(
+        detectionEvent.server_id,
+        getDetectionResponseSettings(serverConfig.settings)
+      );
+      if (!notificationChannel) {
+        return false;
+      }
+
+      const message = await notificationChannel.messages
+        .fetch(metadata.observed_notification_message_id)
+        .catch(() => null);
+      if (!message) {
+        return false;
+      }
+
+      const components = this.createObservedActionRows(detectionEvent.user_id, detectionEvent.id);
+      if (!message.embeds.length) {
+        await message.edit({ allowedMentions: { parse: [] }, components });
+        return false;
+      }
+
+      const updatedEmbed = EmbedBuilder.from(message.embeds[0]);
+      const timestamp = Math.floor(Date.now() / 1000);
+      const field = {
+        name: 'Action Reverted',
+        value: `<@${admin.id}> ${actionDescription} <t:${timestamp}:R>`,
+        inline: false,
+      };
+      const existingFields =
+        updatedEmbed.data.fields?.filter(
+          (existingField) =>
+            existingField.name !== 'Action Taken' && existingField.name !== field.name
+        ) ?? [];
+      updatedEmbed.setFields(...existingFields, field);
+
+      await message.edit({
+        allowedMentions: { parse: [] },
+        embeds: [updatedEmbed],
+        components,
+      });
+      return true;
+    } catch (error) {
+      console.error('Failed to restore observed detection actions:', error);
       return false;
     }
   }
@@ -997,6 +1075,25 @@ export class NotificationManager implements INotificationManager {
           .setCustomId(`observed:dismiss_menu:${userId}:${detectionEventId}`)
           .setLabel('Dismiss...')
           .setStyle(ButtonStyle.Secondary),
+        new ButtonBuilder()
+          .setCustomId(`observed:history:${userId}:${detectionEventId}`)
+          .setLabel('History')
+          .setStyle(ButtonStyle.Secondary)
+      ),
+    ];
+  }
+
+  private createObservedUndoRows(
+    userId: string,
+    detectionEventId: string,
+    undoButtonLabel: string
+  ): ActionRowBuilder<ButtonBuilder>[] {
+    return [
+      new ActionRowBuilder<ButtonBuilder>().addComponents(
+        new ButtonBuilder()
+          .setCustomId(`observed:undo_dismiss:${userId}:${detectionEventId}`)
+          .setLabel(undoButtonLabel)
+          .setStyle(ButtonStyle.Primary),
         new ButtonBuilder()
           .setCustomId(`observed:history:${userId}:${detectionEventId}`)
           .setLabel('History')

--- a/src/services/SecurityActionService.ts
+++ b/src/services/SecurityActionService.ts
@@ -353,6 +353,31 @@ export class SecurityActionService implements ISecurityActionService {
     );
   }
 
+  private async restoreDetectionMetadataForObservedAction(
+    detectionEvent: DetectionEvent,
+    moderator: User,
+    actionType: AdminActionType
+  ): Promise<void> {
+    const metadata =
+      detectionEvent.metadata &&
+      typeof detectionEvent.metadata === 'object' &&
+      !Array.isArray(detectionEvent.metadata)
+        ? detectionEvent.metadata
+        : {};
+
+    await this.detectionEventsRepository.claimObservedAction(detectionEvent.id, {
+      observed_action: actionType,
+      observed_action_by:
+        typeof metadata.observed_action_by === 'string'
+          ? metadata.observed_action_by
+          : moderator.id,
+      observed_action_at:
+        typeof metadata.observed_action_at === 'string'
+          ? metadata.observed_action_at
+          : new Date().toISOString(),
+    });
+  }
+
   private hasObservedAction(detectionEvent: DetectionEvent): boolean {
     return this.getObservedAction(detectionEvent) !== null;
   }
@@ -856,25 +881,38 @@ export class SecurityActionService implements ISecurityActionService {
       return null;
     }
 
-    await this.recordObservedAction({
-      serverId: guildId,
-      userId,
-      moderator,
-      detectionEvent: restoredDetectionEvent,
-      actionType: AdminActionType.UNDO_OBSERVED_ACTION,
-      notes:
+    let actionRecorded = false;
+    try {
+      await this.recordObservedAction({
+        serverId: guildId,
+        userId,
+        moderator,
+        detectionEvent: restoredDetectionEvent,
+        actionType: AdminActionType.UNDO_OBSERVED_ACTION,
+        notes:
+          observedAction === AdminActionType.FALSE_POSITIVE
+            ? 'Undid dismissal and reverted false positive indication.'
+            : 'Undid dismissal.',
+      });
+      actionRecorded = true;
+      await this.notificationManager.restoreObservedDetectionActions(
+        detectionEvent.id,
         observedAction === AdminActionType.FALSE_POSITIVE
-          ? 'Undid dismissal and reverted false positive indication.'
-          : 'Undid dismissal.',
-    });
-    await this.notificationManager.restoreObservedDetectionActions(
-      detectionEvent.id,
-      observedAction === AdminActionType.FALSE_POSITIVE
-        ? 'undid the dismissal and reverted the false positive indication'
-        : 'undid the dismissal',
-      moderator
-    );
-    return observedAction;
+          ? 'undid the dismissal and reverted the false positive indication'
+          : 'undid the dismissal',
+        moderator
+      );
+      return observedAction;
+    } catch (error) {
+      if (!actionRecorded) {
+        await this.restoreDetectionMetadataForObservedAction(
+          detectionEvent,
+          moderator,
+          observedAction
+        );
+      }
+      throw error;
+    }
   }
 
   // TODO: Refactor reopenVerification to use events

--- a/src/services/SecurityActionService.ts
+++ b/src/services/SecurityActionService.ts
@@ -93,6 +93,13 @@ export interface ISecurityActionService {
     actionType: AdminActionType.DISMISS | AdminActionType.FALSE_POSITIVE
   ): Promise<boolean>;
 
+  undoObservedDetectionAction(
+    guildId: string,
+    userId: string,
+    detectionEventId: string,
+    moderator: User
+  ): Promise<AdminActionType.DISMISS | AdminActionType.FALSE_POSITIVE | null>;
+
   /**
    * Reopens a verification event, and re-restricts the user (or unbans them?)
    * @param verificationEvent The verification event to reopen
@@ -347,12 +354,15 @@ export class SecurityActionService implements ISecurityActionService {
   }
 
   private hasObservedAction(detectionEvent: DetectionEvent): boolean {
-    return Boolean(
-      detectionEvent.metadata &&
-      typeof detectionEvent.metadata === 'object' &&
-      !Array.isArray(detectionEvent.metadata) &&
-      detectionEvent.metadata.observed_action
-    );
+    return this.getObservedAction(detectionEvent) !== null;
+  }
+
+  private getObservedAction(detectionEvent: DetectionEvent): AdminActionType | null {
+    const metadata = detectionEvent.metadata;
+    if (!metadata || typeof metadata !== 'object' || Array.isArray(metadata)) {
+      return null;
+    }
+    return metadata.observed_action ? (metadata.observed_action as AdminActionType) : null;
   }
 
   private async recordObservedAction(data: {
@@ -801,7 +811,13 @@ export class SecurityActionService implements ISecurityActionService {
         actionType === AdminActionType.FALSE_POSITIVE
           ? 'marked this detection as a false positive'
           : 'dismissed this alert',
-        moderator
+        moderator,
+        {
+          undoButtonLabel:
+            actionType === AdminActionType.FALSE_POSITIVE
+              ? 'Undo False Positive'
+              : 'Undo Dismissal',
+        }
       );
       return true;
     } catch (error) {
@@ -810,6 +826,55 @@ export class SecurityActionService implements ISecurityActionService {
       }
       throw error;
     }
+  }
+
+  public async undoObservedDetectionAction(
+    guildId: string,
+    userId: string,
+    detectionEventId: string,
+    moderator: User
+  ): Promise<AdminActionType.DISMISS | AdminActionType.FALSE_POSITIVE | null> {
+    const detectionEvent = await this.getObservedDetectionForUser(
+      guildId,
+      userId,
+      detectionEventId
+    );
+    const observedAction = this.getObservedAction(detectionEvent);
+    if (
+      observedAction !== AdminActionType.DISMISS &&
+      observedAction !== AdminActionType.FALSE_POSITIVE
+    ) {
+      return null;
+    }
+
+    await this.ensureObservedEntitiesExist(guildId, userId);
+    const restoredDetectionEvent = await this.detectionEventsRepository.clearObservedAction(
+      detectionEvent.id,
+      [AdminActionType.DISMISS, AdminActionType.FALSE_POSITIVE]
+    );
+    if (!restoredDetectionEvent) {
+      return null;
+    }
+
+    await this.recordObservedAction({
+      serverId: guildId,
+      userId,
+      moderator,
+      detectionEvent: restoredDetectionEvent,
+      actionType: AdminActionType.UNDO_OBSERVED_ACTION,
+      notes:
+        observedAction === AdminActionType.FALSE_POSITIVE
+          ? 'Undid dismissal and reverted false positive indication.'
+          : 'Undid dismissal.',
+    });
+    await this.notificationManager.restoreObservedDetectionActions(
+      detectionEvent.id,
+      observedAction === AdminActionType.FALSE_POSITIVE
+        ? 'undid the dismissal and reverted the false positive indication'
+        : 'undid the dismissal',
+      moderator
+    );
+    return observedAction;
   }
 
   // TODO: Refactor reopenVerification to use events

--- a/src/services/SecurityActionService.ts
+++ b/src/services/SecurityActionService.ts
@@ -387,7 +387,11 @@ export class SecurityActionService implements ISecurityActionService {
     if (!metadata || typeof metadata !== 'object' || Array.isArray(metadata)) {
       return null;
     }
-    return metadata.observed_action ? (metadata.observed_action as AdminActionType) : null;
+    const observedAction = metadata.observed_action;
+    return typeof observedAction === 'string' &&
+      Object.values(AdminActionType).includes(observedAction as AdminActionType)
+      ? (observedAction as AdminActionType)
+      : null;
   }
 
   private async recordObservedAction(data: {


### PR DESCRIPTION
## Summary
- add undo handling for observed dismiss and false-positive actions, including audit history and restored action buttons
- add Prisma migrations for the undo audit enum and Supabase public-table RLS/grant hardening
- refresh Node 24 GitHub Actions versions and lockfile security updates, aligning Prisma CLI/client at 6.19.3

## Validation
- `npm audit --audit-level=moderate`
- `DATABASE_URL=postgresql://postgres:postgres@localhost:5432/drasil_test?schema=public npx prisma validate`
- `npm run prisma:generate`
- `npm run build`
- `npm run lint` (passes with existing ESLint flat-config warning for `scripts/create-prisma-user.js`)
- `npm test`
- `npm run format:check`
- targeted review-fix checks: `npm run build`, `npx jest src/__tests__/unit/SecurityActionService.unit.test.ts --runInBand`, `npx jest src/__tests__/unit/NotificationManager.unit.test.ts --runInBand`, `git diff --check`
- GitHub `build-test` passed, including integration tests against CI Postgres
- local `npm run test:integration` attempted; blocked because no Postgres is listening on `localhost:5432`