### PR TITLE
Require verifier ban confirmation

### DIFF
--- a/src/__tests__/unit/InteractionHandler.unit.test.ts
+++ b/src/__tests__/unit/InteractionHandler.unit.test.ts
@@ -62,13 +62,17 @@ const buildInteraction = (customId: string, guildId: string, user: User): Button
   return interaction as unknown as ButtonInteraction;
 };
 
-const grantInteractionPermissions = (interaction: ButtonInteraction): void => {
+const grantInteractionPermissions = (
+  interaction: ButtonInteraction | ModalSubmitInteraction
+): void => {
   Object.assign(interaction, {
     memberPermissions: { has: jest.fn().mockReturnValue(true) },
   });
 };
 
-const grantOnlyBanMembersPermission = (interaction: ButtonInteraction): void => {
+const grantOnlyBanMembersPermission = (
+  interaction: ButtonInteraction | ModalSubmitInteraction
+): void => {
   Object.assign(interaction, {
     memberPermissions: {
       has: jest.fn((permission: bigint) => permission === PermissionFlagsBits.BanMembers),
@@ -198,7 +202,7 @@ describe('InteractionHandler (unit)', () => {
     });
   });
 
-  it('handles ban button by calling UserModerationService', async () => {
+  it('shows a confirmation modal for the ban button', async () => {
     const handler = new InteractionHandler(
       client,
       notificationManager,
@@ -216,11 +220,12 @@ describe('InteractionHandler (unit)', () => {
 
     await handler.handleButtonInteraction(interaction);
 
-    expect(userModerationService.banUser).toHaveBeenCalledTimes(1);
-    expect(interaction.followUp).toHaveBeenCalledWith({
-      content: 'User <@user-1> has been banned from the server.',
-      flags: MessageFlags.Ephemeral,
-    });
+    expect(userModerationService.banUser).not.toHaveBeenCalled();
+    expect(interaction.deferUpdate).not.toHaveBeenCalled();
+    expect(interaction.showModal).toHaveBeenCalledTimes(1);
+    const modal = (interaction.showModal as jest.Mock).mock.calls[0][0] as any;
+    expect(modal.toJSON().custom_id).toBe('verification:ban_modal:user-1');
+    expect(JSON.stringify(modal.toJSON())).toContain('Final notes (optional)');
   });
 
   it('handles thread button and creates a verification thread', async () => {
@@ -428,7 +433,7 @@ describe('InteractionHandler (unit)', () => {
     }
   );
 
-  it('allows ban button with only BanMembers permission', async () => {
+  it('allows ban confirmation with only BanMembers permission', async () => {
     const handler = new InteractionHandler(
       client,
       notificationManager,
@@ -446,7 +451,84 @@ describe('InteractionHandler (unit)', () => {
 
     await handler.handleButtonInteraction(interaction);
 
-    expect(userModerationService.banUser).toHaveBeenCalledTimes(1);
+    expect(interaction.showModal).toHaveBeenCalledTimes(1);
+    expect(userModerationService.banUser).not.toHaveBeenCalled();
+  });
+
+  it('submits verifier ban modal with final notes', async () => {
+    const handler = new InteractionHandler(
+      client,
+      notificationManager,
+      userModerationService,
+      securityActionService,
+      configService,
+      verificationEventRepository,
+      threadManager,
+      adminActionRepository
+    );
+    const interaction = {
+      customId: 'verification:ban_modal:user-1',
+      guildId: 'guild-1',
+      user: { id: 'admin-1' } as User,
+      fields: {
+        getTextInputValue: jest.fn(() => 'admin final notes'),
+      },
+      deferReply: jest.fn().mockResolvedValue(undefined),
+      editReply: jest.fn().mockResolvedValue(undefined),
+      reply: jest.fn().mockResolvedValue(undefined),
+      followUp: jest.fn().mockResolvedValue(undefined),
+      replied: false,
+      deferred: false,
+    } as unknown as ModalSubmitInteraction;
+    grantOnlyBanMembersPermission(interaction);
+
+    await handler.handleModalSubmit(interaction);
+
+    expect(userModerationService.banUser).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'user-1' }),
+      'admin final notes',
+      interaction.user
+    );
+    expect(interaction.deferReply).toHaveBeenCalledWith({ flags: MessageFlags.Ephemeral });
+    expect(interaction.editReply).toHaveBeenCalledWith({
+      content: 'User <@user-1> has been banned from the server.',
+    });
+  });
+
+  it('submits verifier ban modal with the default reason when notes are blank', async () => {
+    const handler = new InteractionHandler(
+      client,
+      notificationManager,
+      userModerationService,
+      securityActionService,
+      configService,
+      verificationEventRepository,
+      threadManager,
+      adminActionRepository
+    );
+    const interaction = {
+      customId: 'verification:ban_modal:user-1',
+      guildId: 'guild-1',
+      user: { id: 'admin-1' } as User,
+      fields: {
+        getTextInputValue: jest.fn(() => '   '),
+      },
+      deferReply: jest.fn().mockResolvedValue(undefined),
+      editReply: jest.fn().mockResolvedValue(undefined),
+      reply: jest.fn().mockResolvedValue(undefined),
+      followUp: jest.fn().mockResolvedValue(undefined),
+      replied: false,
+      deferred: false,
+    } as unknown as ModalSubmitInteraction;
+    grantOnlyBanMembersPermission(interaction);
+
+    await handler.handleModalSubmit(interaction);
+
+    expect(userModerationService.banUser).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'user-1' }),
+      'Banned by moderator during verification',
+      interaction.user
+    );
   });
 
   it('handles observed open case button', async () => {

--- a/src/__tests__/unit/InteractionHandler.unit.test.ts
+++ b/src/__tests__/unit/InteractionHandler.unit.test.ts
@@ -531,6 +531,51 @@ describe('InteractionHandler (unit)', () => {
     );
   });
 
+  it('rejects verifier ban modal submission without BanMembers permission', async () => {
+    (client.guilds.fetch as jest.Mock).mockResolvedValue({
+      members: {
+        fetch: jest.fn().mockResolvedValue({
+          permissions: { has: jest.fn().mockReturnValue(false) },
+        }),
+      },
+    });
+    const handler = new InteractionHandler(
+      client,
+      notificationManager,
+      userModerationService,
+      securityActionService,
+      configService,
+      verificationEventRepository,
+      threadManager,
+      adminActionRepository
+    );
+    const interaction = {
+      customId: 'verification:ban_modal:user-1',
+      guildId: 'guild-1',
+      user: { id: 'viewer-1' } as User,
+      memberPermissions: { has: jest.fn().mockReturnValue(false) },
+      fields: {
+        getTextInputValue: jest.fn(),
+      },
+      deferReply: jest.fn().mockResolvedValue(undefined),
+      editReply: jest.fn().mockResolvedValue(undefined),
+      reply: jest.fn().mockResolvedValue(undefined),
+      followUp: jest.fn().mockResolvedValue(undefined),
+      replied: false,
+      deferred: false,
+    } as unknown as ModalSubmitInteraction;
+
+    await handler.handleModalSubmit(interaction);
+
+    expect(userModerationService.banUser).not.toHaveBeenCalled();
+    expect(interaction.fields.getTextInputValue).not.toHaveBeenCalled();
+    expect(interaction.deferReply).not.toHaveBeenCalled();
+    expect(interaction.reply).toHaveBeenCalledWith({
+      content: 'You need Ban Members permission to ban a user.',
+      flags: MessageFlags.Ephemeral,
+    });
+  });
+
   it('handles observed open case button', async () => {
     const handler = new InteractionHandler(
       client,

--- a/src/controllers/InteractionHandler.ts
+++ b/src/controllers/InteractionHandler.ts
@@ -51,6 +51,9 @@ dotenv.config();
 
 const OBSERVED_ACTION_MODAL_REASON_FIELD_ID = 'observed_ban_reason';
 const OBSERVED_BAN_DEFAULT_REASON = 'Banned from observed suspicious notification';
+const VERIFICATION_BAN_MODAL_PREFIX = 'verification:ban_modal';
+const VERIFICATION_BAN_NOTES_FIELD_ID = 'verification_ban_notes';
+const VERIFICATION_BAN_DEFAULT_REASON = 'Banned by moderator during verification';
 
 type UserResolution =
   | { status: 'found'; userId: string }
@@ -161,7 +164,7 @@ export class InteractionHandler implements IInteractionHandler {
             );
             return;
           }
-          await this.handleBanButton(interaction, guildId, targetUserId);
+          await this.handleBanButton(interaction, targetUserId);
           break;
         case 'thread':
           if (
@@ -245,31 +248,20 @@ export class InteractionHandler implements IInteractionHandler {
     }
   }
 
-  private async handleBanButton(
-    interaction: ButtonInteraction,
-    guildId: string,
-    userId: string
-  ): Promise<void> {
-    await interaction.deferUpdate();
+  private async handleBanButton(interaction: ButtonInteraction, userId: string): Promise<void> {
+    const modal = new ModalBuilder()
+      .setCustomId(`${VERIFICATION_BAN_MODAL_PREFIX}:${userId}`)
+      .setTitle('Confirm User Ban');
+    const notesInput = new TextInputBuilder()
+      .setCustomId(VERIFICATION_BAN_NOTES_FIELD_ID)
+      .setLabel('Final notes (optional)')
+      .setStyle(TextInputStyle.Paragraph)
+      .setRequired(false)
+      .setMaxLength(500)
+      .setPlaceholder('Submitting this form bans the user. Add notes for the audit log.');
 
-    try {
-      const guild = await this.client.guilds.fetch(guildId);
-      const member = await guild.members.fetch(userId);
-
-      const banReason = 'Banned by moderator during verification (button)';
-      await this.userModerationService.banUser(member, banReason, interaction.user);
-
-      await interaction.followUp({
-        content: `User <@${userId}> has been banned from the server.`,
-        flags: MessageFlags.Ephemeral,
-      });
-    } catch (error) {
-      console.error('Error banning user:', error);
-      await interaction.followUp({
-        content: 'An error occurred while banning the user.',
-        flags: MessageFlags.Ephemeral,
-      });
-    }
+    modal.addComponents(new ActionRowBuilder<TextInputBuilder>().addComponents(notesInput));
+    await interaction.showModal(modal);
   }
 
   private async handleThreadButton(
@@ -439,6 +431,10 @@ export class InteractionHandler implements IInteractionHandler {
         await this.handleSetupVerificationModalSubmit(interaction);
         return;
       default:
+        if (interaction.customId.startsWith(`${VERIFICATION_BAN_MODAL_PREFIX}:`)) {
+          await this.handleVerificationBanModalSubmit(interaction);
+          return;
+        }
         if (interaction.customId.startsWith(`${REPORT_MESSAGE_MODAL_PREFIX}:`)) {
           await this.handleReportMessageModalSubmit(interaction);
           return;
@@ -450,6 +446,60 @@ export class InteractionHandler implements IInteractionHandler {
         console.log(
           `[InteractionHandler] Ignoring unknown modal submission: ${interaction.customId}`
         );
+    }
+  }
+
+  private async handleVerificationBanModalSubmit(
+    interaction: ModalSubmitInteraction
+  ): Promise<void> {
+    if (!interaction.guildId) {
+      await interaction.reply({
+        content: 'This action can only be performed in a server.',
+        flags: MessageFlags.Ephemeral,
+      });
+      return;
+    }
+
+    const userId = interaction.customId.slice(`${VERIFICATION_BAN_MODAL_PREFIX}:`.length);
+    if (!userId) {
+      await interaction.reply({
+        content: 'Unknown ban action.',
+        flags: MessageFlags.Ephemeral,
+      });
+      return;
+    }
+
+    if (
+      !(await this.hasAnyPermission(interaction, interaction.guildId, [
+        PermissionFlagsBits.BanMembers,
+      ]))
+    ) {
+      await this.replyPermissionDenied(
+        interaction,
+        'You need Ban Members permission to ban a user.'
+      );
+      return;
+    }
+
+    const finalNotes = interaction.fields.getTextInputValue(VERIFICATION_BAN_NOTES_FIELD_ID).trim();
+    const banReason = finalNotes || VERIFICATION_BAN_DEFAULT_REASON;
+
+    await interaction.deferReply({ flags: MessageFlags.Ephemeral });
+
+    try {
+      const guild = await this.client.guilds.fetch(interaction.guildId);
+      const member = await guild.members.fetch(userId);
+
+      await this.userModerationService.banUser(member, banReason, interaction.user);
+
+      await interaction.editReply({
+        content: `User <@${userId}> has been banned from the server.`,
+      });
+    } catch (error) {
+      console.error('Error banning user:', error);
+      await interaction.editReply({
+        content: 'An error occurred while banning the user.',
+      });
     }
   }
 


### PR DESCRIPTION
[AGENT]

## What changed
- Changed verifier `Ban User` actions to open a Discord confirmation modal instead of banning immediately.
- Added optional final notes on verifier ban submission, using them as the ban reason/admin action notes when provided.
- Added unit coverage for modal display, BanMembers-only access, custom notes, and blank-note default behavior.

## Why
Verifier bans were a destructive one-click action and did not let admins leave final notes before resolving the case.

## Test plan
- `npm test -- InteractionHandler.unit.test.ts`
- `npm run build`
- `npm run lint`
- `npm run format:check`

## Risk notes
- The modal submission re-checks `BanMembers` before banning.
- Blank notes preserve a default ban reason.