### PR TITLE
Prevent pg sslmode from overriding Prisma SSL config

### DIFF
--- a/src/__tests__/unit/prisma.unit.test.ts
+++ b/src/__tests__/unit/prisma.unit.test.ts
@@ -51,7 +51,7 @@ describe('createPrismaPoolConfig', () => {
     expect(
       createPrismaPoolConfig('postgresql://user:password@example.com:5432/db?sslmode=verify-full')
     ).toEqual({
-      connectionString: 'postgresql://user:password@example.com:5432/db?sslmode=verify-full',
+      connectionString: 'postgresql://user:password@example.com:5432/db',
       max: 10,
       ssl: { rejectUnauthorized: true },
     });
@@ -63,8 +63,7 @@ describe('createPrismaPoolConfig', () => {
         'postgresql://user:password@aws-1-us-east-1.pooler.supabase.com:6543/db?sslmode=verify-full'
       )
     ).toEqual({
-      connectionString:
-        'postgresql://user:password@aws-1-us-east-1.pooler.supabase.com:6543/db?sslmode=verify-full',
+      connectionString: 'postgresql://user:password@aws-1-us-east-1.pooler.supabase.com:6543/db',
       max: 10,
       ssl: { rejectUnauthorized: true },
     });
@@ -74,7 +73,20 @@ describe('createPrismaPoolConfig', () => {
     expect(
       createPrismaPoolConfig('postgresql://user:password@example.com:5432/db?sslmode=require')
     ).toEqual({
-      connectionString: 'postgresql://user:password@example.com:5432/db?sslmode=require',
+      connectionString: 'postgresql://user:password@example.com:5432/db',
+      max: 10,
+      ssl: { rejectUnauthorized: false },
+    });
+  });
+
+  it('strips sslmode while preserving Supabase pooler pgbouncer parameters', () => {
+    expect(
+      createPrismaPoolConfig(
+        'postgresql://user:password@aws-1-us-east-1.pooler.supabase.com:6543/db?pgbouncer=true&sslmode=require'
+      )
+    ).toEqual({
+      connectionString:
+        'postgresql://user:password@aws-1-us-east-1.pooler.supabase.com:6543/db?pgbouncer=true',
       max: 10,
       ssl: { rejectUnauthorized: false },
     });
@@ -86,7 +98,7 @@ describe('createPrismaPoolConfig', () => {
     );
 
     expect(config).toEqual({
-      connectionString: 'postgresql://user:password@example.com:5432/db?sslmode=verify-ca',
+      connectionString: 'postgresql://user:password@example.com:5432/db',
       max: 10,
       ssl: { rejectUnauthorized: true, checkServerIdentity: expect.any(Function) },
     });
@@ -99,7 +111,7 @@ describe('createPrismaPoolConfig', () => {
     expect(
       createPrismaPoolConfig('postgresql://user:password@example.com:5432/db?sslmode=no-verify')
     ).toEqual({
-      connectionString: 'postgresql://user:password@example.com:5432/db?sslmode=no-verify',
+      connectionString: 'postgresql://user:password@example.com:5432/db',
       max: 10,
       ssl: { rejectUnauthorized: false },
     });

--- a/src/__tests__/unit/prisma.unit.test.ts
+++ b/src/__tests__/unit/prisma.unit.test.ts
@@ -116,4 +116,14 @@ describe('createPrismaPoolConfig', () => {
       ssl: { rejectUnauthorized: false },
     });
   });
+
+  it('honors disable sslmode with explicit ssl false', () => {
+    expect(
+      createPrismaPoolConfig('postgresql://user:password@example.com:5432/db?sslmode=disable')
+    ).toEqual({
+      connectionString: 'postgresql://user:password@example.com:5432/db',
+      max: 10,
+      ssl: false,
+    });
+  });
 });

--- a/src/db/prisma.ts
+++ b/src/db/prisma.ts
@@ -23,10 +23,23 @@ export function createPrismaPoolConfig(databaseUrl: string): PoolConfig {
   const poolConfig: PoolConfig = { connectionString: databaseUrl, max: resolvePoolMax() };
   const ssl = resolveSslConfig(databaseUrl);
   if (ssl !== undefined) {
+    poolConfig.connectionString = removeSslModeParam(databaseUrl);
     poolConfig.ssl = ssl;
   }
 
   return poolConfig;
+}
+
+function removeSslModeParam(databaseUrl: string): string {
+  let parsed: URL;
+  try {
+    parsed = new URL(databaseUrl);
+  } catch {
+    return databaseUrl;
+  }
+
+  parsed.searchParams.delete('sslmode');
+  return parsed.toString();
 }
 
 function resolveSslConfig(databaseUrl: string): PoolConfig['ssl'] | undefined {


### PR DESCRIPTION
## What changed
- Strip `sslmode` from the `pg` connection string whenever Drasil supplies an explicit `PoolConfig.ssl` object.
- Preserve non-SSL query params like Supabase `pgbouncer=true`.
- Add regression coverage for the Supabase pooler URL shape used in prod.

## Why
Prod task `drasil-prod:30` has `DATABASE_URL` on the Supabase pooler with `sslmode=require`, but startup logs still showed Prisma `P1011` / `TlsConnectionError`. `pg` parses SSL query params from `connectionString` and can override the explicit `ssl: { rejectUnauthorized: false }` object passed by our Prisma adapter configuration. Removing `sslmode` after resolving the intended SSL object keeps our explicit TLS behavior authoritative.

## Testing
- `npm test -- --runTestsByPath src/__tests__/unit/prisma.unit.test.ts`
- `npm run format:check`
- `npm run lint`
- `npm run build`
- `npm test`