### PR TITLE
Fix report review thread creation

### DIFF
--- a/src/__tests__/integration/SecurityActionService.integration.test.ts
+++ b/src/__tests__/integration/SecurityActionService.integration.test.ts
@@ -81,6 +81,9 @@ describeIntegration('SecurityActionService (integration)', () => {
       createVerificationThread: jest
         .fn()
         .mockResolvedValue({ id: 'thread-1', url: 'https://discord.com/channels/thread-1' } as any),
+      createReportReviewThread: jest
+        .fn()
+        .mockResolvedValue({ id: 'thread-1', url: 'https://discord.com/channels/thread-1' } as any),
       resolveVerificationThread: jest.fn().mockResolvedValue(true),
       reopenVerificationThread: jest.fn().mockResolvedValue(true),
     };

--- a/src/__tests__/integration/UserModerationService.integration.test.ts
+++ b/src/__tests__/integration/UserModerationService.integration.test.ts
@@ -75,6 +75,7 @@ describeIntegration('UserModerationService (integration)', () => {
     };
     threadManager = {
       createVerificationThread: jest.fn().mockResolvedValue({} as any),
+      createReportReviewThread: jest.fn().mockResolvedValue({} as any),
       resolveVerificationThread: jest.fn().mockResolvedValue(true),
       reopenVerificationThread: jest.fn().mockResolvedValue(true),
     };

--- a/src/__tests__/unit/InteractionHandler.unit.test.ts
+++ b/src/__tests__/unit/InteractionHandler.unit.test.ts
@@ -161,6 +161,9 @@ describe('InteractionHandler (unit)', () => {
       createVerificationThread: jest
         .fn()
         .mockResolvedValue({ url: 'https://discord.com/channels/thread-1' } as any),
+      createReportReviewThread: jest
+        .fn()
+        .mockResolvedValue({ url: 'https://discord.com/channels/thread-1' } as any),
       resolveVerificationThread: jest.fn(),
       reopenVerificationThread: jest.fn(),
     };

--- a/src/__tests__/unit/SecurityActionService.unit.test.ts
+++ b/src/__tests__/unit/SecurityActionService.unit.test.ts
@@ -273,6 +273,7 @@ describe('SecurityActionService (unit)', () => {
     expect(detectionEvents[0].metadata).toMatchObject({
       type: 'user_report',
       reporterId,
+      content: 'reported',
     });
 
     const verificationEvents = await verificationEventRepository.findByUserAndServer(

--- a/src/__tests__/unit/SecurityActionService.unit.test.ts
+++ b/src/__tests__/unit/SecurityActionService.unit.test.ts
@@ -1175,6 +1175,33 @@ describe('SecurityActionService (unit)', () => {
     });
   });
 
+  it('uses a verification thread when restricting an observed user report', async () => {
+    const guildId = 'guild-observed-report-restrict';
+    const userId = 'user-observed-report-restrict';
+    const moderator = { id: 'admin-observed' } as User;
+    const member = buildMember(guildId, userId);
+    const detectionEvent = await detectionEventsRepository.create({
+      server_id: guildId,
+      user_id: userId,
+      detection_type: DetectionType.USER_REPORT,
+      confidence: 1.0,
+      reasons: ['Reported by user reporter-observed. Reason: suspicious DM'],
+      detected_at: new Date(),
+      metadata: { type: 'user_report', reporterId: 'reporter-observed', content: 'suspicious DM' },
+    });
+
+    await buildService().restrictObservedDetection(member, detectionEvent.id, moderator);
+
+    expect(threadManager.createReportReviewThread).not.toHaveBeenCalled();
+    expect(threadManager.createVerificationThread).toHaveBeenCalled();
+    expect(userModerationService.restrictUser).toHaveBeenCalledWith(member);
+    expect(notificationManager.markObservedDetectionActionTaken).toHaveBeenCalledWith(
+      detectionEvent.id,
+      'restricted this user',
+      moderator
+    );
+  });
+
   it('keeps an observed restrict claim when audit fails after restricting', async () => {
     const guildId = 'guild-observed-restrict-audit-fails';
     const userId = 'user-observed-restrict-audit-fails';

--- a/src/__tests__/unit/SecurityActionService.unit.test.ts
+++ b/src/__tests__/unit/SecurityActionService.unit.test.ts
@@ -69,6 +69,9 @@ describe('SecurityActionService (unit)', () => {
       createVerificationThread: jest
         .fn()
         .mockResolvedValue({ id: 'thread-1', url: 'https://discord.com/channels/thread-1' } as any),
+      createReportReviewThread: jest
+        .fn()
+        .mockResolvedValue({ id: 'thread-1', url: 'https://discord.com/channels/thread-1' } as any),
       resolveVerificationThread: jest.fn().mockResolvedValue(true),
       reopenVerificationThread: jest.fn().mockResolvedValue(true),
     };
@@ -279,7 +282,16 @@ describe('SecurityActionService (unit)', () => {
     expect(verificationEvents).toHaveLength(1);
     expect(verificationEvents[0].status).toBe(VerificationStatus.PENDING);
     expect(userModerationService.restrictUser).not.toHaveBeenCalled();
-    expect(threadManager.createVerificationThread).toHaveBeenCalled();
+    expect(threadManager.createVerificationThread).not.toHaveBeenCalled();
+    expect(threadManager.createReportReviewThread).toHaveBeenCalledWith(
+      member,
+      expect.objectContaining({ id: verificationEvents[0].id }),
+      expect.objectContaining({
+        triggerSource: DetectionType.USER_REPORT,
+        triggerContent: 'reported',
+      }),
+      undefined
+    );
   });
 
   it('records a user-installed message report without opening a server case', async () => {
@@ -379,9 +391,15 @@ describe('SecurityActionService (unit)', () => {
     );
     expect(verificationEvents).toHaveLength(1);
     expect(verificationEvents[0].status).toBe(VerificationStatus.PENDING);
-    expect(threadManager.createVerificationThread).toHaveBeenCalledWith(
+    expect(threadManager.createVerificationThread).not.toHaveBeenCalled();
+    expect(threadManager.createReportReviewThread).toHaveBeenCalledWith(
       member,
-      expect.objectContaining({ id: verificationEvents[0].id })
+      expect.objectContaining({ id: verificationEvents[0].id }),
+      expect.objectContaining({
+        triggerSource: DetectionType.USER_REPORT,
+        triggerContent: 'local suspicious message',
+      }),
+      undefined
     );
     expect(userModerationService.restrictUser).not.toHaveBeenCalled();
   });
@@ -429,9 +447,15 @@ describe('SecurityActionService (unit)', () => {
       guildId
     );
     expect(verificationEvents).toHaveLength(1);
-    expect(threadManager.createVerificationThread).toHaveBeenCalledWith(
+    expect(threadManager.createVerificationThread).not.toHaveBeenCalled();
+    expect(threadManager.createReportReviewThread).toHaveBeenCalledWith(
       member,
-      expect.objectContaining({ id: verificationEvents[0].id })
+      expect.objectContaining({ id: verificationEvents[0].id }),
+      expect.objectContaining({
+        triggerSource: DetectionType.USER_REPORT,
+        triggerContent: 'reported from native context menu',
+      }),
+      undefined
     );
     expect(userModerationService.restrictUser).not.toHaveBeenCalled();
   });
@@ -511,9 +535,15 @@ describe('SecurityActionService (unit)', () => {
     );
     expect(verificationEvents).toHaveLength(1);
     expect(verificationEvents[0].status).toBe(VerificationStatus.PENDING);
-    expect(threadManager.createVerificationThread).toHaveBeenCalledWith(
+    expect(threadManager.createVerificationThread).not.toHaveBeenCalled();
+    expect(threadManager.createReportReviewThread).toHaveBeenCalledWith(
       member,
-      expect.objectContaining({ id: verificationEvents[0].id })
+      expect.objectContaining({ id: verificationEvents[0].id }),
+      expect.objectContaining({
+        triggerSource: DetectionType.USER_REPORT,
+        triggerContent: 'external suspicious DM',
+      }),
+      undefined
     );
     expect(userModerationService.restrictUser).not.toHaveBeenCalled();
   });
@@ -604,7 +634,7 @@ describe('SecurityActionService (unit)', () => {
         }),
       },
     } as unknown as Client;
-    threadManager.createVerificationThread.mockRejectedValueOnce(new Error('thread unavailable'));
+    threadManager.createReportReviewThread.mockRejectedValueOnce(new Error('thread unavailable'));
     const consoleError = jest.spyOn(console, 'error').mockImplementation(() => undefined);
     const service = buildService(client);
 
@@ -822,7 +852,8 @@ describe('SecurityActionService (unit)', () => {
       VerificationStatus.VERIFIED,
     ]);
     expect(userModerationService.restrictUser).not.toHaveBeenCalled();
-    expect(threadManager.createVerificationThread).toHaveBeenCalledTimes(1);
+    expect(threadManager.createVerificationThread).not.toHaveBeenCalled();
+    expect(threadManager.createReportReviewThread).toHaveBeenCalledTimes(1);
   });
 
   it('opens a new pending case when a manual flag follows a resolved case', async () => {

--- a/src/__tests__/unit/SecurityActionService.unit.test.ts
+++ b/src/__tests__/unit/SecurityActionService.unit.test.ts
@@ -10,7 +10,11 @@ import {
   InMemoryServerRepository,
 } from '../fakes/inMemoryRepositories';
 import { INotificationManager } from '../../services/NotificationManager';
-import { IThreadManager } from '../../services/ThreadManager';
+import {
+  IThreadManager,
+  REPORT_REVIEW_THREAD_TYPE,
+  VERIFICATION_THREAD_TYPE_METADATA_KEY,
+} from '../../services/ThreadManager';
 import { IUserModerationService } from '../../services/UserModerationService';
 import { IAdminActionService } from '../../services/AdminActionService';
 import { USER_REPORT_EXTERNAL_RESPONSE_MODE_SETTING_KEY } from '../../utils/userReportSettings';
@@ -1202,6 +1206,38 @@ describe('SecurityActionService (unit)', () => {
     );
   });
 
+  it('upgrades an existing report review thread when restricting a user report', async () => {
+    const guildId = 'guild-observed-existing-report-restrict';
+    const userId = 'user-observed-existing-report-restrict';
+    const moderator = { id: 'admin-observed' } as User;
+    const reporter = { id: 'reporter-observed' } as User;
+    const member = buildMember(guildId, userId);
+    threadManager.createReportReviewThread.mockImplementationOnce(async (_member, event) => {
+      await verificationEventRepository.update(event.id, {
+        thread_id: 'review-thread-1',
+        metadata: {
+          [VERIFICATION_THREAD_TYPE_METADATA_KEY]: REPORT_REVIEW_THREAD_TYPE,
+        },
+      });
+      return { id: 'review-thread-1' } as any;
+    });
+    const service = buildService();
+
+    await service.handleUserReport(member, reporter, 'suspicious DM');
+    const detectionEvents = await detectionEventsRepository.findByServerAndUser(guildId, userId);
+    const reportDetection = detectionEvents.find(
+      (event) => event.detection_type === DetectionType.USER_REPORT
+    );
+    threadManager.createReportReviewThread.mockClear();
+    threadManager.createVerificationThread.mockClear();
+
+    await service.restrictObservedDetection(member, reportDetection!.id, moderator);
+
+    expect(threadManager.createReportReviewThread).not.toHaveBeenCalled();
+    expect(threadManager.createVerificationThread).toHaveBeenCalled();
+    expect(userModerationService.restrictUser).toHaveBeenCalledWith(member);
+  });
+
   it('uses a verification thread when banning an observed user report', async () => {
     const guildId = 'guild-observed-report-ban';
     const userId = 'user-observed-report-ban';
@@ -1236,6 +1272,43 @@ describe('SecurityActionService (unit)', () => {
       detectionEvent.id,
       'banned this user',
       moderator
+    );
+  });
+
+  it('upgrades an existing report review thread when banning a user report', async () => {
+    const guildId = 'guild-observed-existing-report-ban';
+    const userId = 'user-observed-existing-report-ban';
+    const moderator = { id: 'admin-observed' } as User;
+    const reporter = { id: 'reporter-observed' } as User;
+    const member = buildMember(guildId, userId);
+    threadManager.createReportReviewThread.mockImplementationOnce(async (_member, event) => {
+      await verificationEventRepository.update(event.id, {
+        thread_id: 'review-thread-1',
+        metadata: {
+          [VERIFICATION_THREAD_TYPE_METADATA_KEY]: REPORT_REVIEW_THREAD_TYPE,
+        },
+      });
+      return { id: 'review-thread-1' } as any;
+    });
+    const service = buildService();
+
+    await service.handleUserReport(member, reporter, 'suspicious DM');
+    const detectionEvents = await detectionEventsRepository.findByServerAndUser(guildId, userId);
+    const reportDetection = detectionEvents.find(
+      (event) => event.detection_type === DetectionType.USER_REPORT
+    );
+    threadManager.createReportReviewThread.mockClear();
+    threadManager.createVerificationThread.mockClear();
+
+    await service.banObservedDetection(member, reportDetection!.id, moderator, 'Confirmed scam');
+
+    expect(threadManager.createReportReviewThread).not.toHaveBeenCalled();
+    expect(threadManager.createVerificationThread).toHaveBeenCalled();
+    expect(userModerationService.banUser).toHaveBeenCalledWith(
+      member,
+      'Confirmed scam',
+      moderator,
+      reportDetection!.id
     );
   });
 

--- a/src/__tests__/unit/SecurityActionService.unit.test.ts
+++ b/src/__tests__/unit/SecurityActionService.unit.test.ts
@@ -1202,6 +1202,43 @@ describe('SecurityActionService (unit)', () => {
     );
   });
 
+  it('uses a verification thread when banning an observed user report', async () => {
+    const guildId = 'guild-observed-report-ban';
+    const userId = 'user-observed-report-ban';
+    const moderator = { id: 'admin-observed' } as User;
+    const member = buildMember(guildId, userId);
+    const detectionEvent = await detectionEventsRepository.create({
+      server_id: guildId,
+      user_id: userId,
+      detection_type: DetectionType.USER_REPORT,
+      confidence: 1.0,
+      reasons: ['Reported by user reporter-observed. Reason: suspicious DM'],
+      detected_at: new Date(),
+      metadata: { type: 'user_report', reporterId: 'reporter-observed', content: 'suspicious DM' },
+    });
+
+    await buildService().banObservedDetection(
+      member,
+      detectionEvent.id,
+      moderator,
+      'Confirmed scam'
+    );
+
+    expect(threadManager.createReportReviewThread).not.toHaveBeenCalled();
+    expect(threadManager.createVerificationThread).toHaveBeenCalled();
+    expect(userModerationService.banUser).toHaveBeenCalledWith(
+      member,
+      'Confirmed scam',
+      moderator,
+      detectionEvent.id
+    );
+    expect(notificationManager.markObservedDetectionActionTaken).toHaveBeenCalledWith(
+      detectionEvent.id,
+      'banned this user',
+      moderator
+    );
+  });
+
   it('keeps an observed restrict claim when audit fails after restricting', async () => {
     const guildId = 'guild-observed-restrict-audit-fails';
     const userId = 'user-observed-restrict-audit-fails';

--- a/src/__tests__/unit/SecurityActionService.unit.test.ts
+++ b/src/__tests__/unit/SecurityActionService.unit.test.ts
@@ -930,6 +930,41 @@ describe('SecurityActionService (unit)', () => {
     );
   });
 
+  it('recreates missing threads for observed user reports as moderator-only review threads', async () => {
+    const guildId = 'guild-observed-report-open';
+    const userId = 'user-observed-report-open';
+    const moderator = { id: 'admin-observed' } as User;
+    const member = buildMember(guildId, userId);
+    const detectionEvent = await detectionEventsRepository.create({
+      server_id: guildId,
+      user_id: userId,
+      detection_type: DetectionType.USER_REPORT,
+      confidence: 1.0,
+      reasons: ['Reported by user reporter-observed. Reason: suspicious DM'],
+      detected_at: new Date(),
+      metadata: { type: 'user_report', reporterId: 'reporter-observed', content: 'suspicious DM' },
+    });
+    const existingCase = await verificationEventRepository.createFromDetection(
+      detectionEvent.id,
+      guildId,
+      userId,
+      VerificationStatus.PENDING
+    );
+
+    await buildService().openObservedDetectionCase(member, detectionEvent.id, moderator);
+
+    expect(threadManager.createVerificationThread).not.toHaveBeenCalled();
+    expect(threadManager.createReportReviewThread).toHaveBeenCalledWith(
+      member,
+      expect.objectContaining({ id: existingCase.id }),
+      expect.objectContaining({
+        triggerSource: DetectionType.USER_REPORT,
+        triggerContent: 'suspicious DM',
+      }),
+      undefined
+    );
+  });
+
   it('does not action an already handled observed detection', async () => {
     const guildId = 'guild-observed-actioned';
     const userId = 'user-observed-actioned';

--- a/src/__tests__/unit/ThreadManager.unit.test.ts
+++ b/src/__tests__/unit/ThreadManager.unit.test.ts
@@ -1,5 +1,10 @@
 import { ChannelType, Guild, GuildMember, ThreadChannel, User } from 'discord.js';
-import { ThreadManager } from '../../services/ThreadManager';
+import {
+  REPORT_REVIEW_THREAD_TYPE,
+  ThreadManager,
+  VERIFICATION_THREAD_TYPE,
+  VERIFICATION_THREAD_TYPE_METADATA_KEY,
+} from '../../services/ThreadManager';
 import { IConfigService } from '../../config/ConfigService';
 import {
   InMemoryServerMemberRepository,
@@ -121,6 +126,9 @@ describe('ThreadManager (unit)', () => {
     expect(thread.setInvitable).toHaveBeenCalledWith(false, expect.any(String));
     expect(createdThread?.id).toBe('thread-1');
     expect(storedEvent?.thread_id).toBe('thread-1');
+    expect(storedEvent?.metadata).toMatchObject({
+      [VERIFICATION_THREAD_TYPE_METADATA_KEY]: VERIFICATION_THREAD_TYPE,
+    });
     expect(thread.members.add).toHaveBeenCalledWith(member.id);
     expect(thread.send).toHaveBeenCalledWith({
       content: renderVerificationPromptTemplate(DEFAULT_VERIFICATION_PROMPT_TEMPLATE, {
@@ -209,6 +217,9 @@ describe('ThreadManager (unit)', () => {
     );
     expect(createdThread?.id).toBe('thread-1');
     expect(storedEvent?.thread_id).toBe('thread-1');
+    expect(storedEvent?.metadata).toMatchObject({
+      [VERIFICATION_THREAD_TYPE_METADATA_KEY]: REPORT_REVIEW_THREAD_TYPE,
+    });
     expect(thread.members.add).not.toHaveBeenCalled();
     expect(thread.setInvitable).toHaveBeenCalledWith(false, expect.any(String));
     expect(thread.send).toHaveBeenCalledWith({

--- a/src/__tests__/unit/ThreadManager.unit.test.ts
+++ b/src/__tests__/unit/ThreadManager.unit.test.ts
@@ -7,7 +7,7 @@ import {
   InMemoryUserRepository,
   InMemoryVerificationEventRepository,
 } from '../fakes/inMemoryRepositories';
-import { VerificationEvent, VerificationStatus } from '../../repositories/types';
+import { DetectionType, VerificationEvent, VerificationStatus } from '../../repositories/types';
 import {
   DISCORD_MESSAGE_CONTENT_MAX_LENGTH,
   DEFAULT_VERIFICATION_PROMPT_TEMPLATE,
@@ -168,6 +168,54 @@ describe('ThreadManager (unit)', () => {
       allowedMentions: {
         parse: [],
         users: [member.id],
+        roles: [],
+        repliedUser: false,
+      },
+    });
+  });
+
+  it('creates a moderator-only report review thread without adding the reported user', async () => {
+    const manager = new ThreadManager(
+      {} as any,
+      configService,
+      verificationEventRepository,
+      userRepository,
+      serverRepository,
+      serverMemberRepository
+    );
+
+    const member = buildMember('guild-1', 'user-1');
+    const event = await verificationEventRepository.createFromDetection(
+      null,
+      'guild-1',
+      'user-1',
+      VerificationStatus.PENDING
+    );
+
+    const createdThread = await manager.createReportReviewThread(member, event, {
+      label: 'SUSPICIOUS',
+      confidence: 1.0,
+      reasons: ['Reported by user reporter-1. Reason: suspicious DM'],
+      triggerSource: DetectionType.USER_REPORT,
+      triggerContent: 'suspicious DM',
+    });
+    const storedEvent = await verificationEventRepository.findById(event.id);
+
+    expect(channel.threads.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'Report review: test-user',
+        type: ChannelType.PrivateThread,
+      })
+    );
+    expect(createdThread?.id).toBe('thread-1');
+    expect(storedEvent?.thread_id).toBe('thread-1');
+    expect(thread.members.add).not.toHaveBeenCalled();
+    expect(thread.setInvitable).toHaveBeenCalledWith(false, expect.any(String));
+    expect(thread.send).toHaveBeenCalledWith({
+      content: expect.stringContaining('No automatic restriction was applied.'),
+      allowedMentions: {
+        parse: [],
+        users: [],
         roles: [],
         repliedUser: false,
       },

--- a/src/__tests__/unit/UserModerationService.unit.test.ts
+++ b/src/__tests__/unit/UserModerationService.unit.test.ts
@@ -71,6 +71,7 @@ describe('UserModerationService (unit)', () => {
     };
     threadManager = {
       createVerificationThread: jest.fn().mockResolvedValue({} as any),
+      createReportReviewThread: jest.fn().mockResolvedValue({} as any),
       resolveVerificationThread: jest.fn().mockResolvedValue(true),
       reopenVerificationThread: jest.fn().mockResolvedValue(true),
     };

--- a/src/services/SecurityActionService.ts
+++ b/src/services/SecurityActionService.ts
@@ -483,8 +483,11 @@ export class SecurityActionService implements ISecurityActionService {
     detectionResult: DetectionResult,
     sourceMessage?: Message,
     restrictUser = true,
-    useReportReviewThread = this.shouldUseReportReviewThread(restrictUser, detectionResult)
+    useReportReviewThread?: boolean
   ): Promise<boolean> {
+    const shouldUseReviewThread =
+      useReportReviewThread ?? this.shouldUseReportReviewThread(restrictUser, detectionResult);
+
     // Fail fast: we don't attempt retries or compensation yet.
     // TODO: Add retries/idempotency and partial failure handling if needed later.
     await this.ensureEntitiesExist(
@@ -582,7 +585,7 @@ export class SecurityActionService implements ISecurityActionService {
       member,
       newVerificationEvent,
       detectionResult,
-      useReportReviewThread,
+      shouldUseReviewThread,
       sourceMessage
     );
 

--- a/src/services/SecurityActionService.ts
+++ b/src/services/SecurityActionService.ts
@@ -547,7 +547,11 @@ export class SecurityActionService implements ISecurityActionService {
           )
         : await this.threadManager.createVerificationThread(member, newVerificationEvent);
     if (!thread) {
-      throw new Error(`Failed to create verification thread for ${member.user.tag}`);
+      const threadKind =
+        !restrictUser && detectionResult.triggerSource === DetectionType.USER_REPORT
+          ? 'report review thread'
+          : 'verification thread';
+      throw new Error(`Failed to create ${threadKind} for ${member.user.tag}`);
     }
 
     await this.upsertNotification(member, detectionResult, newVerificationEvent, sourceMessage);

--- a/src/services/SecurityActionService.ts
+++ b/src/services/SecurityActionService.ts
@@ -297,6 +297,36 @@ export class SecurityActionService implements ISecurityActionService {
     };
   }
 
+  private shouldUseReportReviewThread(
+    restrictUser: boolean,
+    detectionResult: DetectionResult
+  ): boolean {
+    return !restrictUser && detectionResult.triggerSource === DetectionType.USER_REPORT;
+  }
+
+  private async createCaseThread(
+    member: GuildMember,
+    verificationEvent: VerificationEvent,
+    detectionResult: DetectionResult,
+    restrictUser: boolean,
+    sourceMessage?: Message
+  ): Promise<void> {
+    const useReportReviewThread = this.shouldUseReportReviewThread(restrictUser, detectionResult);
+    const thread = useReportReviewThread
+      ? await this.threadManager.createReportReviewThread(
+          member,
+          verificationEvent,
+          detectionResult,
+          sourceMessage
+        )
+      : await this.threadManager.createVerificationThread(member, verificationEvent);
+
+    if (!thread) {
+      const threadKind = useReportReviewThread ? 'report review thread' : 'verification thread';
+      throw new Error(`Failed to create ${threadKind} for ${member.user.tag}`);
+    }
+  }
+
   private async getObservedDetectionForMember(
     member: GuildMember,
     detectionEventId: string
@@ -335,10 +365,7 @@ export class SecurityActionService implements ISecurityActionService {
     }
 
     if (!verificationEvent.thread_id) {
-      const thread = await this.threadManager.createVerificationThread(member, verificationEvent);
-      if (!thread) {
-        throw new Error(`Failed to create verification thread for ${member.user.tag}`);
-      }
+      await this.createCaseThread(member, verificationEvent, detectionResult, false);
       await this.upsertNotification(member, detectionResult, verificationEvent);
     }
 
@@ -537,22 +564,13 @@ export class SecurityActionService implements ISecurityActionService {
       });
     }
 
-    const thread =
-      !restrictUser && detectionResult.triggerSource === DetectionType.USER_REPORT
-        ? await this.threadManager.createReportReviewThread(
-            member,
-            newVerificationEvent,
-            detectionResult,
-            sourceMessage
-          )
-        : await this.threadManager.createVerificationThread(member, newVerificationEvent);
-    if (!thread) {
-      const threadKind =
-        !restrictUser && detectionResult.triggerSource === DetectionType.USER_REPORT
-          ? 'report review thread'
-          : 'verification thread';
-      throw new Error(`Failed to create ${threadKind} for ${member.user.tag}`);
-    }
+    await this.createCaseThread(
+      member,
+      newVerificationEvent,
+      detectionResult,
+      restrictUser,
+      sourceMessage
+    );
 
     await this.upsertNotification(member, detectionResult, newVerificationEvent, sourceMessage);
 

--- a/src/services/SecurityActionService.ts
+++ b/src/services/SecurityActionService.ts
@@ -15,7 +15,11 @@ import {
 import { IVerificationEventRepository } from '../repositories/VerificationEventRepository';
 import { IServerRepository } from '../repositories/ServerRepository';
 import { IUserRepository } from '../repositories/UserRepository';
-import { IThreadManager } from './ThreadManager';
+import {
+  IThreadManager,
+  REPORT_REVIEW_THREAD_TYPE,
+  VERIFICATION_THREAD_TYPE_METADATA_KEY,
+} from './ThreadManager';
 import { IUserModerationService } from './UserModerationService';
 import { IAdminActionService } from './AdminActionService';
 import { getUserReportSettings } from '../utils/userReportSettings';
@@ -304,6 +308,17 @@ export class SecurityActionService implements ISecurityActionService {
     return !restrictUser && detectionResult.triggerSource === DetectionType.USER_REPORT;
   }
 
+  private hasReportReviewThread(verificationEvent: VerificationEvent): boolean {
+    const metadata =
+      verificationEvent.metadata &&
+      typeof verificationEvent.metadata === 'object' &&
+      !Array.isArray(verificationEvent.metadata)
+        ? verificationEvent.metadata
+        : {};
+
+    return metadata[VERIFICATION_THREAD_TYPE_METADATA_KEY] === REPORT_REVIEW_THREAD_TYPE;
+  }
+
   private async createCaseThread(
     member: GuildMember,
     verificationEvent: VerificationEvent,
@@ -372,7 +387,10 @@ export class SecurityActionService implements ISecurityActionService {
       throw new Error(`Failed to create or find pending case for ${member.user.tag}`);
     }
 
-    if (!verificationEvent.thread_id) {
+    if (
+      !verificationEvent.thread_id ||
+      (!shouldUseReviewThread && this.hasReportReviewThread(verificationEvent))
+    ) {
       await this.createCaseThread(
         member,
         verificationEvent,

--- a/src/services/SecurityActionService.ts
+++ b/src/services/SecurityActionService.ts
@@ -308,10 +308,9 @@ export class SecurityActionService implements ISecurityActionService {
     member: GuildMember,
     verificationEvent: VerificationEvent,
     detectionResult: DetectionResult,
-    restrictUser: boolean,
+    useReportReviewThread: boolean,
     sourceMessage?: Message
   ): Promise<void> {
-    const useReportReviewThread = this.shouldUseReportReviewThread(restrictUser, detectionResult);
     const thread = useReportReviewThread
       ? await this.threadManager.createReportReviewThread(
           member,
@@ -351,10 +350,19 @@ export class SecurityActionService implements ISecurityActionService {
 
   private async ensureObservedCase(
     member: GuildMember,
-    detectionEvent: DetectionEvent
+    detectionEvent: DetectionEvent,
+    useReportReviewThread?: boolean
   ): Promise<VerificationEvent> {
     const detectionResult = this.createDetectionResultFromEvent(detectionEvent);
-    await this.handleSuspiciousMember(member, detectionResult, undefined, false);
+    const shouldUseReviewThread =
+      useReportReviewThread ?? this.shouldUseReportReviewThread(false, detectionResult);
+    await this.handleSuspiciousMember(
+      member,
+      detectionResult,
+      undefined,
+      false,
+      shouldUseReviewThread
+    );
 
     const verificationEvent = await this.verificationEventRepository.findActiveByUserAndServer(
       member.id,
@@ -365,7 +373,12 @@ export class SecurityActionService implements ISecurityActionService {
     }
 
     if (!verificationEvent.thread_id) {
-      await this.createCaseThread(member, verificationEvent, detectionResult, false);
+      await this.createCaseThread(
+        member,
+        verificationEvent,
+        detectionResult,
+        shouldUseReviewThread
+      );
       await this.upsertNotification(member, detectionResult, verificationEvent);
     }
 
@@ -469,7 +482,8 @@ export class SecurityActionService implements ISecurityActionService {
     member: GuildMember,
     detectionResult: DetectionResult,
     sourceMessage?: Message,
-    restrictUser = true
+    restrictUser = true,
+    useReportReviewThread = this.shouldUseReportReviewThread(restrictUser, detectionResult)
   ): Promise<boolean> {
     // Fail fast: we don't attempt retries or compensation yet.
     // TODO: Add retries/idempotency and partial failure handling if needed later.
@@ -568,7 +582,7 @@ export class SecurityActionService implements ISecurityActionService {
       member,
       newVerificationEvent,
       detectionResult,
-      restrictUser,
+      useReportReviewThread,
       sourceMessage
     );
 
@@ -1002,7 +1016,7 @@ export class SecurityActionService implements ISecurityActionService {
     }
     let actionApplied = false;
     try {
-      const verificationEvent = await this.ensureObservedCase(member, detectionEvent);
+      const verificationEvent = await this.ensureObservedCase(member, detectionEvent, false);
       await this.userModerationService.restrictUser(member);
       actionApplied = true;
       await this.recordObservedAction({
@@ -1051,7 +1065,7 @@ export class SecurityActionService implements ISecurityActionService {
     }
     let actionApplied = false;
     try {
-      await this.ensureObservedCase(member, detectionEvent);
+      await this.ensureObservedCase(member, detectionEvent, false);
       await this.userModerationService.banUser(member, reason, moderator, detectionEvent.id);
       actionApplied = true;
       await this.notificationManager.markObservedDetectionActionTaken(

--- a/src/services/SecurityActionService.ts
+++ b/src/services/SecurityActionService.ts
@@ -711,7 +711,12 @@ export class SecurityActionService implements ISecurityActionService {
         confidence: 1.0,
         reasons: [`Reported by user ${reporter.id}. ${reasonText}`],
         detected_at: new Date(),
-        metadata: { type: 'user_report', reporterId: reporter.id, reason: reason ?? reasonText },
+        metadata: {
+          type: 'user_report',
+          reporterId: reporter.id,
+          content: reason ?? 'User report',
+          reason: reason ?? reasonText,
+        },
       });
 
       const detectionResult: DetectionResult = {

--- a/src/services/SecurityActionService.ts
+++ b/src/services/SecurityActionService.ts
@@ -537,7 +537,15 @@ export class SecurityActionService implements ISecurityActionService {
       });
     }
 
-    const thread = await this.threadManager.createVerificationThread(member, newVerificationEvent);
+    const thread =
+      !restrictUser && detectionResult.triggerSource === DetectionType.USER_REPORT
+        ? await this.threadManager.createReportReviewThread(
+            member,
+            newVerificationEvent,
+            detectionResult,
+            sourceMessage
+          )
+        : await this.threadManager.createVerificationThread(member, newVerificationEvent);
     if (!thread) {
       throw new Error(`Failed to create verification thread for ${member.user.tag}`);
     }

--- a/src/services/ThreadManager.ts
+++ b/src/services/ThreadManager.ts
@@ -22,6 +22,10 @@ import {
 } from '../utils/verificationPromptTemplate';
 import { DetectionResult } from './DetectionOrchestrator';
 
+export const VERIFICATION_THREAD_TYPE_METADATA_KEY = 'thread_type';
+export const VERIFICATION_THREAD_TYPE = 'verification';
+export const REPORT_REVIEW_THREAD_TYPE = 'report_review';
+
 /**
  * Interface for NotificationManager service
  */
@@ -146,6 +150,26 @@ export class ThreadManager implements IThreadManager {
     return enforceDiscordMessageLimit(contentLines.join('\n'));
   }
 
+  private async storeThreadId(
+    verificationEvent: VerificationEvent,
+    threadId: string,
+    threadType: typeof VERIFICATION_THREAD_TYPE | typeof REPORT_REVIEW_THREAD_TYPE
+  ): Promise<void> {
+    const metadata =
+      verificationEvent.metadata &&
+      typeof verificationEvent.metadata === 'object' &&
+      !Array.isArray(verificationEvent.metadata)
+        ? { ...verificationEvent.metadata }
+        : {};
+
+    verificationEvent.thread_id = threadId;
+    verificationEvent.metadata = {
+      ...metadata,
+      [VERIFICATION_THREAD_TYPE_METADATA_KEY]: threadType,
+    };
+    await this.verificationEventRepository.update(verificationEvent.id, verificationEvent);
+  }
+
   /**
    * Creates a thread for a suspicious user in the verification channel
    * @param member The suspicious guild member
@@ -223,8 +247,7 @@ export class ThreadManager implements IThreadManager {
       });
 
       // Store thread in the database
-      verificationEvent.thread_id = thread.id;
-      await this.verificationEventRepository.update(verificationEvent.id, verificationEvent);
+      await this.storeThreadId(verificationEvent, thread.id, VERIFICATION_THREAD_TYPE);
 
       return thread;
     } catch (error) {
@@ -283,8 +306,7 @@ export class ThreadManager implements IThreadManager {
         },
       });
 
-      verificationEvent.thread_id = thread.id;
-      await this.verificationEventRepository.update(verificationEvent.id, verificationEvent);
+      await this.storeThreadId(verificationEvent, thread.id, REPORT_REVIEW_THREAD_TYPE);
 
       return thread;
     } catch (error) {

--- a/src/services/ThreadManager.ts
+++ b/src/services/ThreadManager.ts
@@ -2,6 +2,7 @@ import { injectable, inject } from 'inversify';
 import {
   Client,
   GuildMember,
+  Message,
   ThreadChannel,
   ThreadAutoArchiveDuration,
   ChannelType,
@@ -19,6 +20,7 @@ import {
   resolveVerificationPromptTemplate,
   VERIFICATION_PROMPT_TEMPLATE_SETTING_KEY,
 } from '../utils/verificationPromptTemplate';
+import { DetectionResult } from './DetectionOrchestrator';
 
 /**
  * Interface for NotificationManager service
@@ -32,6 +34,13 @@ export interface IThreadManager {
   createVerificationThread(
     member: GuildMember,
     verificationEvent: VerificationEvent
+  ): Promise<ThreadChannel | null>;
+
+  createReportReviewThread(
+    member: GuildMember,
+    verificationEvent: VerificationEvent,
+    detectionResult: DetectionResult,
+    sourceMessage?: Message
   ): Promise<ThreadChannel | null>;
 
   /**
@@ -109,6 +118,32 @@ export class ThreadManager implements IThreadManager {
         serverName: member.guild.name,
       });
     }
+  }
+
+  private buildReportReviewThreadMessage(
+    member: GuildMember,
+    detectionResult: DetectionResult,
+    sourceMessage?: Message
+  ): string {
+    const reasonLines = detectionResult.reasons.length
+      ? detectionResult.reasons.map((reason) => `- ${reason}`)
+      : ['- No reason provided.'];
+    const contentLines = [
+      `Review-only report opened for ${member.user.tag} (${member.id}).`,
+      'No automatic restriction was applied. Do not add the reported user unless moderators decide to engage them.',
+      '',
+      'Report details:',
+      ...reasonLines,
+    ];
+
+    if (detectionResult.triggerContent) {
+      contentLines.push('', `Context: ${detectionResult.triggerContent}`);
+    }
+    if (sourceMessage?.url) {
+      contentLines.push(`Source message: ${sourceMessage.url}`);
+    }
+
+    return enforceDiscordMessageLimit(contentLines.join('\n'));
   }
 
   /**
@@ -194,6 +229,66 @@ export class ThreadManager implements IThreadManager {
       return thread;
     } catch (error) {
       console.error('Failed to create verification thread:', error);
+      return null;
+    }
+  }
+
+  public async createReportReviewThread(
+    member: GuildMember,
+    verificationEvent: VerificationEvent,
+    detectionResult: DetectionResult,
+    sourceMessage?: Message
+  ): Promise<ThreadChannel | null> {
+    const channel =
+      (await this.configService.getVerificationChannel(member.guild.id)) ||
+      (await this.configService.getAdminChannel(member.guild.id));
+
+    if (!channel) {
+      console.error('No verification or admin channel ID configured');
+      return null;
+    }
+
+    try {
+      await this.serverRepository.getOrCreateServer(member.guild.id);
+      await this.userRepository.getOrCreateUser(member.id, member.user.username);
+      await this.serverMemberRepository.getOrCreateMember(
+        member.guild.id,
+        member.id,
+        member.joinedAt ?? undefined
+      );
+
+      const thread = await channel.threads.create({
+        name: `Report review: ${member.user.username}`,
+        autoArchiveDuration: ThreadAutoArchiveDuration.OneWeek,
+        reason: `Review-only report thread for user: ${member.user.tag}`,
+        type: ChannelType.PrivateThread,
+      });
+
+      try {
+        await thread.setInvitable(false, 'Keep report review thread moderator-only');
+      } catch (error) {
+        console.warn(
+          `Failed to set invitable=false for report review thread ${thread.id} (continuing):`,
+          error
+        );
+      }
+
+      await thread.send({
+        content: this.buildReportReviewThreadMessage(member, detectionResult, sourceMessage),
+        allowedMentions: {
+          parse: [],
+          users: [],
+          roles: [],
+          repliedUser: false,
+        },
+      });
+
+      verificationEvent.thread_id = thread.id;
+      await this.verificationEventRepository.update(verificationEvent.id, verificationEvent);
+
+      return thread;
+    } catch (error) {
+      console.error('Failed to create report review thread:', error);
       return null;
     }
   }


### PR DESCRIPTION
## Summary
- add a moderator-only report review thread path that does not add or mention the reported user
- route non-restricting USER_REPORT cases through the report review thread path
- update unit tests for user/message report cases and thread behavior

## Validation
- npm test -- --runTestsByPath src/__tests__/unit/ThreadManager.unit.test.ts src/__tests__/unit/SecurityActionService.unit.test.ts
- npm run format:check
- npm run build
- npm run lint
- npm test
- git diff --check