### PR TITLE
Prompt for message report reasons

### DIFF
--- a/src/__tests__/unit/CommandHandler.unit.test.ts
+++ b/src/__tests__/unit/CommandHandler.unit.test.ts
@@ -618,7 +618,7 @@ describe('CommandHandler (unit)', () => {
     });
   });
 
-  it('handles Report Message context command when user-install reporting is enabled', async () => {
+  it('opens a Report Message modal when user-install reporting is enabled', async () => {
     process.env.DRASIL_USER_INSTALL_REPORTING_ENABLED = 'true';
     const handleMessageReport = jest.fn().mockResolvedValue(true);
     const { handler, securityActionService } = buildHandler({ handleMessageReport });
@@ -638,28 +638,23 @@ describe('CommandHandler (unit)', () => {
       deferReply: jest.fn().mockResolvedValue(undefined),
       editReply: jest.fn().mockResolvedValue(undefined),
       reply: jest.fn().mockResolvedValue(undefined),
+      showModal: jest.fn().mockResolvedValue(undefined),
     } as any;
 
     await handler.handleMessageContextMenuCommand(interaction);
 
-    expect(securityActionService.handleMessageReport).toHaveBeenCalledWith(
-      targetUser,
-      interaction.user,
-      {
-        messageId: 'message-1',
-        channelId: 'channel-1',
-        guildId: undefined,
-        content: 'suspicious DM',
-        interactionContext: InteractionContextType.PrivateChannel,
-      }
-    );
-    expect(interaction.editReply).toHaveBeenCalledWith({
-      content: 'Thank you for your report regarding <@user-2>. It has been submitted for review.',
-      allowedMentions: { parse: [] },
+    expect(securityActionService.handleMessageReport).not.toHaveBeenCalled();
+    expect(interaction.showModal).toHaveBeenCalledTimes(1);
+
+    const modalJson = (interaction.showModal as jest.Mock).mock.calls[0][0].toJSON();
+    expect(modalJson.custom_id).toBe('rmm:message-1:channel-1:user-2:0:2');
+    expect(modalJson.components[0].components[0]).toMatchObject({
+      custom_id: 'report_message_reason',
+      required: false,
     });
   });
 
-  it('rejects guild Report Message context command when report reasons are required', async () => {
+  it('requires the modal reason for guild Report Message when report reasons are required', async () => {
     process.env.DRASIL_USER_INSTALL_REPORTING_ENABLED = 'true';
     const handleMessageReport = jest.fn().mockResolvedValue(true);
     const getServerConfig = jest.fn().mockResolvedValue({
@@ -686,14 +681,20 @@ describe('CommandHandler (unit)', () => {
       deferReply: jest.fn().mockResolvedValue(undefined),
       editReply: jest.fn().mockResolvedValue(undefined),
       reply: jest.fn().mockResolvedValue(undefined),
+      showModal: jest.fn().mockResolvedValue(undefined),
     } as any;
 
     await handler.handleMessageContextMenuCommand(interaction);
 
     expect(getServerConfig).toHaveBeenCalledWith('guild-1');
     expect(securityActionService.handleMessageReport).not.toHaveBeenCalled();
-    expect(interaction.editReply).toHaveBeenCalledWith({
-      content: 'This server requires a report reason. Please use `/report` instead.',
+    expect(interaction.showModal).toHaveBeenCalledTimes(1);
+
+    const modalJson = (interaction.showModal as jest.Mock).mock.calls[0][0].toJSON();
+    expect(modalJson.custom_id).toBe('rmm:message-1:channel-1:user-2:guild-1:0');
+    expect(modalJson.components[0].components[0]).toMatchObject({
+      custom_id: 'report_message_reason',
+      required: true,
     });
   });
 

--- a/src/__tests__/unit/InteractionHandler.unit.test.ts
+++ b/src/__tests__/unit/InteractionHandler.unit.test.ts
@@ -777,6 +777,62 @@ describe('InteractionHandler (unit)', () => {
     });
   });
 
+  it('submits Report Message modal with optional reason', async () => {
+    const targetUser = { id: 'user-2', username: 'target' } as User;
+    (client as any).users = {
+      fetch: jest.fn().mockResolvedValue(targetUser),
+    };
+    (client as any).channels = {
+      fetch: jest.fn().mockResolvedValue({
+        messages: {
+          fetch: jest.fn().mockResolvedValue({ content: 'suspicious message' }),
+        },
+      }),
+    };
+
+    const handler = new InteractionHandler(
+      client,
+      notificationManager,
+      userModerationService,
+      securityActionService,
+      configService,
+      verificationEventRepository,
+      threadManager,
+      adminActionRepository
+    );
+
+    const interaction = {
+      customId: 'rmm:message-1:channel-1:user-2:guild-1:0',
+      guildId: 'guild-1',
+      user: { id: 'reporter-1' } as User,
+      fields: {
+        getTextInputValue: jest.fn(() => 'message report reason'),
+      },
+      deferReply: jest.fn().mockResolvedValue(undefined),
+      editReply: jest.fn().mockResolvedValue(undefined),
+      reply: jest.fn().mockResolvedValue(undefined),
+    } as unknown as ModalSubmitInteraction;
+
+    await handler.handleModalSubmit(interaction);
+
+    expect(securityActionService.handleMessageReport).toHaveBeenCalledWith(
+      targetUser,
+      interaction.user,
+      {
+        messageId: 'message-1',
+        channelId: 'channel-1',
+        guildId: 'guild-1',
+        content: 'suspicious message',
+        reason: 'message report reason',
+        interactionContext: 0,
+      }
+    );
+    expect(interaction.editReply).toHaveBeenCalledWith({
+      content: 'Thank you for your report regarding <@user-2>. It has been submitted for review.',
+      allowedMentions: { parse: [] },
+    });
+  });
+
   it('handles report modal submission with a modern username', async () => {
     const member = {
       ...buildMember('guild-1', '123456789012345678'),

--- a/src/__tests__/unit/SecurityActionService.unit.test.ts
+++ b/src/__tests__/unit/SecurityActionService.unit.test.ts
@@ -386,6 +386,56 @@ describe('SecurityActionService (unit)', () => {
     expect(userModerationService.restrictUser).not.toHaveBeenCalled();
   });
 
+  it('opens local message report cases even when the target has no stored member row', async () => {
+    const guildId = 'guild-local-untracked-message';
+    const userId = 'user-local-untracked-message';
+    const member = buildMember(guildId, userId);
+    await serverRepository.upsertByGuildId(guildId, {
+      settings: {
+        [USER_REPORT_EXTERNAL_RESPONSE_MODE_SETTING_KEY]: 'off',
+      },
+    });
+    const client = {
+      guilds: {
+        fetch: jest.fn().mockResolvedValue({
+          members: {
+            fetch: jest.fn().mockResolvedValue(member),
+          },
+        }),
+      },
+    } as unknown as Client;
+    const service = buildService(client);
+
+    await service.handleMessageReport(
+      { id: userId, username: 'target-user' } as User,
+      { id: 'reporter-local-message' } as User,
+      {
+        messageId: 'message-local',
+        channelId: 'channel-local',
+        guildId,
+        content: 'local suspicious message',
+        reason: 'reported from native context menu',
+      }
+    );
+
+    const detectionEvents = await detectionEventsRepository.findByServerAndUser(guildId, userId);
+    expect(detectionEvents).toHaveLength(1);
+    expect(detectionEvents[0].metadata).toMatchObject({
+      type: 'message_report',
+      reason: 'reported from native context menu',
+    });
+    const verificationEvents = await verificationEventRepository.findByUserAndServer(
+      userId,
+      guildId
+    );
+    expect(verificationEvents).toHaveLength(1);
+    expect(threadManager.createVerificationThread).toHaveBeenCalledWith(
+      member,
+      expect.objectContaining({ id: verificationEvents[0].id })
+    );
+    expect(userModerationService.restrictUser).not.toHaveBeenCalled();
+  });
+
   it('notifies opted-in servers for external message reports', async () => {
     const member = buildMember('guild-external-1', 'user-6');
     await serverRepository.upsertByGuildId('guild-external-1', {

--- a/src/controllers/CommandHandler.ts
+++ b/src/controllers/CommandHandler.ts
@@ -77,7 +77,6 @@ import {
   isUserReportExternalResponseMode,
   USER_REPORT_EXTERNAL_RESPONSE_MODE_SETTING_KEY,
   USER_REPORT_EXTERNAL_RESPONSE_MODES,
-  USER_REPORT_MESSAGE_CONTENT_MAX_LENGTH,
   USER_REPORT_REASON_MAX_LENGTH,
   USER_REPORT_REASON_REQUIRED_SETTING_KEY,
 } from '../utils/userReportSettings';
@@ -89,6 +88,8 @@ dotenv.config();
 const REPORT_USER_CONTEXT_COMMAND_NAME = 'Report User';
 const REPORT_MESSAGE_CONTEXT_COMMAND_NAME = 'Report Message';
 const USER_INSTALL_REPORTING_ENABLED_ENV = 'DRASIL_USER_INSTALL_REPORTING_ENABLED';
+const REPORT_MESSAGE_MODAL_PREFIX = 'rmm';
+const REPORT_MESSAGE_REASON_FIELD_ID = 'report_message_reason';
 
 function isUserInstallReportingEnabled(): boolean {
   return process.env[USER_INSTALL_REPORTING_ENABLED_ENV] === 'true';
@@ -822,18 +823,18 @@ export class CommandHandler implements ICommandHandler {
       return;
     }
 
-    await interaction.deferReply({ flags: MessageFlags.Ephemeral });
-
     const targetMessage = interaction.targetMessage;
     const targetUser = targetMessage.author;
     if (targetUser.id === interaction.user.id) {
-      await interaction.editReply({
+      await interaction.reply({
         content: 'You cannot report your own message.',
+        flags: MessageFlags.Ephemeral,
       });
       return;
     }
 
     const guildId = interaction.guildId ?? undefined;
+    let reasonRequired = false;
     if (guildId) {
       let reportSettings = getUserReportSettings();
       try {
@@ -843,33 +844,32 @@ export class CommandHandler implements ICommandHandler {
         console.error(`Failed to load report settings for guild ${guildId}:`, error);
       }
 
-      if (reportSettings.reasonRequired) {
-        await interaction.editReply({
-          content: 'This server requires a report reason. Please use `/report` instead.',
-        });
-        return;
-      }
+      reasonRequired = reportSettings.reasonRequired;
     }
 
-    try {
-      await this.securityActionService.handleMessageReport(targetUser, interaction.user, {
-        messageId: targetMessage.id,
-        channelId: interaction.channelId,
-        guildId,
-        content: targetMessage.content.slice(0, USER_REPORT_MESSAGE_CONTENT_MAX_LENGTH),
-        // discord.js may expose a missing interaction context as null; omit it in report metadata.
-        interactionContext: interaction.context ?? undefined,
-      });
-      await interaction.editReply({
-        content: `Thank you for your report regarding <@${targetUser.id}>. It has been submitted for review.`,
-        allowedMentions: { parse: [] },
-      });
-    } catch (error) {
-      console.error(`Failed to handle context message report for ${targetUser.id}:`, error);
-      await interaction.editReply({
-        content: 'An error occurred while submitting your report. Please try again later.',
-      });
-    }
+    const context = interaction.context ?? 'x';
+    const modal = new ModalBuilder()
+      .setCustomId(
+        [
+          REPORT_MESSAGE_MODAL_PREFIX,
+          targetMessage.id,
+          interaction.channelId,
+          targetUser.id,
+          guildId ?? '0',
+          context,
+        ].join(':')
+      )
+      .setTitle('Report Message');
+    const reasonInput = new TextInputBuilder()
+      .setCustomId(REPORT_MESSAGE_REASON_FIELD_ID)
+      .setLabel('Reason')
+      .setStyle(TextInputStyle.Paragraph)
+      .setPlaceholder('What happened? Include extra context if useful.')
+      .setMaxLength(USER_REPORT_REASON_MAX_LENGTH)
+      .setRequired(reasonRequired);
+
+    modal.addComponents(new ActionRowBuilder<TextInputBuilder>().addComponents(reasonInput));
+    await interaction.showModal(modal);
   }
 
   /**

--- a/src/controllers/CommandHandler.ts
+++ b/src/controllers/CommandHandler.ts
@@ -75,6 +75,8 @@ import {
 import {
   getUserReportSettings,
   isUserReportExternalResponseMode,
+  REPORT_MESSAGE_MODAL_PREFIX,
+  REPORT_MESSAGE_REASON_FIELD_ID,
   USER_REPORT_EXTERNAL_RESPONSE_MODE_SETTING_KEY,
   USER_REPORT_EXTERNAL_RESPONSE_MODES,
   USER_REPORT_REASON_MAX_LENGTH,
@@ -88,8 +90,6 @@ dotenv.config();
 const REPORT_USER_CONTEXT_COMMAND_NAME = 'Report User';
 const REPORT_MESSAGE_CONTEXT_COMMAND_NAME = 'Report Message';
 const USER_INSTALL_REPORTING_ENABLED_ENV = 'DRASIL_USER_INSTALL_REPORTING_ENABLED';
-const REPORT_MESSAGE_MODAL_PREFIX = 'rmm';
-const REPORT_MESSAGE_REASON_FIELD_ID = 'report_message_reason';
 
 function isUserInstallReportingEnabled(): boolean {
   return process.env[USER_INSTALL_REPORTING_ENABLED_ENV] === 'true';

--- a/src/controllers/InteractionHandler.ts
+++ b/src/controllers/InteractionHandler.ts
@@ -34,6 +34,8 @@ import { getDetectionResponseSettings } from '../utils/detectionResponseSettings
 import {
   DEFAULT_USER_REPORT_REASON_REQUIRED,
   getUserReportSettings,
+  REPORT_MESSAGE_MODAL_PREFIX,
+  REPORT_MESSAGE_REASON_FIELD_ID,
   USER_REPORT_MESSAGE_CONTENT_MAX_LENGTH,
   USER_REPORT_REASON_MAX_LENGTH,
 } from '../utils/userReportSettings';
@@ -50,8 +52,6 @@ dotenv.config();
 
 const OBSERVED_ACTION_MODAL_REASON_FIELD_ID = 'observed_ban_reason';
 const OBSERVED_BAN_DEFAULT_REASON = 'Banned from observed suspicious notification';
-const REPORT_MESSAGE_MODAL_PREFIX = 'rmm';
-const REPORT_MESSAGE_REASON_FIELD_ID = 'report_message_reason';
 
 type UserResolution =
   | { status: 'found'; userId: string }
@@ -521,8 +521,11 @@ export class InteractionHandler implements IInteractionHandler {
           }) as User
       );
       const message = await this.fetchReportMessage(channelId, messageId);
+      const contextNumber = Number(contextRaw);
       const interactionContext =
-        contextRaw === 'x' ? undefined : (Number(contextRaw) as InteractionContextType);
+        contextRaw === 'x' || Number.isNaN(contextNumber)
+          ? undefined
+          : (contextNumber as InteractionContextType);
 
       await this.securityActionService.handleMessageReport(targetUser, interaction.user, {
         messageId,

--- a/src/controllers/InteractionHandler.ts
+++ b/src/controllers/InteractionHandler.ts
@@ -10,6 +10,8 @@ import {
   TextInputBuilder, // Added
   TextInputStyle, // Added
   ActionRowBuilder, // Added
+  InteractionContextType,
+  User,
   // UserSelectMenuBuilder, // Removed - Cannot be used in Modals
   ModalSubmitInteraction, // Added
   // Interaction, // Removed - Unused
@@ -32,6 +34,7 @@ import { getDetectionResponseSettings } from '../utils/detectionResponseSettings
 import {
   DEFAULT_USER_REPORT_REASON_REQUIRED,
   getUserReportSettings,
+  USER_REPORT_MESSAGE_CONTENT_MAX_LENGTH,
   USER_REPORT_REASON_MAX_LENGTH,
 } from '../utils/userReportSettings';
 import {
@@ -47,6 +50,8 @@ dotenv.config();
 
 const OBSERVED_ACTION_MODAL_REASON_FIELD_ID = 'observed_ban_reason';
 const OBSERVED_BAN_DEFAULT_REASON = 'Banned from observed suspicious notification';
+const REPORT_MESSAGE_MODAL_PREFIX = 'rmm';
+const REPORT_MESSAGE_REASON_FIELD_ID = 'report_message_reason';
 
 type UserResolution =
   | { status: 'found'; userId: string }
@@ -466,6 +471,10 @@ export class InteractionHandler implements IInteractionHandler {
         await this.handleSetupVerificationModalSubmit(interaction);
         return;
       default:
+        if (interaction.customId.startsWith(`${REPORT_MESSAGE_MODAL_PREFIX}:`)) {
+          await this.handleReportMessageModalSubmit(interaction);
+          return;
+        }
         if (interaction.customId.startsWith('observed:ban_modal:')) {
           await this.handleObservedBanModalSubmit(interaction);
           return;
@@ -474,6 +483,79 @@ export class InteractionHandler implements IInteractionHandler {
           `[InteractionHandler] Ignoring unknown modal submission: ${interaction.customId}`
         );
     }
+  }
+
+  private async handleReportMessageModalSubmit(interaction: ModalSubmitInteraction): Promise<void> {
+    const [, messageId, channelId, targetUserId, guildIdRaw, contextRaw] =
+      interaction.customId.split(':');
+    if (!messageId || !channelId || !targetUserId || !guildIdRaw || !contextRaw) {
+      await interaction.reply({
+        content: 'This report form is invalid. Please try reporting the message again.',
+        flags: MessageFlags.Ephemeral,
+      });
+      return;
+    }
+
+    const reason =
+      interaction.fields.getTextInputValue(REPORT_MESSAGE_REASON_FIELD_ID).trim() || undefined;
+    const guildId = guildIdRaw === '0' ? undefined : guildIdRaw;
+    if (guildId) {
+      const reasonRequired = await this.getUserReportReasonRequired(guildId);
+      if (reasonRequired && !reason) {
+        await interaction.reply({
+          content: 'Please include a reason for this report.',
+          flags: MessageFlags.Ephemeral,
+        });
+        return;
+      }
+    }
+
+    await interaction.deferReply({ flags: MessageFlags.Ephemeral });
+
+    try {
+      const targetUser = await this.client.users.fetch(targetUserId).catch(
+        () =>
+          ({
+            id: targetUserId,
+            username: targetUserId,
+          }) as User
+      );
+      const message = await this.fetchReportMessage(channelId, messageId);
+      const interactionContext =
+        contextRaw === 'x' ? undefined : (Number(contextRaw) as InteractionContextType);
+
+      await this.securityActionService.handleMessageReport(targetUser, interaction.user, {
+        messageId,
+        channelId,
+        guildId,
+        content: message?.content.slice(0, USER_REPORT_MESSAGE_CONTENT_MAX_LENGTH),
+        reason,
+        interactionContext,
+      });
+
+      await interaction.editReply({
+        content: `Thank you for your report regarding <@${targetUserId}>. It has been submitted for review.`,
+        allowedMentions: { parse: [] },
+      });
+    } catch (error) {
+      console.error(`Failed to handle message report modal for ${targetUserId}:`, error);
+      await interaction.editReply({
+        content: 'An error occurred while submitting your report. Please try again later.',
+      });
+    }
+  }
+
+  private async fetchReportMessage(
+    channelId: string,
+    messageId: string
+  ): Promise<{ content: string } | null> {
+    const channel = await this.client.channels.fetch(channelId).catch(() => null);
+    if (!channel || !('messages' in channel)) {
+      return null;
+    }
+
+    const message = await channel.messages.fetch(messageId).catch(() => null);
+    return typeof message?.content === 'string' ? { content: message.content } : null;
   }
 
   private async handleReportUserModalSubmit(interaction: ModalSubmitInteraction): Promise<void> {

--- a/src/services/SecurityActionService.ts
+++ b/src/services/SecurityActionService.ts
@@ -120,6 +120,7 @@ export interface MessageReportContext {
   channelId?: string;
   guildId?: string;
   content?: string;
+  reason?: string;
   interactionContext?: InteractionContextType;
 }
 
@@ -707,7 +708,8 @@ export class SecurityActionService implements ISecurityActionService {
     try {
       await this.userRepository.getOrCreateUser(targetUser.id, targetUser.username);
 
-      const reason = `Message reported by user ${reporter.id}.`;
+      const reasonText = report.reason ? `Reason: ${report.reason}` : 'No reason provided.';
+      const reason = `Message reported by user ${reporter.id}. ${reasonText}`;
       const isGuildContext =
         report.interactionContext === InteractionContextType.Guild || !!report.guildId;
       const metadata: Record<string, unknown> = {
@@ -720,6 +722,7 @@ export class SecurityActionService implements ISecurityActionService {
       if (report.guildId) metadata.guildId = report.guildId;
       if (report.channelId) metadata.channelId = report.channelId;
       if (report.content) metadata.content = report.content;
+      metadata.reason = report.reason ?? reasonText;
       if (report.interactionContext !== undefined) {
         metadata.interactionContext = report.interactionContext;
       }
@@ -755,8 +758,25 @@ export class SecurityActionService implements ISecurityActionService {
     report: MessageReportContext,
     globalReportId: string
   ): Promise<void> {
-    const memberships = await this.serverMemberRepository.findByUser(targetUser.id);
     const handledServerIds = new Set<string>();
+
+    if (report.guildId) {
+      const localServer = await this.serverRepository.findByGuildId(report.guildId);
+      if (localServer?.is_active) {
+        handledServerIds.add(report.guildId);
+        await this.processMessageReportForManagedServer(
+          report.guildId,
+          targetUser,
+          reporter,
+          report,
+          globalReportId,
+          true,
+          'open_case'
+        );
+      }
+    }
+
+    const memberships = await this.serverMemberRepository.findByUser(targetUser.id);
 
     for (const membership of memberships) {
       const serverId = membership.server_id;
@@ -777,43 +797,61 @@ export class SecurityActionService implements ISecurityActionService {
         continue;
       }
 
-      const member = await this.fetchManagedReportMember(serverId, targetUser.id);
-      if (!member) {
-        continue;
-      }
-
-      const serverDetectionEvent = await this.createManagedMessageReportDetection(
-        member,
+      await this.processMessageReportForManagedServer(
+        serverId,
+        targetUser,
         reporter,
         report,
         globalReportId,
-        isLocalReport
+        isLocalReport,
+        responseMode
       );
-      const detectionResult: DetectionResult = {
-        label: 'SUSPICIOUS',
-        confidence: 1.0,
-        reasons: [
-          isLocalReport
-            ? `Message reported in this server by user ${reporter.id}.`
-            : `External DM/GDM report submitted by user ${reporter.id}.`,
-        ],
-        triggerSource: DetectionType.USER_REPORT,
-        triggerContent: report.content || 'Message report',
-        detectionEventId: serverDetectionEvent.id,
-      };
+    }
+  }
 
-      if (responseMode === 'notify_only') {
-        try {
-          await this.notificationManager.upsertObservedDetectionNotification(
-            member,
-            detectionResult
-          );
-        } catch (error) {
-          console.error(`Failed to process message report fan-out for guild ${serverId}:`, error);
-        }
-      } else {
-        await this.handleSuspiciousMember(member, detectionResult, undefined, false);
+  private async processMessageReportForManagedServer(
+    serverId: string,
+    targetUser: User | APIUser,
+    reporter: User | APIUser,
+    report: MessageReportContext,
+    globalReportId: string,
+    isLocalReport: boolean,
+    responseMode: 'notify_only' | 'open_case'
+  ): Promise<void> {
+    const member = await this.fetchManagedReportMember(serverId, targetUser.id);
+    if (!member) {
+      return;
+    }
+
+    const serverDetectionEvent = await this.createManagedMessageReportDetection(
+      member,
+      reporter,
+      report,
+      globalReportId,
+      isLocalReport
+    );
+    const reasonText = report.reason ? ` Reason: ${report.reason}` : '';
+    const detectionResult: DetectionResult = {
+      label: 'SUSPICIOUS',
+      confidence: 1.0,
+      reasons: [
+        isLocalReport
+          ? `Message reported in this server by user ${reporter.id}.${reasonText}`
+          : `External DM/GDM report submitted by user ${reporter.id}.${reasonText}`,
+      ],
+      triggerSource: DetectionType.USER_REPORT,
+      triggerContent: report.reason || report.content || 'Message report',
+      detectionEventId: serverDetectionEvent.id,
+    };
+
+    if (responseMode === 'notify_only') {
+      try {
+        await this.notificationManager.upsertObservedDetectionNotification(member, detectionResult);
+      } catch (error) {
+        console.error(`Failed to process message report fan-out for guild ${serverId}:`, error);
       }
+    } else {
+      await this.handleSuspiciousMember(member, detectionResult, undefined, false);
     }
   }
 
@@ -842,6 +880,7 @@ export class SecurityActionService implements ISecurityActionService {
     if (report.guildId) metadata.sourceGuildId = report.guildId;
     if (report.channelId) metadata.sourceChannelId = report.channelId;
     if (report.content) metadata.content = report.content;
+    if (report.reason) metadata.reason = report.reason;
     if (report.interactionContext !== undefined) {
       metadata.interactionContext = report.interactionContext;
     }
@@ -853,8 +892,8 @@ export class SecurityActionService implements ISecurityActionService {
       confidence: 1.0,
       reasons: [
         isLocalReport
-          ? `Message reported in this server by user ${reporter.id}.`
-          : `External DM/GDM report submitted by user ${reporter.id}.`,
+          ? `Message reported in this server by user ${reporter.id}.${report.reason ? ` Reason: ${report.reason}` : ''}`
+          : `External DM/GDM report submitted by user ${reporter.id}.${report.reason ? ` Reason: ${report.reason}` : ''}`,
       ],
       message_id: isLocalReport ? report.messageId : undefined,
       channel_id: isLocalReport ? report.channelId : undefined,

--- a/src/services/SecurityActionService.ts
+++ b/src/services/SecurityActionService.ts
@@ -722,7 +722,7 @@ export class SecurityActionService implements ISecurityActionService {
       if (report.guildId) metadata.guildId = report.guildId;
       if (report.channelId) metadata.channelId = report.channelId;
       if (report.content) metadata.content = report.content;
-      metadata.reason = report.reason ?? reasonText;
+      if (report.reason) metadata.reason = report.reason;
       if (report.interactionContext !== undefined) {
         metadata.interactionContext = report.interactionContext;
       }

--- a/src/utils/userReportSettings.ts
+++ b/src/utils/userReportSettings.ts
@@ -6,6 +6,8 @@ export const DEFAULT_USER_REPORT_REASON_REQUIRED = false;
 export const DEFAULT_USER_REPORT_EXTERNAL_RESPONSE_MODE: UserReportExternalResponseMode = 'off';
 export const USER_REPORT_REASON_MAX_LENGTH = 900;
 export const USER_REPORT_MESSAGE_CONTENT_MAX_LENGTH = 1500;
+export const REPORT_MESSAGE_MODAL_PREFIX = 'rmm';
+export const REPORT_MESSAGE_REASON_FIELD_ID = 'report_message_reason';
 
 export const USER_REPORT_EXTERNAL_RESPONSE_MODES = ['off', 'notify_only', 'open_case'] as const;
 export type UserReportExternalResponseMode = (typeof USER_REPORT_EXTERNAL_RESPONSE_MODES)[number];


### PR DESCRIPTION
## What changed
- `Report Message` now opens a modal with a Reason field instead of submitting immediately.
- The Reason field is required when the server report setting requires reasons and optional otherwise.
- Message report modal submission carries the reason into report metadata and review-case context.
- Local guild message reports now open a review-only case from the source guild even when the target user does not already have a stored `server_members` row.

## Why
QA found that server-installed `Report Message` did not ask for a reason and did not produce a notification/case in the server. The modal fixes the missing reason UX, and the local guild fallback fixes the skipped local case path for users not already tracked in `server_members`.

## Testing
- `npm test -- --runTestsByPath src/__tests__/unit/CommandHandler.unit.test.ts src/__tests__/unit/InteractionHandler.unit.test.ts src/__tests__/unit/SecurityActionService.unit.test.ts`
- `npm run format:check`
- `npm run lint`
- `npm run build`
- `npm test`