### PR TITLE
Use observed alerts for report-only intake

### DIFF
--- a/docs/deploy/discord.md
+++ b/docs/deploy/discord.md
@@ -58,7 +58,7 @@ Modes:
 
 - `off`: default. Store the global report signal only.
 - `notify_only`: post an observe-only notification to that server's observed/admin notification channel.
-- `open_case`: open a review-only pending case in that server without restricting the user.
+- `open_case`: post a moderator-facing alert with case actions in that server without restricting the user or creating a thread by default.
 
 External reports never apply automatic restrictions. Moderators must review and choose any action.
 

--- a/docs/deploy/discord.md
+++ b/docs/deploy/discord.md
@@ -57,8 +57,8 @@ Configure each server with:
 Modes:
 
 - `off`: default. Store the global report signal only.
-- `notify_only`: post an observe-only notification to that server's observed/admin notification channel.
-- `open_case`: post a moderator-facing alert with case actions in that server without restricting the user or creating a thread by default.
+- `notify_only`: post a moderator-facing observed alert to that server's observed/admin notification channel.
+- `open_case`: currently uses the same observed-alert surface as `notify_only`; the separate mode is retained for compatibility and future UX polish.
 
 External reports never apply automatic restrictions. Moderators must review and choose any action.
 

--- a/docs/future-features.md
+++ b/docs/future-features.md
@@ -29,3 +29,7 @@ Right now the message sent in the thread to verify the user is static - it'd be 
 
 This is a MONSTEROUSLY big feature, and shouldn't be worked on until everything else is airtight.
 Make a website for configuring the bot, verifying users, etc.
+
+## Report review UX polish
+
+Improve the report alert action labels and external-report reporter confirmation. See `docs/report-ux-journeys.md` for the persona journeys, tradeoffs, and proposed follow-up work.

--- a/docs/manual-qa.md
+++ b/docs/manual-qa.md
@@ -113,8 +113,12 @@ Prefer deterministic flows first. Use `/flaguser` instead of hoping heuristics t
 - Submit a report against the suspicious-user test account from the reporter test account.
 - Expected result:
   - detection event is created with `USER_REPORT`
-  - the same verification flow starts
-  - report details appear in the admin-facing context
+  - no restricted role is applied
+  - no verification thread is created by default
+  - an observed alert appears with report details and moderator action buttons
+  - `Dismiss...` supports dismiss, false positive, and undo
+  - `Restrict` creates a user-visible verification thread
+  - `Ban` bans and logs the action without creating a verification thread first
 
 ### 8. GPT verification-thread analysis flow
 

--- a/docs/report-ux-journeys.md
+++ b/docs/report-ux-journeys.md
@@ -72,8 +72,8 @@ Safest default. Reporter may not understand that no server acted on the report u
 
 1. Reporter submits a DM/GDM report.
 2. Drasil identifies managed servers where the reported user is known.
-3. Opted-in servers receive an observe-only notification.
-4. No case thread is created and no moderation action is applied.
+3. Opted-in servers receive a moderator-facing observed alert with the existing action buttons.
+4. No case thread is created by default, and no moderation action is applied automatically.
 
 Current UX result:
 Good low-commitment signal for moderators. It avoids case clutter but may be easy to miss if notifications are noisy.
@@ -82,12 +82,12 @@ Good low-commitment signal for moderators. It avoids case clutter but may be eas
 
 1. Reporter submits a DM/GDM report.
 2. Drasil identifies opted-in servers where the reported user is known.
-3. Each opted-in server gets a moderator-facing observed alert with case actions.
+3. Each opted-in server gets the same moderator-facing observed alert as `notify_only`.
 4. No case thread is created by default.
 5. No automatic restriction is applied.
 
 Current UX result:
-Strongest moderator signal for opted-in servers without fan-out thread clutter.
+Currently equivalent to `notify_only`; retained as a separate mode for compatibility and future UX polish.
 
 ### Moderator Escalates A Report Case
 
@@ -155,8 +155,8 @@ Target behavior:
 - Moderator opens case: create the existing moderator-only report review thread/workspace.
 - Moderator restricts: create a user-visible verification thread.
 - Moderator bans: ban and log the action, with no user-visible verification thread.
-- External `notify_only`: observe-only embed, no case thread.
-- External `open_case`: observed alert with case actions, no automatic thread.
+- External `notify_only`: observed alert with action buttons, no case thread.
+- External `open_case`: currently the same observed-alert behavior as `notify_only`, retained for compatibility and future UX polish.
 
 The key product rule should be: report triage needs context and buttons; restriction needs a user-visible conversation; moderator collaboration can use the existing report review thread when a moderator explicitly opens a case.
 

--- a/docs/report-ux-journeys.md
+++ b/docs/report-ux-journeys.md
@@ -1,0 +1,176 @@
+# Report UX Journeys
+
+This note evaluates Drasil's report UX after adding server-installed and user-installed reporting. It focuses on what each persona experiences, where the current implementation is intentionally conservative, and what a better long-term UX could look like.
+
+## Product Boundary
+
+Reports are human-submitted signals, not proof. A report can open moderator review, but it should not automatically restrict or ban a user unless a moderator or a separate configured detector takes that action.
+
+External reports from DMs or group DMs are even weaker signals because they cross server trust boundaries. They must remain opt-in per server and review-only.
+
+## Personas
+
+Reporter:
+The user who submits `/report`, `Report User`, or `Report Message`. They need fast submission, clear confirmation, and confidence that the report reached the right place.
+
+Reported user:
+The user being reported or flagged. They should not be notified for a report-only review. If moderators restrict or ban them through the case flow, they need a visible path to respond when the action is reversible.
+
+Moderator:
+The person triaging reports and detections. They need enough context to decide whether to ignore, watch, restrict, verify, or ban. They also need low-noise action controls.
+
+Server admin:
+The person configuring Drasil. They need safe defaults, clear opt-in boundaries, and predictable server-specific behavior.
+
+Bot operator:
+The maintainer watching deployments, logs, permissions, and Discord API failures. They need failure modes that do not leave users restricted without a visible path.
+
+## Current Journeys
+
+### Guild `/report`
+
+1. Reporter uses `/report` in a server and optionally provides a reason.
+2. Drasil creates a `USER_REPORT` detection event for that server.
+3. If the reported user already has an active case, Drasil links the report to that case and updates the case notification.
+4. Otherwise Drasil posts or updates a moderator-facing observed alert with action buttons.
+5. Reported user is not added, mentioned, restricted, or notified.
+6. Moderators decide whether to dismiss, mark false positive, open a case, restrict, ban, or inspect history.
+
+Current UX result:
+Good for privacy and low clutter. Reports start as triage alerts instead of creating a thread for every report.
+
+### Guild `Report User`
+
+1. Reporter right-clicks a user and chooses `Apps` -> `Report User`.
+2. If a reason is required, Drasil redirects the reporter to `/report` because user context-menu commands cannot collect options directly.
+3. Otherwise the flow matches guild `/report`.
+
+Current UX result:
+Fast when reasons are optional. Awkward but honest when reasons are required.
+
+### Server Message Report
+
+1. Reporter right-clicks a message in a server and chooses `Apps` -> `Report Message`.
+2. Drasil opens a modal for the reason.
+3. Drasil creates a server-local `USER_REPORT` detection event.
+4. If there is no active case for the reported user, Drasil posts or updates a moderator-facing observed alert.
+5. Reported user is not added, mentioned, restricted, or notified.
+
+Current UX result:
+The reporter gets a familiar Discord-native report flow. Moderators get preserved message context without automatic thread creation.
+
+### External DM/GDM Message Report, Server Mode `off`
+
+1. Reporter uses user-installed `Report Message` in a DM or group DM.
+2. Drasil stores the global report signal.
+3. No managed server receives a visible notification or case.
+
+Current UX result:
+Safest default. Reporter may not understand that no server acted on the report unless the confirmation copy is explicit.
+
+### External DM/GDM Message Report, Server Mode `notify_only`
+
+1. Reporter submits a DM/GDM report.
+2. Drasil identifies managed servers where the reported user is known.
+3. Opted-in servers receive an observe-only notification.
+4. No case thread is created and no moderation action is applied.
+
+Current UX result:
+Good low-commitment signal for moderators. It avoids case clutter but may be easy to miss if notifications are noisy.
+
+### External DM/GDM Message Report, Server Mode `open_case`
+
+1. Reporter submits a DM/GDM report.
+2. Drasil identifies opted-in servers where the reported user is known.
+3. Each opted-in server gets a moderator-facing observed alert with case actions.
+4. No case thread is created by default.
+5. No automatic restriction is applied.
+
+Current UX result:
+Strongest moderator signal for opted-in servers without fan-out thread clutter.
+
+### Moderator Escalates A Report Case
+
+1. Moderator reviews the report-only case.
+2. Moderator restricts or bans the reported user.
+3. If the moderator restricts, Drasil creates a user-visible verification thread before applying the restriction.
+4. If the moderator bans, Drasil bans and logs the action without creating a user-visible verification thread.
+
+Current UX result:
+This is the critical safety invariant. Report-only stays quiet; restriction creates a visible path; ban does not create unnecessary conversation space.
+
+## Previous Implementation Tradeoff
+
+The previous implementation created a moderator-only private thread for report-only cases. This was a low-risk implementation because it reused the existing `verification_events` case model and `thread_id` lifecycle.
+
+Benefits:
+
+- Preserves rich report context in a durable workspace.
+- Keeps report-only discussion away from the reported user.
+- Reuses existing moderator case patterns and action controls.
+- Avoids a larger refactor of notifications, buttons, and case state.
+
+Costs:
+
+- Creates a thread even when moderators only need a compact alert.
+- Makes `thread_id` ambiguous unless thread type is tracked.
+- Increases channel/thread clutter for low-quality reports.
+- Can make report-only cases feel heavier than observe-only suspicious activity.
+
+The `metadata.thread_type` distinction still exists as a safety fallback for cases that already have report review threads or for moderators who explicitly open a case workspace.
+
+## Embed-First, Lazy Thread
+
+Report-only intake starts as an observed alert instead of immediately opening a case thread. This matches the action model Drasil already has for observed detections.
+
+1. Report creates a `USER_REPORT` detection event.
+2. Drasil posts or updates a moderator-facing observed alert embed with report context and action buttons.
+3. No verification event or thread is created yet.
+4. Moderator can use the existing observed alert actions: `Open Case`, `Restrict`, `Ban`, `Dismiss...`, and `History`.
+5. `Dismiss...` keeps the existing flow: `Dismiss Alert`, `False Positive`, and undo.
+6. `Restrict` creates or reuses a case, restricts the user, and creates a user-visible verification thread.
+7. `Ban` bans and logs the action without creating a user-visible thread.
+8. `Open Case` is the deliberate path for moderators who want a case workspace without immediately restricting the user.
+
+Benefits:
+
+- Lower clutter for report-only review.
+- Aligns reports with observe-only suspicious activity UX.
+- Keeps thread creation tied to cases that need conversation.
+- Reuses existing observed alert dismissal, false-positive, undo, and history actions.
+
+Costs:
+
+- Report submissions would no longer immediately create a pending case, so any code or docs that assume user reports always create cases must be updated.
+- `Open Case` still needs a clear product meaning for reports: it means "create a moderator review workspace," not "notify the reported user."
+- The existing report review thread remains useful as the workspace for `Open Case`, but it should be deliberate instead of automatic on every report.
+
+## Recommendation
+
+Keep report-only intake on the existing observed alert UX. Do not introduce a new case model just for reports.
+
+Target behavior:
+
+- Report submission: moderator-facing observed alert embed with action buttons, no case/thread by default.
+- Moderator opens case: create the existing moderator-only report review thread/workspace.
+- Moderator restricts: create a user-visible verification thread.
+- Moderator bans: ban and log the action, with no user-visible verification thread.
+- External `notify_only`: observe-only embed, no case thread.
+- External `open_case`: observed alert with case actions, no automatic thread.
+
+The key product rule should be: report triage needs context and buttons; restriction needs a user-visible conversation; moderator collaboration can use the existing report review thread when a moderator explicitly opens a case.
+
+## Open Questions
+
+- Should external reports show which server(s) received the report in the reporter confirmation, or keep that intentionally opaque?
+- If the reporter is an admin in one or more servers that receive an external report, should the confirmation name those servers?
+- Should repeated reports update one embed, append a summary, or create separate case entries?
+- Should moderator-only review threads auto-archive when a case is closed or escalated?
+- Should `Open Case` be relabeled for report alerts, or is the existing label clear enough?
+
+## Follow-Up Work
+
+1. Consider whether `Open Case` should be relabeled for report alerts.
+2. Decide whether admin reporters should see which servers received an external report.
+3. Preserve the current thread-type upgrade behavior as a safety fallback for existing cases.
+4. Update manual QA to cover reporter confirmation, moderator alert actions, dismissal/false-positive undo, open case, restrict, and ban.

--- a/docs/test-cases.md
+++ b/docs/test-cases.md
@@ -9,10 +9,12 @@ For a real-server walkthrough, use `docs/manual-qa.md`.
 - New suspicious message after verification resolved: new verification event and new notification message.
 - Suspicious join: same flow as suspicious message.
 - Manual flag: creates a detection event with admin flag metadata and follows the same case flow.
-- User report: creates a detection event with `USER_REPORT` and follows the same case flow.
-- User report or manual flag while pending: records a new detection event but reuses the existing case.
+- User report without an active case: creates a detection event with `USER_REPORT` and posts an observed alert with moderator actions.
+- User report with an active case: records a new detection event and reuses the existing case.
+- Manual flag while pending: records a new detection event but reuses the existing case.
 - Repeated pending-case reports/flags link the new detection event to the reused case.
-- User report or manual flag after resolution: opens a new pending case.
+- User report after resolution: posts a new observed alert instead of reopening a case automatically.
+- Manual flag after resolution: opens a new pending case.
 - Verify button: restricted role removed, thread resolved, notification updated, admin action logged.
 - Ban button: member banned, verification status set to BANNED (if present), thread resolved, admin action logged.
 - Reopen button: verification returns to PENDING, thread reopened, user restricted again.
@@ -28,9 +30,10 @@ For a real-server walkthrough, use `docs/manual-qa.md`.
   - Updates the admin notification only.
 - `SecurityActionService.handleUserReport`
   - Creates `detection_event` with `detection_type = USER_REPORT` and reporter metadata.
+  - Posts an observed alert when no active case exists.
   - Reuses an existing pending `verification_event` instead of creating a duplicate case.
   - Links repeated reports to the reused pending `verification_event`.
-  - Opens a new pending `verification_event` after a previous case was resolved.
+  - Posts a new observed alert after a previous case was resolved.
 - `SecurityActionService.handleManualFlag`
   - Creates `detection_event` with admin flag metadata.
   - Reuses an existing pending `verification_event` instead of creating a duplicate case.

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -66,7 +66,15 @@ if one is set.
 
 1. A user submits the report modal.
 2. `SecurityActionService.handleUserReport` creates a `detection_event` with
-   `detection_type = USER_REPORT` and follows the same case flow as above.
+   `detection_type = USER_REPORT`.
+3. If the reported user already has an active case in the server, Drasil links
+   the report to that case and updates the case notification.
+4. Otherwise Drasil posts or updates an observed alert with moderator action
+   buttons. No verification event or thread is created until a moderator opens a
+   case or restricts the user.
+
+See `docs/report-ux-journeys.md` for the product-level user journeys and the
+recommended future direction for report-only cases.
 
 ## Admin verify or ban
 

--- a/src/__tests__/unit/SecurityActionService.unit.test.ts
+++ b/src/__tests__/unit/SecurityActionService.unit.test.ts
@@ -250,7 +250,7 @@ describe('SecurityActionService (unit)', () => {
     expect(notificationManager.upsertSuspiciousUserNotification).toHaveBeenCalledTimes(1);
   });
 
-  it('creates a review-only pending case for user report', async () => {
+  it('posts an observed alert for user report without opening a case', async () => {
     const guildId = 'guild-3';
     const userId = 'user-3';
     const reporterId = 'reporter-1';
@@ -284,18 +284,16 @@ describe('SecurityActionService (unit)', () => {
       userId,
       guildId
     );
-    expect(verificationEvents).toHaveLength(1);
-    expect(verificationEvents[0].status).toBe(VerificationStatus.PENDING);
+    expect(verificationEvents).toHaveLength(0);
     expect(userModerationService.restrictUser).not.toHaveBeenCalled();
     expect(threadManager.createVerificationThread).not.toHaveBeenCalled();
-    expect(threadManager.createReportReviewThread).toHaveBeenCalledWith(
+    expect(threadManager.createReportReviewThread).not.toHaveBeenCalled();
+    expect(notificationManager.upsertObservedDetectionNotification).toHaveBeenCalledWith(
       member,
-      expect.objectContaining({ id: verificationEvents[0].id }),
       expect.objectContaining({
         triggerSource: DetectionType.USER_REPORT,
         triggerContent: 'reported',
-      }),
-      undefined
+      })
     );
   });
 
@@ -333,7 +331,7 @@ describe('SecurityActionService (unit)', () => {
     expect(userModerationService.restrictUser).not.toHaveBeenCalled();
   });
 
-  it('opens review-only cases for message reports from the same guild', async () => {
+  it('posts observed alerts for message reports from the same guild', async () => {
     const guildId = 'guild-local-message';
     const userId = 'user-local-message';
     const member = buildMember(guildId, userId);
@@ -394,22 +392,20 @@ describe('SecurityActionService (unit)', () => {
       userId,
       guildId
     );
-    expect(verificationEvents).toHaveLength(1);
-    expect(verificationEvents[0].status).toBe(VerificationStatus.PENDING);
+    expect(verificationEvents).toHaveLength(0);
     expect(threadManager.createVerificationThread).not.toHaveBeenCalled();
-    expect(threadManager.createReportReviewThread).toHaveBeenCalledWith(
+    expect(threadManager.createReportReviewThread).not.toHaveBeenCalled();
+    expect(notificationManager.upsertObservedDetectionNotification).toHaveBeenCalledWith(
       member,
-      expect.objectContaining({ id: verificationEvents[0].id }),
       expect.objectContaining({
         triggerSource: DetectionType.USER_REPORT,
         triggerContent: 'local suspicious message',
-      }),
-      undefined
+      })
     );
     expect(userModerationService.restrictUser).not.toHaveBeenCalled();
   });
 
-  it('opens local message report cases even when the target has no stored member row', async () => {
+  it('posts local message report alerts even when the target has no stored member row', async () => {
     const guildId = 'guild-local-untracked-message';
     const userId = 'user-local-untracked-message';
     const member = buildMember(guildId, userId);
@@ -451,16 +447,15 @@ describe('SecurityActionService (unit)', () => {
       userId,
       guildId
     );
-    expect(verificationEvents).toHaveLength(1);
+    expect(verificationEvents).toHaveLength(0);
     expect(threadManager.createVerificationThread).not.toHaveBeenCalled();
-    expect(threadManager.createReportReviewThread).toHaveBeenCalledWith(
+    expect(threadManager.createReportReviewThread).not.toHaveBeenCalled();
+    expect(notificationManager.upsertObservedDetectionNotification).toHaveBeenCalledWith(
       member,
-      expect.objectContaining({ id: verificationEvents[0].id }),
       expect.objectContaining({
         triggerSource: DetectionType.USER_REPORT,
         triggerContent: 'reported from native context menu',
-      }),
-      undefined
+      })
     );
     expect(userModerationService.restrictUser).not.toHaveBeenCalled();
   });
@@ -505,7 +500,7 @@ describe('SecurityActionService (unit)', () => {
     expect(userModerationService.restrictUser).not.toHaveBeenCalled();
   });
 
-  it('opens review-only cases in opted-in servers for external message reports', async () => {
+  it('posts observed alerts in open-case opted-in servers for external message reports', async () => {
     const member = buildMember('guild-external-2', 'user-7');
     await serverRepository.upsertByGuildId('guild-external-2', {
       settings: {
@@ -538,17 +533,15 @@ describe('SecurityActionService (unit)', () => {
       'user-7',
       'guild-external-2'
     );
-    expect(verificationEvents).toHaveLength(1);
-    expect(verificationEvents[0].status).toBe(VerificationStatus.PENDING);
+    expect(verificationEvents).toHaveLength(0);
     expect(threadManager.createVerificationThread).not.toHaveBeenCalled();
-    expect(threadManager.createReportReviewThread).toHaveBeenCalledWith(
+    expect(threadManager.createReportReviewThread).not.toHaveBeenCalled();
+    expect(notificationManager.upsertObservedDetectionNotification).toHaveBeenCalledWith(
       member,
-      expect.objectContaining({ id: verificationEvents[0].id }),
       expect.objectContaining({
         triggerSource: DetectionType.USER_REPORT,
         triggerContent: 'external suspicious DM',
-      }),
-      undefined
+      })
     );
     expect(userModerationService.restrictUser).not.toHaveBeenCalled();
   });
@@ -622,7 +615,7 @@ describe('SecurityActionService (unit)', () => {
     }
   });
 
-  it('propagates open-case fan-out errors instead of silently leaving partial state', async () => {
+  it('continues open-case message report fan-out when one server notification fails', async () => {
     const member = buildMember('guild-external-fail', 'user-9');
     await serverRepository.upsertByGuildId('guild-external-fail', {
       settings: {
@@ -639,7 +632,9 @@ describe('SecurityActionService (unit)', () => {
         }),
       },
     } as unknown as Client;
-    threadManager.createReportReviewThread.mockRejectedValueOnce(new Error('thread unavailable'));
+    notificationManager.upsertObservedDetectionNotification.mockRejectedValueOnce(
+      new Error('notification unavailable')
+    );
     const consoleError = jest.spyOn(console, 'error').mockImplementation(() => undefined);
     const service = buildService(client);
 
@@ -654,7 +649,12 @@ describe('SecurityActionService (unit)', () => {
             content: 'external suspicious DM',
           }
         )
-      ).rejects.toThrow('thread unavailable');
+      ).resolves.toBe(true);
+      expect(consoleError).toHaveBeenCalledWith(
+        'Failed to process message report fan-out for guild guild-external-fail:',
+        expect.any(Error)
+      );
+      expect(threadManager.createReportReviewThread).not.toHaveBeenCalled();
     } finally {
       consoleError.mockRestore();
     }
@@ -824,7 +824,7 @@ describe('SecurityActionService (unit)', () => {
     expect(notificationManager.upsertSuspiciousUserNotification).toHaveBeenCalledTimes(1);
   });
 
-  it('opens a new pending case when a user report follows a resolved case', async () => {
+  it('posts an observed alert when a user report follows a resolved case', async () => {
     const guildId = 'guild-4c';
     const userId = 'user-4c';
     const reporterId = 'reporter-3';
@@ -851,14 +851,18 @@ describe('SecurityActionService (unit)', () => {
       userId,
       guildId
     );
-    expect(verificationEvents).toHaveLength(2);
-    expect(verificationEvents.map((event) => event.status).sort()).toEqual([
-      VerificationStatus.PENDING,
-      VerificationStatus.VERIFIED,
-    ]);
+    expect(verificationEvents).toHaveLength(1);
+    expect(verificationEvents[0].status).toBe(VerificationStatus.VERIFIED);
     expect(userModerationService.restrictUser).not.toHaveBeenCalled();
     expect(threadManager.createVerificationThread).not.toHaveBeenCalled();
-    expect(threadManager.createReportReviewThread).toHaveBeenCalledTimes(1);
+    expect(threadManager.createReportReviewThread).not.toHaveBeenCalled();
+    expect(notificationManager.upsertObservedDetectionNotification).toHaveBeenCalledWith(
+      member,
+      expect.objectContaining({
+        triggerSource: DetectionType.USER_REPORT,
+        triggerContent: 'new report',
+      })
+    );
   });
 
   it('opens a new pending case when a manual flag follows a resolved case', async () => {
@@ -1212,15 +1216,6 @@ describe('SecurityActionService (unit)', () => {
     const moderator = { id: 'admin-observed' } as User;
     const reporter = { id: 'reporter-observed' } as User;
     const member = buildMember(guildId, userId);
-    threadManager.createReportReviewThread.mockImplementationOnce(async (_member, event) => {
-      await verificationEventRepository.update(event.id, {
-        thread_id: 'review-thread-1',
-        metadata: {
-          [VERIFICATION_THREAD_TYPE_METADATA_KEY]: REPORT_REVIEW_THREAD_TYPE,
-        },
-      });
-      return { id: 'review-thread-1' } as any;
-    });
     const service = buildService();
 
     await service.handleUserReport(member, reporter, 'suspicious DM');
@@ -1228,7 +1223,18 @@ describe('SecurityActionService (unit)', () => {
     const reportDetection = detectionEvents.find(
       (event) => event.detection_type === DetectionType.USER_REPORT
     );
-    threadManager.createReportReviewThread.mockClear();
+    const reviewEvent = await verificationEventRepository.createFromDetection(
+      reportDetection!.id,
+      guildId,
+      userId,
+      VerificationStatus.PENDING
+    );
+    await verificationEventRepository.update(reviewEvent.id, {
+      thread_id: 'review-thread-1',
+      metadata: {
+        [VERIFICATION_THREAD_TYPE_METADATA_KEY]: REPORT_REVIEW_THREAD_TYPE,
+      },
+    });
     threadManager.createVerificationThread.mockClear();
 
     await service.restrictObservedDetection(member, reportDetection!.id, moderator);
@@ -1238,7 +1244,7 @@ describe('SecurityActionService (unit)', () => {
     expect(userModerationService.restrictUser).toHaveBeenCalledWith(member);
   });
 
-  it('uses a verification thread when banning an observed user report', async () => {
+  it('bans an observed user report without creating a verification thread', async () => {
     const guildId = 'guild-observed-report-ban';
     const userId = 'user-observed-report-ban';
     const moderator = { id: 'admin-observed' } as User;
@@ -1261,7 +1267,7 @@ describe('SecurityActionService (unit)', () => {
     );
 
     expect(threadManager.createReportReviewThread).not.toHaveBeenCalled();
-    expect(threadManager.createVerificationThread).toHaveBeenCalled();
+    expect(threadManager.createVerificationThread).not.toHaveBeenCalled();
     expect(userModerationService.banUser).toHaveBeenCalledWith(
       member,
       'Confirmed scam',
@@ -1273,23 +1279,22 @@ describe('SecurityActionService (unit)', () => {
       'banned this user',
       moderator
     );
+    expect(adminActionService.recordAction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action_type: AdminActionType.BAN,
+        detection_event_id: detectionEvent.id,
+        verification_event_id: null,
+        notes: 'Confirmed scam',
+      })
+    );
   });
 
-  it('upgrades an existing report review thread when banning a user report', async () => {
+  it('does not upgrade an existing report review thread when banning a user report', async () => {
     const guildId = 'guild-observed-existing-report-ban';
     const userId = 'user-observed-existing-report-ban';
     const moderator = { id: 'admin-observed' } as User;
     const reporter = { id: 'reporter-observed' } as User;
     const member = buildMember(guildId, userId);
-    threadManager.createReportReviewThread.mockImplementationOnce(async (_member, event) => {
-      await verificationEventRepository.update(event.id, {
-        thread_id: 'review-thread-1',
-        metadata: {
-          [VERIFICATION_THREAD_TYPE_METADATA_KEY]: REPORT_REVIEW_THREAD_TYPE,
-        },
-      });
-      return { id: 'review-thread-1' } as any;
-    });
     const service = buildService();
 
     await service.handleUserReport(member, reporter, 'suspicious DM');
@@ -1297,13 +1302,24 @@ describe('SecurityActionService (unit)', () => {
     const reportDetection = detectionEvents.find(
       (event) => event.detection_type === DetectionType.USER_REPORT
     );
-    threadManager.createReportReviewThread.mockClear();
+    const reviewEvent = await verificationEventRepository.createFromDetection(
+      reportDetection!.id,
+      guildId,
+      userId,
+      VerificationStatus.PENDING
+    );
+    await verificationEventRepository.update(reviewEvent.id, {
+      thread_id: 'review-thread-1',
+      metadata: {
+        [VERIFICATION_THREAD_TYPE_METADATA_KEY]: REPORT_REVIEW_THREAD_TYPE,
+      },
+    });
     threadManager.createVerificationThread.mockClear();
 
     await service.banObservedDetection(member, reportDetection!.id, moderator, 'Confirmed scam');
 
     expect(threadManager.createReportReviewThread).not.toHaveBeenCalled();
-    expect(threadManager.createVerificationThread).toHaveBeenCalled();
+    expect(threadManager.createVerificationThread).not.toHaveBeenCalled();
     expect(userModerationService.banUser).toHaveBeenCalledWith(
       member,
       'Confirmed scam',

--- a/src/__tests__/unit/SecurityActionService.unit.test.ts
+++ b/src/__tests__/unit/SecurityActionService.unit.test.ts
@@ -87,6 +87,7 @@ describe('SecurityActionService (unit)', () => {
 
     adminActionService = {
       recordAction: jest.fn().mockResolvedValue({} as any),
+      getActionsForUser: jest.fn().mockResolvedValue([]),
     } as unknown as jest.Mocked<IAdminActionService>;
   });
 
@@ -1346,6 +1347,50 @@ describe('SecurityActionService (unit)', () => {
       moderator,
       reportDetection!.id
     );
+    expect(adminActionService.recordAction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action_type: AdminActionType.BAN,
+        detection_event_id: reportDetection!.id,
+        verification_event_id: reviewEvent.id,
+        notes: 'Confirmed scam',
+      })
+    );
+  });
+
+  it('does not duplicate observed ban audit when ban service already records it', async () => {
+    const guildId = 'guild-observed-ban-existing-audit';
+    const userId = 'user-observed-ban-existing-audit';
+    const moderator = { id: 'admin-observed' } as User;
+    const member = buildMember(guildId, userId);
+    const detectionEvent = await detectionEventsRepository.create({
+      server_id: guildId,
+      user_id: userId,
+      detection_type: DetectionType.SUSPICIOUS_CONTENT,
+      confidence: 0.82,
+      reasons: ['Suspicious content'],
+      detected_at: new Date(),
+    });
+    await verificationEventRepository.createFromDetection(
+      detectionEvent.id,
+      guildId,
+      userId,
+      VerificationStatus.PENDING
+    );
+    adminActionService.getActionsForUser.mockResolvedValueOnce([
+      {
+        detection_event_id: detectionEvent.id,
+        action_type: AdminActionType.BAN,
+      } as any,
+    ]);
+
+    await buildService().banObservedDetection(
+      member,
+      detectionEvent.id,
+      moderator,
+      'Confirmed scam'
+    );
+
+    expect(adminActionService.recordAction).not.toHaveBeenCalled();
   });
 
   it('keeps an observed restrict claim when audit fails after restricting', async () => {

--- a/src/__tests__/unit/SecurityActionService.unit.test.ts
+++ b/src/__tests__/unit/SecurityActionService.unit.test.ts
@@ -297,6 +297,26 @@ describe('SecurityActionService (unit)', () => {
     );
   });
 
+  it('fails user report submission when the observed alert cannot be delivered', async () => {
+    const guildId = 'guild-report-alert-fails';
+    const userId = 'user-report-alert-fails';
+    const reporterId = 'reporter-alert-fails';
+    const member = buildMember(guildId, userId);
+    notificationManager.upsertObservedDetectionNotification.mockResolvedValueOnce(null);
+    const consoleError = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    try {
+      await expect(
+        buildService().handleUserReport(member, { id: reporterId } as User, 'reported')
+      ).rejects.toThrow('Failed to send or update report observed alert');
+    } finally {
+      consoleError.mockRestore();
+    }
+
+    expect(threadManager.createReportReviewThread).not.toHaveBeenCalled();
+    expect(threadManager.createVerificationThread).not.toHaveBeenCalled();
+  });
+
   it('records a user-installed message report without opening a server case', async () => {
     const service = buildService();
 

--- a/src/services/SecurityActionService.ts
+++ b/src/services/SecurityActionService.ts
@@ -520,6 +520,19 @@ export class SecurityActionService implements ISecurityActionService {
     });
   }
 
+  private async hasRecordedObservedAction(
+    serverId: string,
+    userId: string,
+    detectionEventId: string,
+    actionType: AdminActionType
+  ): Promise<boolean> {
+    const actions = await this.adminActionService.getActionsForUser(serverId, userId);
+    return actions.some(
+      (action) =>
+        action.detection_event_id === detectionEventId && action.action_type === actionType
+    );
+  }
+
   private async ensureObservedEntitiesExist(guildId: string, userId: string): Promise<void> {
     await this.serverRepository.getOrCreateServer(guildId);
     await this.userRepository.getOrCreateUser(userId);
@@ -896,6 +909,8 @@ export class SecurityActionService implements ISecurityActionService {
       if (responseMode === 'off') {
         continue;
       }
+      // notify_only and open_case both use observed alerts now. The distinction is
+      // retained for compatibility and future UX polish.
 
       await this.processMessageReportForManagedServer(
         serverId,
@@ -1122,12 +1137,22 @@ export class SecurityActionService implements ISecurityActionService {
         );
       await this.userModerationService.banUser(member, reason, moderator, detectionEvent.id);
       actionApplied = true;
-      if (!activeVerificationEvent) {
+      const actionAlreadyRecorded = await this.hasRecordedObservedAction(
+        member.guild.id,
+        member.id,
+        claimedDetectionEvent.id,
+        AdminActionType.BAN
+      );
+      if (!actionAlreadyRecorded) {
+        const currentVerificationEvent = activeVerificationEvent
+          ? await this.verificationEventRepository.findById(activeVerificationEvent.id)
+          : null;
         await this.recordObservedAction({
           serverId: member.guild.id,
           userId: member.id,
           moderator,
           detectionEvent: claimedDetectionEvent,
+          verificationEvent: currentVerificationEvent ?? activeVerificationEvent ?? undefined,
           actionType: AdminActionType.BAN,
           notes: reason,
         });

--- a/src/services/SecurityActionService.ts
+++ b/src/services/SecurityActionService.ts
@@ -341,6 +341,32 @@ export class SecurityActionService implements ISecurityActionService {
     }
   }
 
+  private async upsertReportObservedAlertOrActiveCase(
+    member: GuildMember,
+    detectionResult: DetectionResult,
+    detectionEventId: string
+  ): Promise<void> {
+    const activeVerificationEvent =
+      await this.verificationEventRepository.findActiveByUserAndServer(member.id, member.guild.id);
+
+    if (!activeVerificationEvent) {
+      await this.notificationManager.upsertObservedDetectionNotification(member, detectionResult);
+      return;
+    }
+
+    const linkedDetectionEvent = await this.detectionEventsRepository.linkToVerificationEvent(
+      detectionEventId,
+      activeVerificationEvent.id
+    );
+    if (!linkedDetectionEvent) {
+      throw new Error(
+        `Failed to link report detection event ${detectionEventId} to verification event ${activeVerificationEvent.id}`
+      );
+    }
+
+    await this.upsertNotification(member, detectionResult, activeVerificationEvent);
+  }
+
   private async getObservedDetectionForMember(
     member: GuildMember,
     detectionEventId: string
@@ -763,7 +789,8 @@ export class SecurityActionService implements ISecurityActionService {
         detectionEventId: detectionEvent.id,
       };
 
-      return await this.handleSuspiciousMember(member, detectionResult, undefined, false);
+      await this.upsertReportObservedAlertOrActiveCase(member, detectionResult, detectionEvent.id);
+      return true;
     } catch (error) {
       console.error(`Failed to handle user report for ${member.user.tag}:`, error);
       throw error;
@@ -840,8 +867,7 @@ export class SecurityActionService implements ISecurityActionService {
           reporter,
           report,
           globalReportId,
-          true,
-          'open_case'
+          true
         );
       }
     }
@@ -873,8 +899,7 @@ export class SecurityActionService implements ISecurityActionService {
         reporter,
         report,
         globalReportId,
-        isLocalReport,
-        responseMode
+        isLocalReport
       );
     }
   }
@@ -885,8 +910,7 @@ export class SecurityActionService implements ISecurityActionService {
     reporter: User | APIUser,
     report: MessageReportContext,
     globalReportId: string,
-    isLocalReport: boolean,
-    responseMode: 'notify_only' | 'open_case'
+    isLocalReport: boolean
   ): Promise<void> {
     const member = await this.fetchManagedReportMember(serverId, targetUser.id);
     if (!member) {
@@ -914,14 +938,14 @@ export class SecurityActionService implements ISecurityActionService {
       detectionEventId: serverDetectionEvent.id,
     };
 
-    if (responseMode === 'notify_only') {
-      try {
-        await this.notificationManager.upsertObservedDetectionNotification(member, detectionResult);
-      } catch (error) {
-        console.error(`Failed to process message report fan-out for guild ${serverId}:`, error);
-      }
-    } else {
-      await this.handleSuspiciousMember(member, detectionResult, undefined, false);
+    try {
+      await this.upsertReportObservedAlertOrActiveCase(
+        member,
+        detectionResult,
+        serverDetectionEvent.id
+      );
+    } catch (error) {
+      console.error(`Failed to process message report fan-out for guild ${serverId}:`, error);
     }
   }
 
@@ -1086,9 +1110,24 @@ export class SecurityActionService implements ISecurityActionService {
     }
     let actionApplied = false;
     try {
-      await this.ensureObservedCase(member, detectionEvent, false);
+      await this.ensureObservedEntitiesExist(member.guild.id, member.id);
+      const activeVerificationEvent =
+        await this.verificationEventRepository.findActiveByUserAndServer(
+          member.id,
+          member.guild.id
+        );
       await this.userModerationService.banUser(member, reason, moderator, detectionEvent.id);
       actionApplied = true;
+      if (!activeVerificationEvent) {
+        await this.recordObservedAction({
+          serverId: member.guild.id,
+          userId: member.id,
+          moderator,
+          detectionEvent: claimedDetectionEvent,
+          actionType: AdminActionType.BAN,
+          notes: reason,
+        });
+      }
       await this.notificationManager.markObservedDetectionActionTaken(
         detectionEvent.id,
         'banned this user',

--- a/src/services/SecurityActionService.ts
+++ b/src/services/SecurityActionService.ts
@@ -350,7 +350,11 @@ export class SecurityActionService implements ISecurityActionService {
       await this.verificationEventRepository.findActiveByUserAndServer(member.id, member.guild.id);
 
     if (!activeVerificationEvent) {
-      await this.notificationManager.upsertObservedDetectionNotification(member, detectionResult);
+      const notificationMessage =
+        await this.notificationManager.upsertObservedDetectionNotification(member, detectionResult);
+      if (!notificationMessage) {
+        throw new Error('Failed to send or update report observed alert');
+      }
       return;
     }
 


### PR DESCRIPTION
## Summary
- Route report-only intake through the existing observed-alert embed/actions instead of creating a report-review thread by default.
- Keep active-case behavior by linking new reports into an existing pending case and updating its notification.
- Make observed-report bans ban/log without creating a user-visible verification thread first.
- Document persona journeys and update workflow/manual QA/test docs for the embed-first report UX.

## Why
Report triage needs context and action buttons, not a thread for every report. Threads should be created when a moderator explicitly opens a case/workspace or restricts a user into verification.

## Test Plan
- `npm run format:check`
- `npm run build`
- `npm test`
- `npm run lint` (passes with existing ESLint flat-config warning in `scripts/create-prisma-user.js`)
- `git diff --check`

## Risk Notes
- Report-only cases no longer create `verification_events` unless there is already an active case to link to or a moderator opens/restricts from the observed alert.
- Existing thread-type upgrade behavior remains as a fallback for report-review-thread cases already created by the previous implementation.