### PR TITLE
Override vulnerable Hono transitive dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2331,9 +2331,9 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.11",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.11.tgz",
-      "integrity": "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==",
+      "version": "1.19.13",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.13.tgz",
+      "integrity": "sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ==",
       "license": "MIT",
       "engines": {
         "node": ">=18.14.1"

--- a/package.json
+++ b/package.json
@@ -81,5 +81,8 @@
     "prisma": "^7.8.0",
     "reflect-metadata": "^0.2.2",
     "zod": "^3.25.76"
+  },
+  "overrides": {
+    "@hono/node-server": "1.19.13"
   }
 }


### PR DESCRIPTION
## Summary
- Add an npm override for `@hono/node-server@1.19.13` to satisfy the Prisma 7 transitive security advisory.
- Refresh `package-lock.json` so Dependabot can resolve the patched transitive package.

## Verification
- `npm audit --omit=dev`
- `npm run prisma:generate`
- `npx prisma validate` with placeholder `DATABASE_URL`
- `npm run format:check`
- `npm run lint` (passes with existing flat-config warning in `scripts/create-prisma-user.js`)
- `npm run build`
- `npm test`