### PR TITLE
Guard moderation interactions and reports

### DIFF
--- a/src/__tests__/unit/InteractionHandler.unit.test.ts
+++ b/src/__tests__/unit/InteractionHandler.unit.test.ts
@@ -297,6 +297,34 @@ describe('InteractionHandler (unit)', () => {
     });
   });
 
+  it('handles history button for members with moderation permissions', async () => {
+    verificationEventRepository.findByUserAndServer.mockResolvedValue([]);
+
+    const handler = new InteractionHandler(
+      client,
+      notificationManager,
+      userModerationService,
+      securityActionService,
+      configService,
+      verificationEventRepository,
+      threadManager,
+      adminActionRepository
+    );
+    const interaction = buildInteraction('history_user-1', 'guild-1', {
+      id: 'admin-1',
+    } as User);
+    grantInteractionPermissions(interaction);
+
+    await handler.handleButtonInteraction(interaction);
+
+    expect(interaction.deferReply).toHaveBeenCalledWith({ flags: MessageFlags.Ephemeral });
+    expect(verificationEventRepository.findByUserAndServer).toHaveBeenCalledWith(
+      'user-1',
+      'guild-1'
+    );
+    expect(interaction.editReply).toHaveBeenCalled();
+  });
+
   it.each([
     ['verify_user-1', 'You need moderation permissions to verify a user.'],
     ['ban_user-1', 'You need Ban Members permission to ban a user.'],

--- a/src/__tests__/unit/InteractionHandler.unit.test.ts
+++ b/src/__tests__/unit/InteractionHandler.unit.test.ts
@@ -6,6 +6,7 @@ import {
   GuildMember,
   MessageFlags,
   ModalSubmitInteraction,
+  PermissionFlagsBits,
   User,
 } from 'discord.js';
 import { InteractionHandler } from '../../controllers/InteractionHandler';
@@ -63,6 +64,14 @@ const buildInteraction = (customId: string, guildId: string, user: User): Button
 const grantInteractionPermissions = (interaction: ButtonInteraction): void => {
   Object.assign(interaction, {
     memberPermissions: { has: jest.fn().mockReturnValue(true) },
+  });
+};
+
+const grantOnlyBanMembersPermission = (interaction: ButtonInteraction): void => {
+  Object.assign(interaction, {
+    memberPermissions: {
+      has: jest.fn((permission: bigint) => permission === PermissionFlagsBits.BanMembers),
+    },
   });
 };
 
@@ -370,6 +379,70 @@ describe('InteractionHandler (unit)', () => {
       expect(securityActionService.reopenVerification).not.toHaveBeenCalled();
     }
   );
+
+  it.each([
+    ['verify_user-1', 'You need moderation permissions to verify a user.'],
+    ['thread_user-1', 'You need moderation permissions to create a verification thread.'],
+    ['history_user-1', 'You need moderation permissions to view history.'],
+    ['reopen_user-1', 'You need moderation permissions to reopen verification.'],
+  ])(
+    'denies non-ban legacy button %s with only BanMembers permission',
+    async (customId, message) => {
+      (client.guilds.fetch as jest.Mock).mockResolvedValue({
+        members: {
+          fetch: jest.fn().mockResolvedValue({
+            permissions: {
+              has: jest.fn((permission: bigint) => permission === PermissionFlagsBits.BanMembers),
+            },
+          }),
+        },
+      });
+      const handler = new InteractionHandler(
+        client,
+        notificationManager,
+        userModerationService,
+        securityActionService,
+        configService,
+        verificationEventRepository,
+        threadManager,
+        adminActionRepository
+      );
+      const interaction = buildInteraction(customId, 'guild-1', { id: 'ban-mod-1' } as User);
+      grantOnlyBanMembersPermission(interaction);
+
+      await handler.handleButtonInteraction(interaction);
+
+      expect(interaction.reply).toHaveBeenCalledWith({
+        content: message,
+        flags: MessageFlags.Ephemeral,
+      });
+      expect(userModerationService.verifyUser).not.toHaveBeenCalled();
+      expect(threadManager.createVerificationThread).not.toHaveBeenCalled();
+      expect(notificationManager.handleHistoryButtonClick).not.toHaveBeenCalled();
+      expect(securityActionService.reopenVerification).not.toHaveBeenCalled();
+    }
+  );
+
+  it('allows ban button with only BanMembers permission', async () => {
+    const handler = new InteractionHandler(
+      client,
+      notificationManager,
+      userModerationService,
+      securityActionService,
+      configService,
+      verificationEventRepository,
+      threadManager,
+      adminActionRepository
+    );
+    const interaction = buildInteraction('ban_user-1', 'guild-1', {
+      id: 'ban-mod-1',
+    } as User);
+    grantOnlyBanMembersPermission(interaction);
+
+    await handler.handleButtonInteraction(interaction);
+
+    expect(userModerationService.banUser).toHaveBeenCalledTimes(1);
+  });
 
   it('handles observed open case button', async () => {
     const handler = new InteractionHandler(

--- a/src/__tests__/unit/InteractionHandler.unit.test.ts
+++ b/src/__tests__/unit/InteractionHandler.unit.test.ts
@@ -173,6 +173,7 @@ describe('InteractionHandler (unit)', () => {
     const interaction = buildInteraction('verify_user-1', 'guild-1', {
       id: 'admin-1',
     } as User);
+    grantInteractionPermissions(interaction);
 
     await handler.handleButtonInteraction(interaction);
 
@@ -197,6 +198,7 @@ describe('InteractionHandler (unit)', () => {
     const interaction = buildInteraction('ban_user-1', 'guild-1', {
       id: 'admin-1',
     } as User);
+    grantInteractionPermissions(interaction);
 
     await handler.handleButtonInteraction(interaction);
 
@@ -238,6 +240,7 @@ describe('InteractionHandler (unit)', () => {
     const interaction = buildInteraction('thread_user-1', 'guild-1', {
       id: 'admin-1',
     } as User);
+    grantInteractionPermissions(interaction);
 
     await handler.handleButtonInteraction(interaction);
 
@@ -280,6 +283,7 @@ describe('InteractionHandler (unit)', () => {
     const interaction = buildInteraction('reopen_user-1', 'guild-1', {
       id: 'admin-1',
     } as User);
+    grantInteractionPermissions(interaction);
 
     await handler.handleButtonInteraction(interaction);
 
@@ -292,6 +296,52 @@ describe('InteractionHandler (unit)', () => {
       flags: MessageFlags.Ephemeral,
     });
   });
+
+  it.each([
+    ['verify_user-1', 'You need moderation permissions to verify a user.'],
+    ['ban_user-1', 'You need Ban Members permission to ban a user.'],
+    ['thread_user-1', 'You need moderation permissions to create a verification thread.'],
+    ['history_user-1', 'You need moderation permissions to view history.'],
+    ['reopen_user-1', 'You need moderation permissions to reopen verification.'],
+  ])(
+    'denies legacy moderation button %s without moderator permissions',
+    async (customId, message) => {
+      (client.guilds.fetch as jest.Mock).mockResolvedValue({
+        members: {
+          fetch: jest.fn().mockResolvedValue({
+            permissions: { has: jest.fn().mockReturnValue(false) },
+          }),
+        },
+      });
+      const handler = new InteractionHandler(
+        client,
+        notificationManager,
+        userModerationService,
+        securityActionService,
+        configService,
+        verificationEventRepository,
+        threadManager,
+        adminActionRepository
+      );
+      const interaction = buildInteraction(customId, 'guild-1', { id: 'viewer-1' } as User);
+      Object.assign(interaction, {
+        memberPermissions: { has: jest.fn().mockReturnValue(false) },
+      });
+
+      await handler.handleButtonInteraction(interaction);
+
+      expect(interaction.reply).toHaveBeenCalledWith({
+        content: message,
+        flags: MessageFlags.Ephemeral,
+      });
+      expect(interaction.deferUpdate).not.toHaveBeenCalled();
+      expect(userModerationService.verifyUser).not.toHaveBeenCalled();
+      expect(userModerationService.banUser).not.toHaveBeenCalled();
+      expect(threadManager.createVerificationThread).not.toHaveBeenCalled();
+      expect(notificationManager.handleHistoryButtonClick).not.toHaveBeenCalled();
+      expect(securityActionService.reopenVerification).not.toHaveBeenCalled();
+    }
+  );
 
   it('handles observed open case button', async () => {
     const handler = new InteractionHandler(

--- a/src/__tests__/unit/SecurityActionService.unit.test.ts
+++ b/src/__tests__/unit/SecurityActionService.unit.test.ts
@@ -242,7 +242,7 @@ describe('SecurityActionService (unit)', () => {
     expect(notificationManager.upsertSuspiciousUserNotification).toHaveBeenCalledTimes(1);
   });
 
-  it('creates detection event for user report', async () => {
+  it('creates a review-only pending case for user report', async () => {
     const guildId = 'guild-3';
     const userId = 'user-3';
     const reporterId = 'reporter-1';
@@ -277,7 +277,7 @@ describe('SecurityActionService (unit)', () => {
     );
     expect(verificationEvents).toHaveLength(1);
     expect(verificationEvents[0].status).toBe(VerificationStatus.PENDING);
-    expect(userModerationService.restrictUser).toHaveBeenCalled();
+    expect(userModerationService.restrictUser).not.toHaveBeenCalled();
     expect(threadManager.createVerificationThread).toHaveBeenCalled();
   });
 
@@ -429,7 +429,7 @@ describe('SecurityActionService (unit)', () => {
       VerificationStatus.PENDING,
       VerificationStatus.VERIFIED,
     ]);
-    expect(userModerationService.restrictUser).toHaveBeenCalledWith(member);
+    expect(userModerationService.restrictUser).not.toHaveBeenCalled();
     expect(threadManager.createVerificationThread).toHaveBeenCalledTimes(1);
   });
 

--- a/src/__tests__/unit/SecurityActionService.unit.test.ts
+++ b/src/__tests__/unit/SecurityActionService.unit.test.ts
@@ -354,7 +354,7 @@ describe('SecurityActionService (unit)', () => {
     expect(notificationManager.upsertSuspiciousUserNotification).toHaveBeenCalledTimes(1);
   });
 
-  it('adds a manual flag to an existing pending case without creating a duplicate case', async () => {
+  it('adds a manual flag to an existing review-only pending case and restricts the user', async () => {
     const guildId = 'guild-4b';
     const userId = 'user-4b';
     const moderatorId = 'admin-2';
@@ -392,7 +392,7 @@ describe('SecurityActionService (unit)', () => {
     );
     expect(verificationEvents).toHaveLength(1);
     expect(verificationEvents[0].status).toBe(VerificationStatus.PENDING);
-    expect(userModerationService.restrictUser).not.toHaveBeenCalled();
+    expect(userModerationService.restrictUser).toHaveBeenCalledWith(member);
     expect(threadManager.createVerificationThread).not.toHaveBeenCalled();
     expect(notificationManager.upsertSuspiciousUserNotification).toHaveBeenCalledTimes(1);
   });

--- a/src/__tests__/unit/SecurityActionService.unit.test.ts
+++ b/src/__tests__/unit/SecurityActionService.unit.test.ts
@@ -397,6 +397,54 @@ describe('SecurityActionService (unit)', () => {
     expect(notificationManager.upsertSuspiciousUserNotification).toHaveBeenCalledTimes(1);
   });
 
+  it('restricts the user when auto-detection follows an existing review-only pending case', async () => {
+    const guildId = 'guild-4b-auto';
+    const userId = 'user-4b-auto';
+    const member = buildMember(guildId, userId);
+    const message = buildMessage(guildId, 'channel-4b-auto');
+
+    const initialDetection = await detectionEventsRepository.create({
+      server_id: guildId,
+      user_id: userId,
+      detection_type: DetectionType.USER_REPORT,
+      confidence: 1.0,
+      reasons: ['Initial report'],
+      detected_at: new Date(),
+    });
+    const activeCase = await verificationEventRepository.createFromDetection(
+      initialDetection.id,
+      guildId,
+      userId,
+      VerificationStatus.PENDING
+    );
+    const detectionResult: DetectionResult = {
+      label: 'SUSPICIOUS',
+      confidence: 0.88,
+      reasons: ['Suspicious content after report'],
+      triggerSource: DetectionType.SUSPICIOUS_CONTENT,
+      triggerContent: message.content,
+    };
+
+    await buildService().handleSuspiciousMessage(member, detectionResult, message);
+
+    const detectionEvents = await detectionEventsRepository.findByServerAndUser(guildId, userId);
+    expect(detectionEvents).toHaveLength(2);
+    const autoDetectionEvent = detectionEvents.find(
+      (event) => event.detection_type === DetectionType.SUSPICIOUS_CONTENT
+    );
+    expect(autoDetectionEvent?.latest_verification_event_id).toBe(activeCase.id);
+
+    const verificationEvents = await verificationEventRepository.findByUserAndServer(
+      userId,
+      guildId
+    );
+    expect(verificationEvents).toHaveLength(1);
+    expect(verificationEvents[0].status).toBe(VerificationStatus.PENDING);
+    expect(userModerationService.restrictUser).toHaveBeenCalledWith(member);
+    expect(threadManager.createVerificationThread).not.toHaveBeenCalled();
+    expect(notificationManager.upsertSuspiciousUserNotification).toHaveBeenCalledTimes(1);
+  });
+
   it('opens a new pending case when a user report follows a resolved case', async () => {
     const guildId = 'guild-4c';
     const userId = 'user-4c';

--- a/src/controllers/InteractionHandler.ts
+++ b/src/controllers/InteractionHandler.ts
@@ -126,18 +126,63 @@ export class InteractionHandler implements IInteractionHandler {
 
       switch (action) {
         case 'verify':
+          if (
+            !(await this.hasAnyPermission(interaction, guildId, this.getModerationPermissions()))
+          ) {
+            await this.replyPermissionDenied(
+              interaction,
+              'You need moderation permissions to verify a user.'
+            );
+            return;
+          }
           await this.handleVerifyButton(interaction, guildId, targetUserId);
           break;
         case 'ban':
+          if (
+            !(await this.hasAnyPermission(interaction, guildId, [PermissionFlagsBits.BanMembers]))
+          ) {
+            await this.replyPermissionDenied(
+              interaction,
+              'You need Ban Members permission to ban a user.'
+            );
+            return;
+          }
           await this.handleBanButton(interaction, guildId, targetUserId);
           break;
         case 'thread':
+          if (
+            !(await this.hasAnyPermission(interaction, guildId, this.getModerationPermissions()))
+          ) {
+            await this.replyPermissionDenied(
+              interaction,
+              'You need moderation permissions to create a verification thread.'
+            );
+            return;
+          }
           await this.handleThreadButton(interaction, guildId, targetUserId);
           break;
         case 'history':
+          if (
+            !(await this.hasAnyPermission(interaction, guildId, this.getModerationPermissions()))
+          ) {
+            await this.replyPermissionDenied(
+              interaction,
+              'You need moderation permissions to view history.'
+            );
+            return;
+          }
           await this.handleHistoryButton(interaction, guildId, targetUserId);
           break;
         case 'reopen':
+          if (
+            !(await this.hasAnyPermission(interaction, guildId, this.getModerationPermissions()))
+          ) {
+            await this.replyPermissionDenied(
+              interaction,
+              'You need moderation permissions to reopen verification.'
+            );
+            return;
+          }
           await this.handleReopenButton(interaction, guildId, targetUserId);
           break;
         default:
@@ -539,12 +584,16 @@ export class InteractionHandler implements IInteractionHandler {
     return member;
   }
 
-  private getObservedModerationPermissions(): bigint[] {
+  private getModerationPermissions(): bigint[] {
     return [
       PermissionFlagsBits.ManageGuild,
       PermissionFlagsBits.ModerateMembers,
       PermissionFlagsBits.BanMembers,
     ];
+  }
+
+  private getObservedModerationPermissions(): bigint[] {
+    return this.getModerationPermissions();
   }
 
   private async handleObservedButtonInteraction(

--- a/src/controllers/InteractionHandler.ts
+++ b/src/controllers/InteractionHandler.ts
@@ -585,11 +585,7 @@ export class InteractionHandler implements IInteractionHandler {
   }
 
   private getModerationPermissions(): bigint[] {
-    return [
-      PermissionFlagsBits.ManageGuild,
-      PermissionFlagsBits.ModerateMembers,
-      PermissionFlagsBits.BanMembers,
-    ];
+    return [PermissionFlagsBits.ManageGuild, PermissionFlagsBits.ModerateMembers];
   }
 
   private getObservedModerationPermissions(): bigint[] {

--- a/src/services/SecurityActionService.ts
+++ b/src/services/SecurityActionService.ts
@@ -658,7 +658,7 @@ export class SecurityActionService implements ISecurityActionService {
         detectionEventId: detectionEvent.id,
       };
 
-      return await this.handleSuspiciousMember(member, detectionResult);
+      return await this.handleSuspiciousMember(member, detectionResult, undefined, false);
     } catch (error) {
       console.error(`Failed to handle user report for ${member.user.tag}:`, error);
       throw error;

--- a/src/services/SecurityActionService.ts
+++ b/src/services/SecurityActionService.ts
@@ -459,6 +459,21 @@ export class SecurityActionService implements ISecurityActionService {
           `Failed to link detection event ${detectionEventId} to verification event ${activeVerificationEvent.id}`
         );
       }
+      const initialDetection = activeVerificationEvent.detection_event_id
+        ? await this.detectionEventsRepository.findById(activeVerificationEvent.detection_event_id)
+        : null;
+      if (restrictUser && initialDetection?.detection_type === DetectionType.USER_REPORT) {
+        const serverMember = await this.serverMemberRepository.findByServerAndUser(
+          member.guild.id,
+          member.id
+        );
+        if (serverMember?.is_restricted !== true) {
+          const restricted = await this.userModerationService.restrictUser(member);
+          if (!restricted) {
+            throw new Error(`Failed to restrict user ${member.user.tag}`);
+          }
+        }
+      }
       await this.upsertNotification(
         member,
         detectionResult,

--- a/src/services/SecurityActionService.ts
+++ b/src/services/SecurityActionService.ts
@@ -459,18 +459,22 @@ export class SecurityActionService implements ISecurityActionService {
           `Failed to link detection event ${detectionEventId} to verification event ${activeVerificationEvent.id}`
         );
       }
-      const initialDetection = activeVerificationEvent.detection_event_id
-        ? await this.detectionEventsRepository.findById(activeVerificationEvent.detection_event_id)
-        : null;
-      if (restrictUser && initialDetection?.detection_type === DetectionType.USER_REPORT) {
-        const serverMember = await this.serverMemberRepository.findByServerAndUser(
-          member.guild.id,
-          member.id
-        );
-        if (serverMember?.is_restricted !== true) {
-          const restricted = await this.userModerationService.restrictUser(member);
-          if (!restricted) {
-            throw new Error(`Failed to restrict user ${member.user.tag}`);
+      if (restrictUser) {
+        const initialDetection = activeVerificationEvent.detection_event_id
+          ? await this.detectionEventsRepository.findById(
+              activeVerificationEvent.detection_event_id
+            )
+          : null;
+        if (initialDetection?.detection_type === DetectionType.USER_REPORT) {
+          const serverMember = await this.serverMemberRepository.findByServerAndUser(
+            member.guild.id,
+            member.id
+          );
+          if (serverMember?.is_restricted !== true) {
+            const restricted = await this.userModerationService.restrictUser(member);
+            if (!restricted) {
+              throw new Error(`Failed to restrict user ${member.user.tag}`);
+            }
           }
         }
       }


### PR DESCRIPTION
## What / Why

- Adds explicit permission gates to legacy moderation buttons (`verify_*`, `ban_*`, `thread_*`, `history_*`, `reopen_*`).
- Changes public user reports to open review-only pending cases instead of restricting the reported member automatically.
- Preserves escalation: later manual flags or automated detections on a report-only pending case can still restrict the user.
- Narrows `BanMembers` to the dedicated `ban_*` path instead of general non-ban moderation actions.
- Updates focused unit coverage for these behaviors.

## Linked issues

- None.

## How to test

- `npm audit --omit=dev`
- `npm run prisma:generate`
- `$env:DATABASE_URL='postgresql://user:password@localhost:5432/db'; npx prisma validate`
- `npx jest src/__tests__/unit/InteractionHandler.unit.test.ts src/__tests__/unit/SecurityActionService.unit.test.ts --runInBand`
- `npm run format:check`
- `npm run lint`
- `npm run build`
- `npm test`

If applicable:

- `npm run test:integration` was not run locally because no local test Postgres URL is configured.

## Risk / rollout

- Low migration risk: code-only moderation behavior change, no schema changes.
- Product behavior change: public reports still create moderation cases/threads, but no longer restrict users before moderator review.
- Permission behavior change: `BanMembers` alone can use `ban_*`, but not `verify_*`, `thread_*`, `history_*`, or `reopen_*`.
- Rollout should include staging Discord smoke QA for reporter flow, denied non-mod buttons, denied ban-only non-ban buttons, and allowed moderator buttons.

## AI Review Packet (fresh-context friendly)

- Primary goal: prevent non-moderators from using legacy moderation button custom IDs and prevent public reports from auto-restricting reported users.
- Non-goals: no interaction router refactor, no moderation case schema changes, no Discord UI redesign.
- Key files changed: `src/controllers/InteractionHandler.ts`, `src/services/SecurityActionService.ts`, `src/__tests__/unit/InteractionHandler.unit.test.ts`, `src/__tests__/unit/SecurityActionService.unit.test.ts`.
- Invariants this PR must preserve: observed suspicious activity actions keep their existing moderator/admin guard; moderator/admin legacy buttons still perform their intended actions; user reports still notify/create a pending case for moderator review; later confirmed suspicious activity can still restrict a report-only case.
- Manual test notes: local unit suite passed; staging Discord smoke QA is still recommended before relying on production behavior.
- Questions for reviewers: none currently open.

## Merge checklist

- [x] All PR review threads resolved (or explicitly addressed)
- [x] CI, IaC checks, and CodeQL are green on current head
- [x] Copilot review comments addressed
- [x] Greptile review comments addressed
- [x] Greptile rerun completed successfully