### PR TITLE
Add release confidence QA docs

### DIFF
--- a/docs/manual-qa.md
+++ b/docs/manual-qa.md
@@ -9,6 +9,11 @@ Related docs:
 - `docs/release-checklist.md`
 - `docs/test-cases.md`
 - `docs/workflow.md`
+- `docs/qa/manual-qa-cards.md` for card-based release smoke testing
+- `docs/qa/release-readiness-gaps.md` for large-server rollout gaps
+- `docs/qa/faceless-rollout-plan.md` for the low-attention production rollout path
+
+For high-confidence release testing, prefer `docs/qa/manual-qa-cards.md`. This file is the shorter walkthrough; the card runbook is the stricter go/no-go procedure.
 
 ## Test setup
 

--- a/docs/qa/faceless-rollout-plan.md
+++ b/docs/qa/faceless-rollout-plan.md
@@ -1,0 +1,182 @@
+# The Faceless Rollout Plan
+
+This plan is for enabling Drasil on a large public server with many spam bots while keeping operator attention and user risk low.
+
+The default posture is conservative: observe first, review reports, and require humans for disruptive actions.
+
+## Rollout Principles
+
+- Do not test bans on real members.
+- Do not enable automatic restrictions on a large server until staging cards pass.
+- Do not enable external reports for a server unless its admins explicitly choose that mode.
+- Prefer one clear moderator surface over multiple noisy channels.
+- Stop and triage if Drasil produces confusing alerts, unexpected role changes, or permission errors.
+
+## Phase 0: Staging Confidence
+
+Goal: prove the mechanics away from the real community.
+
+Required cards:
+
+- Cards 1-3 from `docs/qa/manual-qa-cards.md`.
+- Cards 5, 8, 9, 11, 12, and 16 when the needed accounts/guilds exist.
+
+Exit criteria:
+
+- Report-only intake creates alerts and does not restrict.
+- `Restrict` creates a user-visible verification thread.
+- `Ban` bans only the sacrificial account and does not create a verification thread first.
+- External opted-out guild receives no alert.
+- External opted-in guild receives an alert and takes no automatic action.
+
+## Phase 1: Production Install, No Disruption
+
+Goal: confirm Drasil can live in The Faceless without affecting members.
+
+Config:
+
+- Detection mode: `notify_only` or equivalent observe-only posture.
+- External report mode: `off` until the moderator team explicitly opts in.
+- User-installed reporting: enabled only after command registration and staging external-report cards pass.
+- Ban/restrict actions: moderator-click only.
+
+Do:
+
+- Install the bot with the minimum practical permissions documented in `docs/release-checklist.md`.
+- Configure the admin/observed channel and verification channel.
+- Run a harmless command to confirm command registration.
+- Watch logs after deploy.
+
+Expect:
+
+- No member gets restricted or banned automatically.
+- Moderator-only channels receive any expected test alerts.
+- No `Missing Access`, `Missing Permissions`, or role hierarchy errors appear.
+
+Stop if:
+
+- Drasil posts in the wrong channel.
+- Drasil cannot create threads.
+- Any real member receives a role change unexpectedly.
+
+## Phase 2: Report-Only Pilot
+
+Goal: let a small moderator cohort evaluate report UX without broad server announcement.
+
+Config:
+
+- `/report` and `Report User` enabled in the server.
+- `Report Message` enabled only if the team is ready to test that path.
+- External report mode remains `off` unless explicitly testing external reports.
+
+Do:
+
+- Have one moderator or test reporter submit a controlled report.
+- Review the observed alert as a team.
+- Test `Dismiss...` and undo on a non-disruptive report.
+- Test `Open Case` only if the team wants a moderator-only workspace.
+
+Expect:
+
+- Reported user is not notified for report-only review.
+- Moderators can understand who reported whom and why.
+- Dismiss/false-positive behavior is understandable.
+
+Stop if:
+
+- Moderators cannot tell what action each button will take.
+- Alerts are too noisy or lack target context.
+
+## Phase 3: Controlled Escalation
+
+Goal: prove that moderator-selected actions work in production without using real victims.
+
+Config:
+
+- Sacrificial reported-user account present in the server.
+- Bot role above the restricted role and sacrificial account.
+- Moderator team aware of the test window.
+
+Do:
+
+- Submit a controlled report against the sacrificial account.
+- Click `Restrict` and verify the private verification thread.
+- Resolve the case.
+- In a separate run, click `Ban` against the sacrificial account.
+
+Expect:
+
+- Restrict creates a visible path for the target to respond.
+- Ban is logged and does not create a needless verification thread.
+- No unrelated member is affected.
+
+Stop if:
+
+- The verification thread is not visible to the sacrificial target.
+- The thread is visible to unrelated members.
+- The ban action fails because of hierarchy or permission problems.
+
+## Phase 4: Limited Moderator Use
+
+Goal: use Drasil for real triage while keeping irreversible action human-controlled.
+
+Config:
+
+- Detection remains observe-only until spam volume and false positives are understood.
+- External reports remain `off` or `notify_only` only.
+- Moderator cohort is limited to people briefed on the action model.
+
+Do:
+
+- Let moderators process real report-only alerts.
+- Prefer dismiss/history/open-case before restrict/ban when uncertain.
+- Record examples where the alert is confusing or insufficient.
+- Review OpenAI and AWS usage after the first busy period.
+
+Expect:
+
+- Drasil reduces triage time without creating unexplained punishments.
+- Moderators trust the difference between report-only review, restriction, and ban.
+
+Stop if:
+
+- False positives are frequent.
+- Costs spike unexpectedly.
+- Moderators start using `Ban` when the evidence shown in the alert is insufficient.
+
+## Phase 5: Later Automation Review
+
+Goal: decide whether automatic restriction should ever be enabled on The Faceless.
+
+Do not enter this phase until earlier phases produce enough evidence.
+
+Required evidence:
+
+- Representative sample of observed detections.
+- False-positive review from moderators.
+- Known cost at real traffic volume.
+- Clear rollback path.
+- Agreement on what signals justify automatic restriction.
+
+Default recommendation:
+
+- Keep large-public-server behavior review-first unless spam pressure and detection quality justify a narrow automatic rule.
+
+## Operator Checklist
+
+Before each production step:
+
+- Know the current detection mode.
+- Know the current external report mode.
+- Know the admin/observed channel.
+- Know the verification channel.
+- Know the restricted role.
+- Know how to roll back the ECS task definition.
+- Know how to disable external reports for the server.
+
+After each production step:
+
+- Check moderator channel behavior.
+- Check CloudWatch logs.
+- Check for unexpected role changes.
+- Record screenshots for the first successful path and the first failure.

--- a/docs/qa/manual-qa-cards.md
+++ b/docs/qa/manual-qa-cards.md
@@ -1,0 +1,376 @@
+# Manual QA Cards
+
+These cards are the release smoke test for Drasil moderation and reporting changes. They are intentionally concrete: configure the server, perform the action, record the expected result, and stop on serious surprises.
+
+Severity:
+
+- `P0`: Blocks release or production rollout.
+- `P1`: Should fix before relying on the feature broadly.
+- `P2`: Nice to verify, useful for polish or confidence.
+
+Evidence to collect:
+
+- Screenshot of the relevant Discord alert, thread, or command response.
+- Bot log excerpt for failures.
+- Database row IDs only when needed for debugging; do not paste secrets.
+- CloudWatch query result for production deploy checks.
+
+## Test Accounts
+
+Do not use a primary personal account for ban/restrict testing.
+
+Minimum accounts:
+
+- Moderator account with access to the admin/observed channel.
+- Reporter account for report submission.
+- Reported-user sacrificial account for restrict/ban tests.
+
+Minimum guilds:
+
+- One staging guild for local report and moderation flows.
+- Two managed staging guilds for high-confidence external report testing: one opted out, one opted in.
+
+Reduced-confidence fallback:
+
+- If only one managed guild is available, run local report cards and defer external trust-boundary sign-off.
+
+## Batch A: Server Preflight
+
+1. **Discord Permission Matrix** (`P0`)
+
+   Config:
+   - Dedicated staging guild.
+   - Bot role above the restricted role.
+   - Admin/observed channel visible to moderators and bot only.
+   - Verification channel where the bot can create private threads.
+
+   Do:
+   - Confirm the bot has `Manage Roles`, `Ban Members`, `View Channels`, `Send Messages`, `Manage Threads`, and `Create Private Threads`.
+   - Confirm privileged intents are enabled in the Discord Developer Portal: Server Members Intent and Message Content Intent.
+   - Run the normal setup/config commands for restricted role, admin channel, and verification channel.
+
+   Expect:
+   - Bot config commands succeed.
+   - Bot can post in the admin/observed channel.
+   - No `Missing Access` or `Missing Permissions` error appears in logs.
+
+   Watch for:
+   - Channel overrides denying thread creation.
+   - Bot role below restricted role.
+   - Bot role unable to ban the sacrificial account.
+
+2. **Database And Startup** (`P0`)
+
+   Config:
+   - `DISCORD_TOKEN`, `DATABASE_URL`, and `OPENAI_API_KEY` configured for the test environment.
+   - Prisma migrations deployed.
+
+   Do:
+   - Run `npm run build`.
+   - Run `npm test`.
+   - Start the bot for the staging environment.
+
+   Expect:
+   - Build and unit tests pass.
+   - Bot starts and registers commands.
+   - No Prisma TLS or migration error appears.
+
+   Watch for:
+   - `P1011` or TLS connection errors.
+   - Commands missing after startup.
+   - Bot connected to the wrong guild or database.
+
+## Batch B: Local Reports
+
+3. **Guild Slash Report** (`P0`)
+
+   Config:
+   - Report reasons optional or known.
+   - Staging guild has an admin/observed channel.
+
+   Do:
+   - From the reporter account, run `/report` against the sacrificial reported-user account.
+   - Include a short reason.
+
+   Expect:
+   - Reporter receives a successful command response.
+   - Moderator channel receives a report-only observed alert.
+   - Reported user is not restricted, mentioned, or added to a thread.
+   - Alert includes moderator actions: `Open Case`, `Restrict`, `Ban`, `Dismiss...`, and `History` when available.
+
+   Watch for:
+   - Any automatic restriction from report-only intake.
+   - A verification thread created before moderator action.
+   - Missing report reason or wrong reporter/target identity.
+
+4. **Guild User Context Report** (`P1`)
+
+   Config:
+   - `Report User` command registered in the staging guild.
+   - If report reasons are required, know that the context menu cannot collect options.
+
+   Do:
+   - Right-click the sacrificial reported-user account.
+   - Choose `Apps` -> `Report User`.
+
+   Expect:
+   - If reasons are optional, flow matches `/report`.
+   - If reasons are required, Drasil tells the reporter to use `/report`.
+
+   Watch for:
+   - Context menu silently failing.
+   - Required-reason config producing a confusing success response.
+
+5. **Guild Message Report** (`P0`)
+
+   Config:
+   - `DRASIL_USER_INSTALL_REPORTING_ENABLED=true` in the environment that registered commands.
+   - `Report Message` command visible in the staging guild.
+
+   Do:
+   - Have the sacrificial reported-user account send a harmless test message.
+   - From the reporter account, right-click the message.
+   - Choose `Apps` -> `Report Message`.
+   - Submit the modal reason.
+
+   Expect:
+   - Reporter receives success confirmation.
+   - Moderator channel receives a report-only observed alert with message context.
+   - No restriction or verification thread is created by default.
+
+   Watch for:
+   - Modal submission errors.
+   - Missing message context.
+   - Report incorrectly treated as an external DM/GDM report.
+
+6. **Report Dismiss And Undo** (`P1`)
+
+   Config:
+   - A fresh report-only observed alert from cards 3 or 5.
+
+   Do:
+   - Click `Dismiss...`.
+   - Choose `Dismiss Alert`.
+   - Use undo if available.
+   - Repeat with `False Positive`.
+
+   Expect:
+   - Alert state updates without restricting or banning.
+   - Undo restores the previous actionable state.
+   - False-positive action is recorded distinctly from a plain dismiss.
+
+   Watch for:
+   - Buttons remaining enabled after final dismissal.
+   - Dismissal changing the reported user's roles.
+
+## Batch C: Escalation Actions
+
+7. **Open Report Case Workspace** (`P1`)
+
+   Config:
+   - A report-only observed alert exists for the sacrificial reported-user account.
+
+   Do:
+   - Click `Open Case` from the observed alert.
+
+   Expect:
+   - Drasil creates or exposes a moderator-only review workspace.
+   - Reported user is not added to that workspace.
+   - Reported user is not restricted by `Open Case` alone.
+
+   Watch for:
+   - Moderator-only workspace accidentally visible to the reported user.
+   - `Open Case` behaving like `Restrict`.
+
+8. **Restrict From Report Alert** (`P0`)
+
+   Config:
+   - A report-only observed alert exists.
+   - Bot can assign the restricted role and create private verification threads.
+
+   Do:
+   - Click `Restrict`.
+
+   Expect:
+   - Sacrificial reported-user account receives the restricted role.
+   - A user-visible verification thread is created.
+   - Moderator alert updates to show the active case.
+   - Admin action is recorded.
+
+   Watch for:
+   - Restriction without a user-visible verification thread.
+   - Thread created in the wrong channel.
+   - Thread visible to users other than the target and moderators.
+
+9. **Ban From Report Alert** (`P0`)
+
+   Config:
+   - Fresh report-only alert for the sacrificial reported-user account.
+   - Sacrificial account is safe to ban from staging.
+
+   Do:
+   - Click `Ban`.
+
+   Expect:
+   - Sacrificial account is banned from the staging guild.
+   - Admin action is recorded.
+   - No user-visible verification thread is created just for the ban.
+
+   Watch for:
+   - Ban attempted against a non-sacrificial account.
+   - Discord role hierarchy failure.
+   - Thread creation before ban.
+
+10. **Repeated Reports Coalesce** (`P1`)
+
+    Config:
+    - Same reporter and target accounts.
+    - Existing report alert or active case.
+
+    Do:
+    - Submit two reports against the same target before resolving the first.
+    - Resolve or dismiss the case.
+    - Submit one more report after resolution.
+
+    Expect:
+    - Repeated pending reports update or link to the existing active state.
+    - Post-resolution report creates a new review alert rather than reopening automatically.
+
+    Watch for:
+    - Notification spam.
+    - Lost second report reason.
+    - Resolved case silently reopened.
+
+## Batch D: External Reports
+
+11. **External Report Opted Out** (`P0`)
+
+    Config:
+    - User-installed `Report Message` enabled in Discord Developer Portal and registered by Drasil.
+    - Managed staging guild A has the reported user as a known member.
+    - Guild A external report mode is `off`.
+
+    Do:
+    - From a DM or group DM, report a message authored by the sacrificial reported-user account.
+
+    Expect:
+    - Global report signal is accepted.
+    - Guild A receives no visible moderator alert.
+    - No restriction, ban, case, or thread is created in Guild A.
+
+    Watch for:
+    - Opted-out guild receiving any visible notification.
+    - Reporter confirmation claiming a server took action.
+
+12. **External Report Notify Only** (`P0`)
+
+    Config:
+    - Managed staging guild B has the reported user as a known member.
+    - Guild B external report mode is `notify_only`.
+
+    Do:
+    - From a DM or group DM, report a message authored by the sacrificial reported-user account.
+
+    Expect:
+    - Guild B receives a moderator-facing observed alert.
+    - No automatic restriction, ban, verification event, or user-visible thread is created.
+    - Alert clearly indicates the report came from outside the server context.
+
+    Watch for:
+    - Alert posted to a non-moderator channel.
+    - Cross-server source details exposing more than intended.
+
+13. **External Report Open Case Mode** (`P1`)
+
+    Config:
+    - Managed staging guild B external report mode is `open_case`.
+
+    Do:
+    - Submit the same DM/GDM report flow.
+
+    Expect:
+    - Current behavior matches `notify_only`: observed alert, no automatic case thread.
+    - Moderators still choose `Open Case`, `Restrict`, or `Ban` manually.
+
+    Watch for:
+    - Admin expectation mismatch. This mode is retained for future UX polish but is currently conservative.
+
+## Batch E: Detection And AI
+
+14. **Observe-Only Suspicious Detection** (`P1`)
+
+    Config:
+    - Detection mode set to `notify_only`.
+    - Notification window set to a known value, such as 60 minutes.
+
+    Do:
+    - Trigger a suspicious automatic detection from a safe test account.
+
+    Expect:
+    - No restricted role is assigned.
+    - No verification thread is created.
+    - Moderator channel receives a `Suspicious Activity Observed` alert.
+    - AI analysis, heuristic reasons, confidence, and summary are understandable when present.
+
+    Watch for:
+    - AI output posted into a user-visible thread or public channel.
+    - Excessive repeated alerts for the same user inside the notification window.
+
+15. **Verification Thread Analysis Is Admin-Only** (`P1`)
+
+    Config:
+    - Verification thread analysis enabled.
+    - Active restricted case with a user-visible verification thread.
+
+    Do:
+    - Have the sacrificial reported-user account reply in their verification thread.
+
+    Expect:
+    - AI analysis appears only in the moderator-facing notification area.
+    - User-visible thread does not receive AI judgment text.
+    - Repeated replies update the same admin-facing analysis area.
+
+    Watch for:
+    - AI analysis exposed to the restricted user.
+    - Duplicate admin notifications for every reply.
+
+## Batch F: Production Deploy Smoke
+
+16. **Post-Deploy Runtime Check** (`P0`)
+
+    Config:
+    - Production deploy completed and ECS service stable.
+
+    Do:
+    - Confirm ECS desired/running count is stable.
+    - Check CloudWatch logs for recent errors.
+    - Run one harmless command that does not moderate a real user.
+
+    Expect:
+    - ECS service is stable.
+    - No recent `ERROR`, `Exception`, `P1011`, `TlsConnectionError`, `Missing Access`, or `Missing Permissions` signal is present.
+    - Commands respond normally.
+
+    Watch for:
+    - Deploy appears stable but commands are stale or missing.
+    - Any Discord permission error after command registration.
+
+17. **Production Report-Only Pilot** (`P0`)
+
+    Config:
+    - Large server remains in review-only/observe-only posture.
+    - A sacrificial or clearly controlled target is used.
+
+    Do:
+    - Submit one report through the intended production entry point.
+    - Do not click disruptive actions until moderators verify the alert.
+
+    Expect:
+    - Moderator alert appears in the intended channel.
+    - No automatic restriction or ban occurs.
+    - Moderator team can explain what happened from the alert alone.
+
+    Watch for:
+    - Alert noise in the wrong channel.
+    - Confusing action labels.
+    - Any real member affected without explicit moderator action.

--- a/docs/qa/release-readiness-gaps.md
+++ b/docs/qa/release-readiness-gaps.md
@@ -1,0 +1,187 @@
+# Release Readiness Gaps
+
+This is the confidence checklist for enabling Drasil on a large public server. It focuses on the gaps that matter before trusting anti-spam, reports, and moderator actions on a real community.
+
+Use this with:
+
+- `docs/qa/manual-qa-cards.md`
+- `docs/qa/faceless-rollout-plan.md`
+- `docs/manual-qa.md`
+- `docs/release-checklist.md`
+
+## Current Confidence
+
+Ready for staged testing:
+
+- Guild `/report`, `Report User`, and `Report Message` create review-only report signals.
+- External DM/GDM reports are opt-in per managed server.
+- Report-only intake does not automatically restrict or ban.
+- Report alerts use the observed-alert surface with moderator buttons.
+- `Restrict` creates a user-visible verification thread.
+- `Ban` does not create a user-visible verification thread first.
+- Recent production deploys stabilized on ECS with no known recurring TLS or `Missing Access` errors.
+
+Not ready for broad unattended enforcement:
+
+- Large-server rollout still needs a full card-based staging pass.
+- Cross-server external reports need at least two managed test guilds for high confidence.
+- Cost and abuse controls around AI-backed analysis need an operator-facing review before high-volume exposure.
+- Moderator trust still depends on clear screenshots/evidence from real Discord flows, not just unit tests.
+
+## P0 Gaps
+
+Fix or explicitly accept these before enabling disruptive actions on a large server.
+
+1. Real Discord permission matrix not fully exercised on a staging guild.
+
+   Risk: Drasil can pass unit tests but fail to create threads, assign roles, post alerts, or ban because of Discord role hierarchy and channel overrides.
+
+   Required evidence:
+   - Bot role is above the restricted role.
+   - Bot can post in the admin/observed channel.
+   - Bot can create private verification threads.
+   - Bot can add the flagged user to their verification thread.
+   - Bot can ban only accounts intentionally placed below its highest role.
+
+2. Ban/restrict testing must use sacrificial accounts.
+
+   Risk: Testing with a real personal account is not repeatable and can create account/server damage.
+
+   Required evidence:
+   - One reporter account.
+   - One reported-user account.
+   - One moderator account.
+   - Ban tests run only against the sacrificial reported-user account in staging until production has a final approval.
+
+3. External reports need trust-boundary validation.
+
+   Risk: A DM/GDM report could appear to cross server boundaries silently or notify a server that did not opt in.
+
+   Required evidence:
+   - Opted-out server receives no visible alert.
+   - Opted-in server receives a moderator-facing observed alert.
+   - No external report applies automatic restriction.
+   - Reporter confirmation does not over-promise server action.
+
+4. Fail-closed report alert delivery must be observed.
+
+   Risk: A report submission can appear accepted while moderators never receive an alert.
+
+   Required evidence:
+   - If the admin/observed channel is unavailable, the command fails visibly or logs a clear failure.
+   - No silent success is recorded for a missing moderator alert.
+
+5. Rollback path must be rehearsed before production expansion.
+
+   Risk: A bad moderation behavior can remain active while operators search for the correct rollback steps.
+
+   Required evidence:
+   - Known previous commit SHA or ECS task definition revision.
+   - Deploy workflow rollback steps from `docs/deploy/aws.md` are understood.
+   - Server-side feature switches are known: detection mode and report external-response mode.
+
+## P1 Gaps
+
+These should be closed before inviting a large moderator group to rely on Drasil.
+
+1. Observability checklist is mostly manual.
+
+   Current state:
+   - CloudWatch logs and alarms exist for production infrastructure.
+   - Operators can query `/ecs/drasil-prod` for errors.
+
+   Gap:
+   - There is no single runbook for post-deploy moderation-specific signals.
+
+   Minimum useful signals:
+   - Discord `Missing Access`, `Missing Permissions`, and role hierarchy failures.
+   - Report delivery failures.
+   - Thread creation failures.
+   - Ban/restrict failures.
+   - OpenAI request failures and rate-limit errors.
+
+2. Cost controls need a moderation-volume review.
+
+   Current state:
+   - AWS budget and cost anomaly notifications can be configured.
+   - GPT-backed analysis is available.
+
+   Gap:
+   - High-volume public servers can produce unexpected OpenAI usage if suspicious-message analysis or verification-thread analysis is noisy.
+
+   Minimum rollout guardrail:
+   - Keep automatic detection in observe-only until moderators understand volume.
+   - Enable verification-thread analysis only for a limited cohort during early rollout.
+   - Review OpenAI dashboard usage after the first production day and first busy period.
+
+3. Moderator explainability needs real screenshots.
+
+   Current state:
+   - Alerts include report context, GPT analysis fields when available, and action buttons.
+
+   Gap:
+   - We need moderator-readable evidence that the embed explains why the alert exists and what each action does.
+
+   Required evidence:
+   - Screenshot of report-only alert.
+   - Screenshot after `Dismiss...`.
+   - Screenshot after `Open Case`.
+   - Screenshot after `Restrict`.
+   - Screenshot after `Ban`.
+
+4. Repeated-report behavior needs a human noise check.
+
+   Current state:
+   - Reports can update an existing active case/notification instead of creating duplicate state.
+
+   Gap:
+   - The moderator-facing UX still needs review for whether repeat reports are readable or noisy.
+
+   Required evidence:
+   - Two reports against the same user inside one notification window.
+   - One report after a case is resolved.
+
+5. Production server settings need a preflight snapshot.
+
+   Required evidence:
+   - Detection mode.
+   - Notification window.
+   - Report settings.
+   - External report mode.
+   - Restricted role.
+   - Admin/observed channel.
+   - Verification channel.
+
+## P2 Gaps
+
+These improve confidence but should not block a careful staged rollout.
+
+1. External `open_case` is currently equivalent to `notify_only`.
+
+   Impact: Safe but potentially surprising for admins who expect automatic case workspace creation.
+
+   Mitigation: Docs state the current behavior clearly. Keep the separate config value for future UX polish.
+
+2. Reporter confirmation copy may need product polish.
+
+   Impact: Reporters might not understand that external reports are recorded but may not notify any server.
+
+   Mitigation: Keep server delivery intentionally opaque unless the product boundary changes.
+
+3. Manual QA remains partly operator-driven.
+
+   Impact: Discord UI and permission behavior are hard to fully automate.
+
+   Mitigation: Use card-based QA with screenshots and log snippets as evidence.
+
+## Go/No-Go Rule
+
+Go for a limited production pilot only when all P0 cards in `docs/qa/manual-qa-cards.md` pass and the rollout starts in review-only/observe-only mode.
+
+No-go for disruptive production automation if any of these are true:
+
+- Reports can restrict or ban without moderator action.
+- External reports notify an opted-out server.
+- `Restrict` fails to create a user-visible verification thread.
+- Permission failures are present and unexplained in production logs.
+- Moderators cannot tell from the alert why a user was reported or flagged.

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -7,6 +7,9 @@ This is intended to be concise and actionable. For flow details see:
 - `docs/workflow.md`
 - `docs/test-cases.md`
 - `docs/manual-qa.md`
+- `docs/qa/manual-qa-cards.md`
+- `docs/qa/release-readiness-gaps.md`
+- `docs/qa/faceless-rollout-plan.md`
 
 ## Pre-flight
 
@@ -65,6 +68,7 @@ Configure the bot (current UX is via `/config`):
 Use `docs/test-cases.md` as the authoritative list. Minimum set:
 
 - If you want a step-by-step runbook instead of a short checklist, use `docs/manual-qa.md`.
+- If you are validating reports, external reports, or large-server rollout confidence, use the stricter card runbook in `docs/qa/manual-qa-cards.md`.
 
 - Suspicious message:
   - user restricted
@@ -86,6 +90,11 @@ Use `docs/test-cases.md` as the authoritative list. Minimum set:
 Privacy check:
 
 - Verify the restricted user can only see their own verification thread.
+
+Large-server go/no-go:
+
+- Close or explicitly accept the P0 items in `docs/qa/release-readiness-gaps.md`.
+- Start production rollout from the conservative phases in `docs/qa/faceless-rollout-plan.md`.
 
 ## Common failure modes
 

--- a/docs/test-cases.md
+++ b/docs/test-cases.md
@@ -4,6 +4,8 @@
 
 For a real-server walkthrough, use `docs/manual-qa.md`.
 
+For release confidence on reporting, external reports, or large-server rollout, use the card runbook in `docs/qa/manual-qa-cards.md`.
+
 - Suspicious message: user gets restricted, verification thread auto-created, admin notification sent.
 - Additional suspicious message while pending: no new verification event; notification updated.
 - New suspicious message after verification resolved: new verification event and new notification message.


### PR DESCRIPTION
## Summary
- Add a release-readiness gap analysis for large-server reporting/moderation rollout.
- Add card-based manual QA runbook for local reports, external reports, escalation actions, detection, and production smoke checks.
- Add a conservative rollout plan for a controlled production server and link the docs from existing QA/release entry points.

## Validation
- npm run format:check

## Risk
- Docs-only change; no runtime behavior changes.