### PR TITLE
Add detection testing mode

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,12 @@ NODE_ENV=development
 # Optional comma-separated Discord user IDs allowed to audit global detections
 # DRASIL_GLOBAL_ADMIN_IDS=123456789012345678
 
+# Optional pre-live/manual testing mode.
+# Records detections and reports normally, but excludes new events from future accounting.
+# Keep unset or false in production.
+# DRASIL_DETECTION_TEST_MODE=false
+# DRASIL_DETECTION_TEST_RUN_ID=manual-test-001
+
 # Password for the dedicated 'prisma' database user (used during local reset)
 PRISMA_DB_PASSWORD=replace-with-a-strong-password
 

--- a/prisma/migrations/20260526000000_enable_rls_for_prisma_migrations/migration.sql
+++ b/prisma/migrations/20260526000000_enable_rls_for_prisma_migrations/migration.sql
@@ -1,0 +1,16 @@
+ALTER TABLE IF EXISTS "public"."_prisma_migrations" ENABLE ROW LEVEL SECURITY;
+
+DO $$
+BEGIN
+  IF to_regclass('public._prisma_migrations') IS NOT NULL THEN
+    REVOKE ALL ON TABLE "public"."_prisma_migrations" FROM PUBLIC;
+
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'anon') THEN
+      REVOKE ALL ON TABLE "public"."_prisma_migrations" FROM anon;
+    END IF;
+
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'authenticated') THEN
+      REVOKE ALL ON TABLE "public"."_prisma_migrations" FROM authenticated;
+    END IF;
+  END IF;
+END $$;

--- a/src/__tests__/unit/DetectionOrchestrator.unit.test.ts
+++ b/src/__tests__/unit/DetectionOrchestrator.unit.test.ts
@@ -537,4 +537,66 @@ describe('DetectionOrchestrator (unit)', () => {
       },
     });
   });
+
+  it('excludes suspicious new joins from accounting in detection test mode', async () => {
+    const originalTestMode = process.env.DRASIL_DETECTION_TEST_MODE;
+    const originalTestRunId = process.env.DRASIL_DETECTION_TEST_RUN_ID;
+    process.env.DRASIL_DETECTION_TEST_MODE = 'true';
+    process.env.DRASIL_DETECTION_TEST_RUN_ID = 'join-test-run';
+    gptService.analyzeProfile.mockResolvedValue(
+      makeGptAnalysis({
+        result: 'SUSPICIOUS',
+        confidence: 0.9,
+        reasons: ['AI analysis flagged user/message context as suspicious'],
+        reasonCodes: ['unusual_username'],
+        primarySignal: 'username',
+        summary: 'Username context looks suspicious.',
+      })
+    );
+
+    try {
+      const orchestrator = new DetectionOrchestrator(
+        heuristicService,
+        gptService,
+        detectionEventsRepository,
+        userRepository,
+        serverRepository
+      );
+
+      const profile: UserProfileData = {
+        username: 'old-user',
+        accountCreatedAt: new Date('2020-01-01T00:00:00.000Z'),
+        joinedServerAt: new Date('2020-01-01T00:00:00.000Z'),
+        recentMessages: [],
+      };
+
+      await orchestrator.detectNewJoin(serverId, userId, profile);
+
+      const events = await detectionEventsRepository.findByServerAndUser(serverId, userId);
+      expect(events).toHaveLength(1);
+      expect(events[0].metadata).toMatchObject({
+        join: true,
+        test_mode: true,
+        test_run_id: 'join-test-run',
+        excluded_from_accounting: true,
+        accounting_exclusion_scope: 'server',
+        accounting_excluded_by: 'system:test-mode',
+        accounting_exclusion_reason: 'Detection test mode',
+      });
+      await expect(
+        detectionEventsRepository.findCountedByServerAndUser(serverId, userId)
+      ).resolves.toHaveLength(0);
+    } finally {
+      if (originalTestMode === undefined) {
+        delete process.env.DRASIL_DETECTION_TEST_MODE;
+      } else {
+        process.env.DRASIL_DETECTION_TEST_MODE = originalTestMode;
+      }
+      if (originalTestRunId === undefined) {
+        delete process.env.DRASIL_DETECTION_TEST_RUN_ID;
+      } else {
+        process.env.DRASIL_DETECTION_TEST_RUN_ID = originalTestRunId;
+      }
+    }
+  });
 });

--- a/src/__tests__/unit/DetectionOrchestrator.unit.test.ts
+++ b/src/__tests__/unit/DetectionOrchestrator.unit.test.ts
@@ -104,6 +104,55 @@ describe('DetectionOrchestrator (unit)', () => {
     expect(events[0].metadata).toMatchObject({ content: 'free nitro' });
   });
 
+  it('excludes new detection events from accounting in detection test mode', async () => {
+    const originalTestMode = process.env.DRASIL_DETECTION_TEST_MODE;
+    const originalTestRunId = process.env.DRASIL_DETECTION_TEST_RUN_ID;
+    process.env.DRASIL_DETECTION_TEST_MODE = 'true';
+    process.env.DRASIL_DETECTION_TEST_RUN_ID = 'unit-run-1';
+    heuristicService.analyzeMessage.mockReturnValue({
+      result: 'SUSPICIOUS',
+      reasons: ['Suspicious keywords'],
+    });
+
+    try {
+      const orchestrator = new DetectionOrchestrator(
+        heuristicService,
+        gptService,
+        detectionEventsRepository,
+        userRepository,
+        serverRepository
+      );
+
+      await orchestrator.detectMessage(serverId, userId, 'free nitro');
+
+      const events = await detectionEventsRepository.findByServerAndUser(serverId, userId);
+      expect(events).toHaveLength(1);
+      expect(events[0].metadata).toMatchObject({
+        content: 'free nitro',
+        test_mode: true,
+        test_run_id: 'unit-run-1',
+        excluded_from_accounting: true,
+        accounting_exclusion_scope: 'server',
+        accounting_excluded_by: 'system:test-mode',
+        accounting_exclusion_reason: 'Detection test mode',
+      });
+      await expect(
+        detectionEventsRepository.findCountedByServerAndUser(serverId, userId)
+      ).resolves.toHaveLength(0);
+    } finally {
+      if (originalTestMode === undefined) {
+        delete process.env.DRASIL_DETECTION_TEST_MODE;
+      } else {
+        process.env.DRASIL_DETECTION_TEST_MODE = originalTestMode;
+      }
+      if (originalTestRunId === undefined) {
+        delete process.env.DRASIL_DETECTION_TEST_RUN_ID;
+      } else {
+        process.env.DRASIL_DETECTION_TEST_RUN_ID = originalTestRunId;
+      }
+    }
+  });
+
   it('uses GPT for new accounts and returns suspicious when GPT flags it', async () => {
     heuristicService.analyzeMessage.mockReturnValue({ result: 'OK', reasons: [] });
     gptService.analyzeProfile.mockResolvedValue(

--- a/src/__tests__/unit/SecurityActionService.unit.test.ts
+++ b/src/__tests__/unit/SecurityActionService.unit.test.ts
@@ -1089,6 +1089,48 @@ describe('SecurityActionService (unit)', () => {
     expect(threadManager.createVerificationThread).toHaveBeenCalled();
   });
 
+  it('excludes manual admin flags from accounting in detection test mode', async () => {
+    const originalTestMode = process.env.DRASIL_DETECTION_TEST_MODE;
+    const originalTestRunId = process.env.DRASIL_DETECTION_TEST_RUN_ID;
+    process.env.DRASIL_DETECTION_TEST_MODE = 'true';
+    process.env.DRASIL_DETECTION_TEST_RUN_ID = 'manual-flag-test-run';
+    const guildId = 'guild-manual-flag-test-mode';
+    const userId = 'user-manual-flag-test-mode';
+    const moderatorId = 'admin-manual-flag-test-mode';
+    const member = buildMember(guildId, userId);
+
+    try {
+      await buildService().handleManualFlag(member, { id: moderatorId } as User, 'manual flag');
+
+      const detectionEvents = await detectionEventsRepository.findByServerAndUser(guildId, userId);
+      expect(detectionEvents).toHaveLength(1);
+      expect(detectionEvents[0].metadata).toMatchObject({
+        type: 'admin_flag',
+        adminId: moderatorId,
+        test_mode: true,
+        test_run_id: 'manual-flag-test-run',
+        excluded_from_accounting: true,
+        accounting_exclusion_scope: 'server',
+        accounting_excluded_by: 'system:test-mode',
+        accounting_exclusion_reason: 'Detection test mode',
+      });
+      await expect(
+        detectionEventsRepository.findCountedByServerAndUser(guildId, userId)
+      ).resolves.toHaveLength(0);
+    } finally {
+      if (originalTestMode === undefined) {
+        delete process.env.DRASIL_DETECTION_TEST_MODE;
+      } else {
+        process.env.DRASIL_DETECTION_TEST_MODE = originalTestMode;
+      }
+      if (originalTestRunId === undefined) {
+        delete process.env.DRASIL_DETECTION_TEST_RUN_ID;
+      } else {
+        process.env.DRASIL_DETECTION_TEST_RUN_ID = originalTestRunId;
+      }
+    }
+  });
+
   it('adds a user report to an existing pending case without creating a duplicate case', async () => {
     const guildId = 'guild-4a';
     const userId = 'user-4a';

--- a/src/__tests__/unit/SecurityActionService.unit.test.ts
+++ b/src/__tests__/unit/SecurityActionService.unit.test.ts
@@ -416,6 +416,50 @@ describe('SecurityActionService (unit)', () => {
     );
   });
 
+  it('excludes user reports from accounting in detection test mode', async () => {
+    const originalTestMode = process.env.DRASIL_DETECTION_TEST_MODE;
+    const originalTestRunId = process.env.DRASIL_DETECTION_TEST_RUN_ID;
+    process.env.DRASIL_DETECTION_TEST_MODE = 'true';
+    process.env.DRASIL_DETECTION_TEST_RUN_ID = 'report-test-run';
+    const guildId = 'guild-report-test-mode';
+    const userId = 'user-report-test-mode';
+    const member = buildMember(guildId, userId);
+
+    try {
+      await buildService().handleUserReport(
+        member,
+        { id: 'reporter-test-mode' } as User,
+        'reported'
+      );
+
+      const detectionEvents = await detectionEventsRepository.findByServerAndUser(guildId, userId);
+      expect(detectionEvents).toHaveLength(1);
+      expect(detectionEvents[0].metadata).toMatchObject({
+        type: 'user_report',
+        test_mode: true,
+        test_run_id: 'report-test-run',
+        excluded_from_accounting: true,
+        accounting_exclusion_scope: 'server',
+        accounting_excluded_by: 'system:test-mode',
+        accounting_exclusion_reason: 'Detection test mode',
+      });
+      await expect(
+        detectionEventsRepository.findCountedByServerAndUser(guildId, userId)
+      ).resolves.toHaveLength(0);
+    } finally {
+      if (originalTestMode === undefined) {
+        delete process.env.DRASIL_DETECTION_TEST_MODE;
+      } else {
+        process.env.DRASIL_DETECTION_TEST_MODE = originalTestMode;
+      }
+      if (originalTestRunId === undefined) {
+        delete process.env.DRASIL_DETECTION_TEST_RUN_ID;
+      } else {
+        process.env.DRASIL_DETECTION_TEST_RUN_ID = originalTestRunId;
+      }
+    }
+  });
+
   it('stores enabled report AI triage as sanitized detection metadata and notification context', async () => {
     const guildId = 'guild-report-ai';
     const userId = 'user-report-ai';
@@ -592,6 +636,47 @@ describe('SecurityActionService (unit)', () => {
     });
     expect(threadManager.createVerificationThread).not.toHaveBeenCalled();
     expect(userModerationService.restrictUser).not.toHaveBeenCalled();
+  });
+
+  it('marks user-installed message reports as globally excluded in detection test mode', async () => {
+    const originalTestMode = process.env.DRASIL_DETECTION_TEST_MODE;
+    const originalTestRunId = process.env.DRASIL_DETECTION_TEST_RUN_ID;
+    process.env.DRASIL_DETECTION_TEST_MODE = 'true';
+    process.env.DRASIL_DETECTION_TEST_RUN_ID = 'global-report-test-run';
+
+    try {
+      await buildService().handleMessageReport(
+        { id: 'user-global-test', username: 'target-user' } as User,
+        { id: 'reporter-global-test' } as User,
+        {
+          messageId: 'message-global-test',
+          channelId: 'dm-channel-global-test',
+          content: 'suspicious DM',
+        }
+      );
+
+      const detectionEvent = await detectionEventsRepository.findById('det-1');
+      expect(detectionEvent?.metadata).toMatchObject({
+        type: 'user_installed_message_report',
+        test_mode: true,
+        test_run_id: 'global-report-test-run',
+        excluded_from_accounting: true,
+        accounting_exclusion_scope: 'global',
+        accounting_excluded_by: 'system:test-mode',
+        accounting_exclusion_reason: 'Detection test mode',
+      });
+    } finally {
+      if (originalTestMode === undefined) {
+        delete process.env.DRASIL_DETECTION_TEST_MODE;
+      } else {
+        process.env.DRASIL_DETECTION_TEST_MODE = originalTestMode;
+      }
+      if (originalTestRunId === undefined) {
+        delete process.env.DRASIL_DETECTION_TEST_RUN_ID;
+      } else {
+        process.env.DRASIL_DETECTION_TEST_RUN_ID = originalTestRunId;
+      }
+    }
   });
 
   it('posts observed alerts for message reports from the same guild', async () => {

--- a/src/services/DetectionOrchestrator.ts
+++ b/src/services/DetectionOrchestrator.ts
@@ -14,6 +14,7 @@ import { TYPES } from '../di/symbols';
 import { meetsConfidenceLevel } from '../utils/confidence';
 import { getConfidenceBucket } from '../utils/analyticsHelpers';
 import { DetectionType } from '../repositories/types';
+import { withDetectionTestingMetadata } from '../utils/detectionEventAccounting';
 import {
   IProductAnalyticsService,
   NOOP_PRODUCT_ANALYTICS_SERVICE,
@@ -286,10 +287,10 @@ export class DetectionOrchestrator implements IDetectionOrchestrator {
           reasons: result.reasons,
           detected_at: new Date(),
           // message_id and channel_id are not needed here; context is available later via event payload
-          metadata: {
+          metadata: withDetectionTestingMetadata({
             content: content,
             ...(gptAnalysis ? { gpt: this.createGptMetadata(gptAnalysis) } : {}),
-          },
+          }),
         });
 
         result.detectionEventId = createdEvent.id;
@@ -375,7 +376,10 @@ export class DetectionOrchestrator implements IDetectionOrchestrator {
           reasons: initialResult.reasons,
           detected_at: new Date(),
           // No message_id or channel_id for join events
-          metadata: { join: true, gpt: this.createGptMetadata(gptAnalysis) },
+          metadata: withDetectionTestingMetadata({
+            join: true,
+            gpt: this.createGptMetadata(gptAnalysis),
+          }),
         });
 
         initialResult.detectionEventId = createdEvent.id;

--- a/src/services/SecurityActionService.ts
+++ b/src/services/SecurityActionService.ts
@@ -33,7 +33,10 @@ import {
   appendVerificationActionFailure,
   type VerificationActionFailureKind,
 } from '../utils/verificationActionFailures';
-import { createAccountingExclusionMetadata } from '../utils/detectionEventAccounting';
+import {
+  createAccountingExclusionMetadata,
+  withDetectionTestingMetadata,
+} from '../utils/detectionEventAccounting';
 import {
   IProductAnalyticsService,
   NOOP_PRODUCT_ANALYTICS_SERVICE,
@@ -271,7 +274,10 @@ export class SecurityActionService implements ISecurityActionService {
       detected_at: new Date(),
       message_id: messageId,
       channel_id: channelId,
-      metadata: messageContent ? { content: messageContent } : undefined,
+      metadata: withDetectionTestingMetadata(
+        messageContent ? { content: messageContent } : undefined,
+        'server'
+      ),
     });
   }
 
@@ -1088,7 +1094,10 @@ export class SecurityActionService implements ISecurityActionService {
         confidence: 1.0,
         reasons: [`Manually flagged by admin ${moderator.id}. ${reasonText}`],
         detected_at: new Date(),
-        metadata: { type: 'admin_flag', adminId: moderator.id, reason: reason ?? reasonText },
+        metadata: withDetectionTestingMetadata(
+          { type: 'admin_flag', adminId: moderator.id, reason: reason ?? reasonText },
+          'server'
+        ),
       });
 
       const detectionResult: DetectionResult = {
@@ -1154,13 +1163,16 @@ export class SecurityActionService implements ISecurityActionService {
         confidence: 1.0,
         reasons: [`Reported by user ${reporter.id}. ${reasonText}`],
         detected_at: new Date(),
-        metadata: {
-          type: 'user_report',
-          reporterId: reporter.id,
-          content: reason ?? 'User report',
-          reason: reason ?? reasonText,
-          ...(reportAiAnalysis ? { report_ai: reportAiAnalysis } : {}),
-        },
+        metadata: withDetectionTestingMetadata(
+          {
+            type: 'user_report',
+            reporterId: reporter.id,
+            content: reason ?? 'User report',
+            reason: reason ?? reasonText,
+            ...(reportAiAnalysis ? { report_ai: reportAiAnalysis } : {}),
+          },
+          'server'
+        ),
       });
 
       const detectionResult: DetectionResult = {
@@ -1230,7 +1242,7 @@ export class SecurityActionService implements ISecurityActionService {
         reasons: [reason],
         message_id: report.messageId,
         channel_id: report.channelId,
-        metadata,
+        metadata: withDetectionTestingMetadata(metadata, 'global'),
       });
 
       await this.processMessageReportForManagedServers(
@@ -1434,7 +1446,7 @@ export class SecurityActionService implements ISecurityActionService {
       ],
       message_id: isLocalReport ? report.messageId : undefined,
       channel_id: isLocalReport ? report.channelId : undefined,
-      metadata,
+      metadata: withDetectionTestingMetadata(metadata, 'server'),
     });
   }
 

--- a/src/utils/detectionEventAccounting.ts
+++ b/src/utils/detectionEventAccounting.ts
@@ -5,6 +5,13 @@ export const DETECTION_ACCOUNTING_EXCLUSION_SCOPE_METADATA_KEY = 'accounting_exc
 export const DETECTION_ACCOUNTING_EXCLUDED_BY_METADATA_KEY = 'accounting_excluded_by';
 export const DETECTION_ACCOUNTING_EXCLUDED_AT_METADATA_KEY = 'accounting_excluded_at';
 export const DETECTION_ACCOUNTING_EXCLUSION_REASON_METADATA_KEY = 'accounting_exclusion_reason';
+export const DETECTION_TEST_MODE_METADATA_KEY = 'test_mode';
+export const DETECTION_TEST_RUN_ID_METADATA_KEY = 'test_run_id';
+export const DRASIL_DETECTION_TEST_MODE_ENV = 'DRASIL_DETECTION_TEST_MODE';
+export const DRASIL_DETECTION_TEST_RUN_ID_ENV = 'DRASIL_DETECTION_TEST_RUN_ID';
+
+const DETECTION_TEST_MODE_EXCLUDED_BY = 'system:test-mode';
+const DETECTION_TEST_MODE_EXCLUSION_REASON = 'Detection test mode';
 
 interface DetectionAccountingAction {
   action_type: string;
@@ -95,6 +102,31 @@ export function createAccountingExclusionMetadata(
     [DETECTION_ACCOUNTING_EXCLUDED_BY_METADATA_KEY]: moderatorId,
     [DETECTION_ACCOUNTING_EXCLUDED_AT_METADATA_KEY]: new Date().toISOString(),
     [DETECTION_ACCOUNTING_EXCLUSION_REASON_METADATA_KEY]: reason,
+  };
+}
+
+export function isDetectionTestModeEnabled(): boolean {
+  return process.env[DRASIL_DETECTION_TEST_MODE_ENV] === 'true';
+}
+
+export function withDetectionTestingMetadata(
+  metadata?: Record<string, unknown>,
+  scope = 'server'
+): Record<string, unknown> | undefined {
+  if (!isDetectionTestModeEnabled()) {
+    return metadata;
+  }
+
+  const testRunId = process.env[DRASIL_DETECTION_TEST_RUN_ID_ENV]?.trim();
+  return {
+    ...(metadata ?? {}),
+    [DETECTION_TEST_MODE_METADATA_KEY]: true,
+    ...(testRunId ? { [DETECTION_TEST_RUN_ID_METADATA_KEY]: testRunId } : {}),
+    ...createAccountingExclusionMetadata(
+      DETECTION_TEST_MODE_EXCLUDED_BY,
+      DETECTION_TEST_MODE_EXCLUSION_REASON,
+      scope
+    ),
   };
 }
 


### PR DESCRIPTION
[AGENT]

## Summary
- Added DRASIL_DETECTION_TEST_MODE to record new detections/reports normally while excluding them from future accounting.
- Added optional DRASIL_DETECTION_TEST_RUN_ID metadata so manual test batches can be grouped and repeated.
- Covered message detections, join detections, manual flags, server reports, global/user-installed reports, and documented the env flags.
- Includes the Prisma migrations-table RLS hardening migration currently bundled in this branch by explicit owner decision.

## Why
The app is still pre-live, and manual QA detections should remain visible for UI/history validation without affecting future suspicion scoring for test users.

## Test Plan
- npm run build
- npm run lint
- npm test

## Rollout Notes
- Keep DRASIL_DETECTION_TEST_MODE=true only during pre-live/manual testing.
- Turn it off before production launch so real detections count normally.
- Existing configured database detections were separately marked as pre-live test data outside this PR: 4 total, 4 excluded from accounting.
- The bundled Prisma migration hardens access to _prisma_migrations and should be reviewed as part of this PR.