### PR TITLE
Wire PostHog production environment

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -131,7 +131,11 @@ jobs:
           set -euo pipefail
 
           CURRENT_TD_ARN="$(aws ecs describe-services --cluster "$ECS_CLUSTER" --services "$ECS_SERVICE" --query 'services[0].taskDefinition' --output text)"
-          aws ecs describe-task-definition --task-definition "$CURRENT_TD_ARN" --query 'taskDefinition' > taskdef.json
+          CURRENT_TD_FAMILY="$(aws ecs describe-task-definition --task-definition "$CURRENT_TD_ARN" --query 'taskDefinition.family' --output text)"
+          BASE_TD_ARN="$(aws ecs describe-task-definition --task-definition "$CURRENT_TD_FAMILY" --query 'taskDefinition.taskDefinitionArn' --output text)"
+
+          echo "Using task definition baseline: $BASE_TD_ARN"
+          aws ecs describe-task-definition --task-definition "$BASE_TD_ARN" --query 'taskDefinition' > taskdef.json
 
           jq --arg IMAGE "$IMAGE" '
             .containerDefinitions |= map(if .name == "drasil" then .image = $IMAGE else . end)

--- a/docs/deploy/aws.md
+++ b/docs/deploy/aws.md
@@ -87,7 +87,9 @@ aws secretsmanager put-secret-value \
 
 Repeat for the other secrets.
 
-`POSTHOG_PROJECT_API_KEY` is the PostHog project token used by the server SDK.
+`POSTHOG_PROJECT_API_KEY` is the PostHog project API key used by the server SDK.
+The default `POSTHOG_HOST` is the US ingestion endpoint; set `posthog_host` to
+`https://eu.i.posthog.com` before first apply when EU data residency is required.
 `OBSERVABILITY_HASH_KEY` should be a high-entropy random value that stays stable
 for the environment so anonymous analytics identifiers remain stable across task
 restarts.

--- a/docs/deploy/aws.md
+++ b/docs/deploy/aws.md
@@ -69,11 +69,13 @@ applying `infra/aws/prod` so this stack reuses it.
 
 ## 3) Set production secrets
 
-Terraform creates three Secrets Manager secrets:
+Terraform creates these Secrets Manager secrets:
 
 - `drasil/prod/DISCORD_TOKEN`
 - `drasil/prod/OPENAI_API_KEY`
 - `drasil/prod/DATABASE_URL`
+- `drasil/prod/OBSERVABILITY_HASH_KEY`
+- `drasil/prod/POSTHOG_PROJECT_API_KEY`
 
 Set their values (console or CLI). Example:
 
@@ -84,6 +86,11 @@ aws secretsmanager put-secret-value \
 ```
 
 Repeat for the other secrets.
+
+`POSTHOG_PROJECT_API_KEY` is the PostHog project token used by the server SDK.
+`OBSERVABILITY_HASH_KEY` should be a high-entropy random value that stays stable
+for the environment so anonymous analytics identifiers remain stable across task
+restarts.
 
 ## 4) Configure GitHub Actions deploy variables
 
@@ -105,7 +112,7 @@ It will:
 
 - build and push the container image to ECR
 - tag it with the commit SHA
-- register a new ECS task definition revision pinned to that image
+- register a new ECS task definition revision pinned to that image, using the latest active task definition in the service family as the baseline
 - update the ECS service to the new task definition and wait for it to stabilize
 
 ## 6) Observability and cost controls
@@ -126,6 +133,7 @@ Re-run the deploy workflow and set the `ref` input to an older commit SHA. The w
 - The Terraform-managed task definition uses a placeholder image tag (`:bootstrap`). The deploy workflow registers task definitions using immutable commit SHA tags.
 - `desired_count` defaults to `1` for production uptime. If you are bootstrapping before the first image push, set `desired_count=0` temporarily and switch back to `1` after the first deploy.
 - The ECS service task definition is updated by the deploy workflow; Terraform intentionally ignores `task_definition` drift to avoid fighting deploys.
+- After Terraform changes task definition environment variables or secrets, run `terraform apply`, then run the deploy workflow so the service adopts a new image revision based on Terraform's latest task definition revision.
 - If/when we add sharding, we can increase `desired_count` and/or move to a more controlled rollout.
 - If you prefer private subnets, add a NAT Gateway and set `assign_public_ip = false` in `infra/aws/prod/main.tf`.
 - Secrets Manager automatic rotation is intentionally not configured yet; it requires a rotation Lambda and an ops runbook.

--- a/infra/aws/README.md
+++ b/infra/aws/README.md
@@ -35,6 +35,10 @@ terraform apply
 
 4. Set secret values in AWS Secrets Manager (created by Terraform) and then deploy the container image.
 
+The production stack creates Secrets Manager entries for `DISCORD_TOKEN`,
+`OPENAI_API_KEY`, `DATABASE_URL`, `OBSERVABILITY_HASH_KEY`, and
+`POSTHOG_PROJECT_API_KEY`.
+
 ## Optional intelligence bucket
 
 Use `infra/aws/intel` when you want a lightweight private bucket for screenshots and case JSON.

--- a/infra/aws/prod/main.tf
+++ b/infra/aws/prod/main.tf
@@ -172,6 +172,20 @@ resource "aws_secretsmanager_secret" "database_url" {
   kms_key_id              = aws_kms_key.prod.arn
 }
 
+resource "aws_secretsmanager_secret" "observability_hash_key" {
+  name = "${local.secrets_prefix}/OBSERVABILITY_HASH_KEY"
+  #checkov:skip=CKV2_AWS_57:Automatic rotation requires dedicated rotation Lambda + runbook and is deferred intentionally.
+  recovery_window_in_days = 7
+  kms_key_id              = aws_kms_key.prod.arn
+}
+
+resource "aws_secretsmanager_secret" "posthog_project_api_key" {
+  name = "${local.secrets_prefix}/POSTHOG_PROJECT_API_KEY"
+  #checkov:skip=CKV2_AWS_57:Automatic rotation requires dedicated rotation Lambda + runbook and is deferred intentionally.
+  recovery_window_in_days = 7
+  kms_key_id              = aws_kms_key.prod.arn
+}
+
 resource "aws_default_security_group" "main" {
   vpc_id = aws_vpc.main.id
 
@@ -211,7 +225,9 @@ data "aws_iam_policy_document" "ecs_task_execution_secrets" {
     resources = [
       aws_secretsmanager_secret.discord_token.arn,
       aws_secretsmanager_secret.openai_api_key.arn,
-      aws_secretsmanager_secret.database_url.arn
+      aws_secretsmanager_secret.database_url.arn,
+      aws_secretsmanager_secret.observability_hash_key.arn,
+      aws_secretsmanager_secret.posthog_project_api_key.arn
     ]
   }
 
@@ -283,6 +299,18 @@ resource "aws_ecs_task_definition" "bot" {
         {
           name  = "DRASIL_USER_INSTALL_REPORTING_ENABLED"
           value = "true"
+        },
+        {
+          name  = "POSTHOG_HOST"
+          value = var.posthog_host
+        },
+        {
+          name  = "POSTHOG_PRODUCT_ANALYTICS_ENABLED"
+          value = tostring(var.posthog_product_analytics_enabled)
+        },
+        {
+          name  = "POSTHOG_DEBUG"
+          value = tostring(var.posthog_debug)
         }
       ]
       secrets = [
@@ -297,6 +325,14 @@ resource "aws_ecs_task_definition" "bot" {
         {
           name      = "DATABASE_URL"
           valueFrom = aws_secretsmanager_secret.database_url.arn
+        },
+        {
+          name      = "OBSERVABILITY_HASH_KEY"
+          valueFrom = aws_secretsmanager_secret.observability_hash_key.arn
+        },
+        {
+          name      = "POSTHOG_PROJECT_API_KEY"
+          valueFrom = aws_secretsmanager_secret.posthog_project_api_key.arn
         }
       ]
       logConfiguration = {

--- a/infra/aws/prod/outputs.tf
+++ b/infra/aws/prod/outputs.tf
@@ -35,9 +35,11 @@ output "github_oidc_provider_arn" {
 
 output "secrets" {
   value = {
-    DISCORD_TOKEN  = aws_secretsmanager_secret.discord_token.arn
-    OPENAI_API_KEY = aws_secretsmanager_secret.openai_api_key.arn
-    DATABASE_URL   = aws_secretsmanager_secret.database_url.arn
+    DISCORD_TOKEN           = aws_secretsmanager_secret.discord_token.arn
+    OPENAI_API_KEY          = aws_secretsmanager_secret.openai_api_key.arn
+    DATABASE_URL            = aws_secretsmanager_secret.database_url.arn
+    OBSERVABILITY_HASH_KEY  = aws_secretsmanager_secret.observability_hash_key.arn
+    POSTHOG_PROJECT_API_KEY = aws_secretsmanager_secret.posthog_project_api_key.arn
   }
   description = "Secrets Manager secret ARNs created for this environment."
 }

--- a/infra/aws/prod/variables.tf
+++ b/infra/aws/prod/variables.tf
@@ -54,13 +54,13 @@ variable "container_insights" {
 
 variable "posthog_host" {
   type        = string
-  description = "PostHog ingestion host for product analytics."
+  description = "PostHog ingestion host for product analytics. Use https://eu.i.posthog.com instead when EU data residency is required."
   default     = "https://us.i.posthog.com"
 }
 
 variable "posthog_product_analytics_enabled" {
   type        = bool
-  description = "Whether the Drasil product analytics exporter is enabled when a PostHog project token is configured."
+  description = "Whether the Drasil product analytics exporter is enabled when a PostHog project API key is configured."
   default     = true
 }
 

--- a/infra/aws/prod/variables.tf
+++ b/infra/aws/prod/variables.tf
@@ -52,6 +52,24 @@ variable "container_insights" {
   default     = true
 }
 
+variable "posthog_host" {
+  type        = string
+  description = "PostHog ingestion host for product analytics."
+  default     = "https://us.i.posthog.com"
+}
+
+variable "posthog_product_analytics_enabled" {
+  type        = bool
+  description = "Whether the Drasil product analytics exporter is enabled when a PostHog project token is configured."
+  default     = true
+}
+
+variable "posthog_debug" {
+  type        = bool
+  description = "Enable PostHog SDK debug logging in the ECS task. Keep false in production except during short smoke tests."
+  default     = false
+}
+
 variable "github_repo" {
   type        = string
   description = "GitHub repo in OWNER/REPO format used to restrict OIDC role assumption."


### PR DESCRIPTION
[AGENT]
## Summary
- Add Terraform-managed Secrets Manager entries for `OBSERVABILITY_HASH_KEY` and `POSTHOG_PROJECT_API_KEY`.
- Wire those secrets plus explicit PostHog runtime switches into the ECS task definition.
- Update deploy workflow to base image-only task definition revisions on the latest active family revision, so Terraform task-definition env/secret changes can flow into the next deploy.
- Update AWS deployment docs with the new secret names and apply/deploy sequence.

## Test Plan
- `terraform fmt -check -recursive`
- `terraform -chdir="infra/aws/prod" init -backend=false`
- `terraform -chdir="infra/aws/prod" validate`
- `git diff --check`

## Post-Merge Ops
- Merging this PR does not run `terraform apply`.
- After merge, apply `infra/aws/prod`, set the two new Secrets Manager secret values, then rerun Deploy (prod) so the ECS service adopts the latest Terraform task definition baseline.