### PR TITLE
Add Supabase RLS guardrails

### DIFF
--- a/docs/security/2026-05-26-supabase-rls-audit.md
+++ b/docs/security/2026-05-26-supabase-rls-audit.md
@@ -1,0 +1,35 @@
+# Supabase RLS Exposure Audit - 2026-05-26
+
+## Scope
+
+- Supabase project: production Drasil Supabase project. The project reference is intentionally omitted from this committed audit note.
+- Schema reviewed: `public`
+- Tables reviewed: `_prisma_migrations`, `admin_actions`, `detection_events`, `server_members`, `servers`, `users`, `verification_events`
+- Method: metadata-only SQL audit. Raw table contents were not exported or reviewed.
+
+## Remediation Timeline
+
+- `2026-03-02`: Initial Prisma schema migration created public application tables.
+- `2026-05-12`: `20260512100000_enable_rls_for_public_tables` enabled RLS and revoked `anon` / `authenticated` table grants for application tables.
+- `2026-05-26`: `20260526000000_enable_rls_for_prisma_migrations` enabled RLS and revoked client grants for `_prisma_migrations`.
+- `2026-05-26`: `20260526001000_revoke_client_default_table_privileges` revoked migration-owner default table privileges for Supabase client roles so future Prisma-created tables do not inherit client access.
+
+## Findings
+
+- Current production posture is locked down: every public table has RLS enabled.
+- Current production posture has no effective `anon` or `authenticated` table privileges on public tables.
+- Current production posture has no public, `anon`, or `authenticated` RLS policies on public tables.
+- `pg_stat_statements` was enabled and had data since `2026-05-08T09:15:57Z`.
+- Since that stats reset, aggregated statements touching Drasil application tables were only observed under `postgres` and `supabase_admin`; no `anon`, `authenticated`, or `authenticator` application-table activity was observed in `pg_stat_statements`.
+- Production row counts at audit time were small: `servers` 2, `users` 28, `server_members` 12, `detection_events` 32, `verification_events` 12, `admin_actions` 1.
+
+## Residual Risk
+
+- `pg_stat_statements` does not prove absence of access before its `2026-05-08` reset.
+- Supabase API gateway / PostgREST logs were not reviewed in this repository-local audit. If longer-retention Supabase logs are available, review requests for `/rest/v1/admin_actions`, `/rest/v1/detection_events`, `/rest/v1/server_members`, `/rest/v1/servers`, `/rest/v1/users`, `/rest/v1/verification_events`, and `/rest/v1/_prisma_migrations` during the exposure window.
+- Supabase-owned `supabase_admin` default table privileges for `anon` and `authenticated` were visible but cannot be changed by the migration role. The new CI guardrail fails for checked owners (`postgres`, `prisma`, and the active migration role) and warns on unmanaged platform-owned defaults.
+
+## Follow-Up Controls
+
+- `npm run db:check:rls` now checks public tables for RLS, effective client-role privileges, client-facing policies, and checked-owner default table privileges.
+- CI runs `npm run db:check:rls` after integration tests, so migrations that create public tables without RLS or leave client access enabled fail before merge.

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "format:check": "prettier --check \"**/*.{ts,js,json,md,mjs}\"",
     "check": "npm run lint:fix && npm run build && npm test",
     "check:full": "npm run format:check && npm run check && npm run test:integration",
-    "check:ci": "npm run format:check && npm run lint && npm run build && npm test && npm run test:integration",
+    "check:ci": "npm run format:check && npm run lint && npm run build && npm test && npm run test:integration && npm run db:check:rls",
     "prisma:generate": "node scripts/prisma-generate.js",
     "prisma:migrate:deploy": "prisma migrate deploy",
     "prisma:migrate:dev": "prisma migrate dev",
@@ -33,6 +33,7 @@
     "prisma:format": "prisma format",
     "db:seed": "prisma db seed",
     "db:reset:local": "npx supabase db reset --local && node scripts/create-prisma-user.js && prisma migrate reset && npm run db:seed",
+    "db:check:rls": "node scripts/check-public-rls.js",
     "intel:upload": "node scripts/upload-intel-case.js"
   },
   "keywords": [

--- a/prisma/migrations/20260526001000_revoke_client_default_table_privileges/migration.sql
+++ b/prisma/migrations/20260526001000_revoke_client_default_table_privileges/migration.sql
@@ -1,0 +1,25 @@
+DO $$
+DECLARE
+  owner_role text;
+  client_role text;
+BEGIN
+  FOREACH owner_role IN ARRAY ARRAY['postgres', 'supabase_admin', 'prisma'] LOOP
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = owner_role)
+      AND pg_has_role(current_user, owner_role, 'MEMBER') THEN
+      EXECUTE format(
+        'ALTER DEFAULT PRIVILEGES FOR ROLE %I IN SCHEMA public REVOKE ALL ON TABLES FROM PUBLIC',
+        owner_role
+      );
+
+      FOREACH client_role IN ARRAY ARRAY['anon', 'authenticated'] LOOP
+        IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = client_role) THEN
+          EXECUTE format(
+            'ALTER DEFAULT PRIVILEGES FOR ROLE %I IN SCHEMA public REVOKE ALL ON TABLES FROM %I',
+            owner_role,
+            client_role
+          );
+        END IF;
+      END LOOP;
+    END IF;
+  END LOOP;
+END $$;

--- a/scripts/check-public-rls.js
+++ b/scripts/check-public-rls.js
@@ -1,0 +1,213 @@
+require('dotenv/config');
+
+const { Client } = require('pg');
+
+const CLIENT_ROLES = ['anon', 'authenticated'];
+const DEFAULT_DEFAULT_ACL_OWNERS = ['postgres', 'prisma'];
+const TABLE_PRIVILEGE_CANDIDATES = [
+  'SELECT',
+  'INSERT',
+  'UPDATE',
+  'DELETE',
+  'TRUNCATE',
+  'REFERENCES',
+  'TRIGGER',
+  'MAINTAIN',
+];
+
+function createConnectionConfig() {
+  const databaseUrl = process.env.TEST_DATABASE_URL || process.env.DATABASE_URL;
+
+  if (!databaseUrl) {
+    throw new Error('Missing TEST_DATABASE_URL or DATABASE_URL for RLS check.');
+  }
+
+  if (process.env.PGSSL_REJECT_UNAUTHORIZED === 'false') {
+    const url = new URL(databaseUrl);
+    url.searchParams.delete('sslmode');
+
+    return {
+      connectionString: url.toString(),
+      ssl: { rejectUnauthorized: false },
+    };
+  }
+
+  return { connectionString: databaseUrl };
+}
+
+function formatList(items) {
+  return items.length > 0 ? items.join(', ') : 'none';
+}
+
+function configuredDefaultAclOwners(currentUser) {
+  const configured = process.env.RLS_CHECK_DEFAULT_ACL_OWNERS;
+  const owners = configured
+    ? configured
+        .split(',')
+        .map((owner) => owner.trim())
+        .filter(Boolean)
+    : DEFAULT_DEFAULT_ACL_OWNERS;
+
+  return new Set([...owners, currentUser]);
+}
+
+async function supportedTablePrivileges(client) {
+  const privileges = [];
+
+  for (const privilege of TABLE_PRIVILEGE_CANDIDATES) {
+    try {
+      await client.query("SELECT has_table_privilege(current_user, 'pg_class'::regclass, $1)", [
+        privilege,
+      ]);
+      privileges.push(privilege);
+    } catch (error) {
+      if (!error.message.includes('unrecognized privilege type')) {
+        throw error;
+      }
+    }
+  }
+
+  return privileges;
+}
+
+async function main() {
+  const client = new Client(createConnectionConfig());
+  await client.connect();
+
+  try {
+    const currentUserResult = await client.query('SELECT current_user AS user_name;');
+    const defaultAclOwners = configuredDefaultAclOwners(currentUserResult.rows[0].user_name);
+    const tablePrivileges = await supportedTablePrivileges(client);
+
+    const tableResult = await client.query(
+      `
+        WITH public_tables AS (
+          SELECT c.oid, c.relname, c.relrowsecurity
+          FROM pg_class c
+          JOIN pg_namespace n ON n.oid = c.relnamespace
+          WHERE n.nspname = 'public'
+            AND c.relkind IN ('r', 'p')
+        ), client_privileges AS (
+          SELECT
+            t.oid,
+            client_role.role_name,
+            privilege.privilege_type
+          FROM public_tables t
+          CROSS JOIN unnest($1::text[]) AS client_role(role_name)
+          CROSS JOIN unnest($2::text[]) AS privilege(privilege_type)
+          WHERE to_regrole(client_role.role_name) IS NOT NULL
+            AND has_table_privilege(client_role.role_name, t.oid, privilege.privilege_type)
+        )
+        SELECT
+          t.relname AS table_name,
+          t.relrowsecurity AS rls_enabled,
+          COALESCE(
+            array_agg(DISTINCT cp.role_name || ':' || cp.privilege_type)
+              FILTER (WHERE cp.role_name IS NOT NULL),
+            ARRAY[]::text[]
+          ) AS client_privileges
+        FROM public_tables t
+        LEFT JOIN client_privileges cp ON cp.oid = t.oid
+        GROUP BY t.relname, t.relrowsecurity
+        ORDER BY t.relname;
+      `,
+      [CLIENT_ROLES, tablePrivileges]
+    );
+
+    const policyResult = await client.query(
+      `
+        SELECT schemaname, tablename, policyname, roles, cmd
+        FROM pg_policies
+        WHERE schemaname = 'public'
+          AND roles && ARRAY['public', 'anon', 'authenticated']::name[]
+        ORDER BY tablename, policyname;
+      `
+    );
+
+    const defaultPrivilegeResult = await client.query(
+      `
+        SELECT
+          COALESCE(owner.rolname, 'PUBLIC') AS owner,
+          n.nspname AS schema_name,
+          COALESCE(grantee.rolname, 'PUBLIC') AS grantee,
+          acl.privilege_type
+        FROM pg_default_acl d
+        JOIN pg_namespace n ON n.oid = d.defaclnamespace
+        LEFT JOIN pg_roles owner ON owner.oid = d.defaclrole
+        CROSS JOIN LATERAL aclexplode(d.defaclacl) acl
+        LEFT JOIN pg_roles grantee ON grantee.oid = acl.grantee
+        WHERE n.nspname = 'public'
+          AND d.defaclobjtype = 'r'
+          AND COALESCE(grantee.rolname, 'PUBLIC') = ANY($1)
+        ORDER BY owner, grantee, acl.privilege_type;
+      `,
+      [['PUBLIC', ...CLIENT_ROLES]]
+    );
+
+    if (tableResult.rows.length === 0) {
+      throw new Error('RLS check found no public tables; migrations may not have run.');
+    }
+
+    const missingRls = tableResult.rows.filter((row) => !row.rls_enabled);
+    const clientPrivileges = tableResult.rows.filter((row) => row.client_privileges.length > 0);
+
+    const blockingDefaultPrivileges = defaultPrivilegeResult.rows.filter((row) =>
+      defaultAclOwners.has(row.owner)
+    );
+    const unmanagedDefaultPrivileges = defaultPrivilegeResult.rows.filter(
+      (row) => !defaultAclOwners.has(row.owner)
+    );
+
+    if (
+      missingRls.length > 0 ||
+      clientPrivileges.length > 0 ||
+      policyResult.rows.length > 0 ||
+      blockingDefaultPrivileges.length > 0
+    ) {
+      console.error('Public database security check failed.');
+      console.error(`Tables missing RLS: ${formatList(missingRls.map((row) => row.table_name))}`);
+      console.error(
+        `Tables with effective anon/authenticated table privileges: ${formatList(
+          clientPrivileges.map((row) => `${row.table_name} (${row.client_privileges.join(', ')})`)
+        )}`
+      );
+      console.error(
+        `Client-facing RLS policies: ${formatList(
+          policyResult.rows.map(
+            (row) => `${row.tablename}.${row.policyname} (${row.roles.join(', ')}/${row.cmd})`
+          )
+        )}`
+      );
+      console.error(
+        `Client default table privileges: ${formatList(
+          blockingDefaultPrivileges.map(
+            (row) => `${row.owner}->${row.grantee}:${row.privilege_type}`
+          )
+        )}`
+      );
+      process.exitCode = 1;
+      return;
+    }
+
+    if (unmanagedDefaultPrivileges.length > 0) {
+      console.warn(
+        `Unmanaged client default table privileges were observed but not failed: ${formatList(
+          unmanagedDefaultPrivileges.map(
+            (row) => `${row.owner}->${row.grantee}:${row.privilege_type}`
+          )
+        )}`
+      );
+    }
+
+    console.log(
+      `Public database security check passed for ${tableResult.rows.length} tables: RLS enabled, no effective client privileges, no client policies, no checked-owner client default table privileges.`
+    );
+  } finally {
+    await client.end();
+  }
+}
+
+main().catch((error) => {
+  console.error(error.message);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- add a Prisma migration that revokes migration-owner default table privileges for Supabase client roles
- add 
pm run db:check:rls and wire it into CI after integration migrations run
- document the 2026-05-26 metadata-only Supabase RLS exposure audit

## Validation
- 
pm run format:check`n- 
pm run lint`n- 
pm run build`n- 
pm test`n- 
px prisma validate with a dummy local DATABASE_URL
- production 
pm run db:check:rls using the AWS Secrets Manager production DATABASE_URL

## Production notes
- 20260526001000_revoke_client_default_table_privileges has already been applied to production after the Supabase alert remediation.
- The first attempt hit a Supabase permission boundary on supabase_admin default privileges and was marked rolled back; the corrected migration then applied successfully.
- The production guardrail now passes for all current public tables and checked owners, with a warning for unmanaged Supabase-owned defaults that the migration role cannot alter.

## Audit result
- Current public tables all have RLS enabled and no effective non/uthenticated table privileges.
- pg_stat_statements had data since 2026-05-08 and showed no non, uthenticated, or uthenticator activity against Drasil application tables.
- Longer-retention Supabase API gateway/PostgREST logs were not available from this repo-local audit; the audit doc records that residual gap.