### PR TITLE
Add unified setup diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,8 +71,8 @@ High-signal manual and automated test ideas live in `docs/test-cases.md`.
 ## Usage
 
 - Invite the bot to your server.
-- Follow the setup instructions below
-- Use the `/config` command to set up server-specific settings
+- Run `/config setup` to configure the restricted role and channels.
+- Run `/config validate` after permission or channel changes.
 - Update other config as needed (spam thresholds, OpenAI prompts).
 - Let the bot automatically classify new users or run the `/verify` command for manual overrides.
 
@@ -80,27 +80,30 @@ High-signal manual and automated test ideas live in `docs/test-cases.md`.
 
 ### Server Configuration
 
-1. **Create a Restricted Role**:
-   - Create a role in your Discord server that has limited permissions
-   - Take note of the role ID (enable Developer Mode in Discord Settings -> Advanced, then right-click the role and select "Copy ID")
-   - Use the `/config key:restricted_role_id value:<role-id>` command to set this value
+1. **Run Unified Setup**:
+   - Use `/config setup admin-channel:<channel>`.
+   - Optionally pass `restricted-role:<role>` to use an existing restricted role.
+   - Omit `restricted-role` to let Drasil create `Drasil Restricted`.
+   - Optionally pass `verification-channel:<channel>` to reuse an existing verification channel.
+   - Omit `verification-channel` to let Drasil create or reuse a `verification` text channel.
+   - Optionally pass `report-channel:<channel>` to create or update the report instructions message.
 
-2. **Create an Admin Channel**:
-   - Create a channel that only moderators/admins have access to
-   - This channel will receive notifications about suspicious users with interactive buttons
-   - Use the `/config key:admin_channel_id value:<channel-id>` command to set this value
+2. **Validate Setup**:
+   - Use `/config validate` after setup, permission changes, or channel changes.
+   - Hard errors block `/config setup` from saving.
+   - Warnings are shown but do not block saving.
 
-3. **Create a Verification Channel**:
-   - Create a channel visible only to admins and users with the restricted role
-   - Configure so restricted users can't see message history
-   - This is where verification threads will be created
-   - Use the `/config key:verification_channel_id value:<channel-id>` command to set this value
+3. **Legacy Direct Setup**:
+   - `/setupverification` and `/setupreportbutton` still exist for now.
+   - Prefer `/config setup` for new servers.
 
 ### Slash Commands
 
 The bot automatically registers the following slash commands during startup:
 
-- `/config key:value value:value` - Configure server-specific settings
+- `/config setup` - Configure required Drasil channels and restricted role
+- `/config validate` - Check setup, permissions, channels, and role hierarchy
+- `/config set key:<key> value:<value>` - Configure low-level server settings
 
 Slash commands are automatically registered when the bot starts up. There's no need for manual registration.
 

--- a/docs/manual-qa.md
+++ b/docs/manual-qa.md
@@ -50,10 +50,14 @@ Prefer deterministic flows first. Use `/flaguser` instead of hoping heuristics t
 
 ### 1. Verification setup sanity check
 
-- Run `/setupverification` if the staging server is not configured yet.
+- Run `/config setup admin-channel:<channel>` if the staging server is not configured yet.
+- Omit `restricted-role` to verify Drasil can create the default restricted role, or pass an existing role when testing role reuse.
+- Omit `verification-channel` to verify Drasil can create or reuse the `verification` channel, or pass an existing text channel when testing channel reuse.
+- Run `/config validate` after setup.
 - Confirm the restricted role, admin channel, and verification channel are configured.
 - Expected result:
   - commands succeed without permission errors
+  - setup hard errors block saving and warnings do not
   - the bot can post in the admin channel
   - the bot can create private verification threads
 
@@ -109,10 +113,11 @@ Prefer deterministic flows first. Use `/flaguser` instead of hoping heuristics t
 
 ### 7. User report flow
 
-- Run `/setupreportbutton` if needed.
+- Run `/config setup report-channel:<channel>` or `/setupreportbutton` if needed.
 - Submit a report against the suspicious-user test account from the reporter test account.
 - Expected result:
   - detection event is created with `USER_REPORT`
+  - rerunning report setup updates the existing instructions message instead of duplicating it
   - no restricted role is applied
   - no verification thread is created by default
   - an observed alert appears with report details and moderator action buttons

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -48,17 +48,19 @@ npx prisma migrate deploy
 
 ## Server setup (staging)
 
-Create:
+Create or choose:
 
 - Restricted role (limited permissions).
 - Admin channel (mods only).
-- Verification channel (where the bot creates verification threads).
+- Verification channel (where the bot creates verification threads), or let setup create/reuse `verification`.
 
-Configure the bot (current UX is via `/config`):
+Configure and validate the bot:
 
-- `restricted_role_id`
-- `admin_channel_id`
-- `verification_channel_id`
+- Run `/config setup admin-channel:<channel>`.
+- Pass `restricted-role:<role>` only when reusing an existing role; otherwise Drasil creates `Drasil Restricted`.
+- Pass `verification-channel:<channel>` only when reusing an existing channel; otherwise Drasil creates/reuses `verification`.
+- Optionally pass `report-channel:<channel>` to create/update report instructions.
+- Run `/config validate` and fix all errors before smoke tests.
 
 ## Smoke tests (end-to-end)
 

--- a/src/Bot.ts
+++ b/src/Bot.ts
@@ -44,10 +44,10 @@ export class Bot implements IBot {
     if (!token) {
       throw new Error('DISCORD_TOKEN environment variable not set');
     }
+    await this.eventHandler.setupEventHandlers();
+
     await this.client.login(token);
     console.log('Bot started and logged in!');
-
-    await this.eventHandler.setupEventHandlers();
   }
 
   /**

--- a/src/__tests__/unit/Bot.unit.test.ts
+++ b/src/__tests__/unit/Bot.unit.test.ts
@@ -1,0 +1,33 @@
+import { Bot } from '../../Bot';
+
+describe('Bot (unit)', () => {
+  const originalDiscordToken = process.env.DISCORD_TOKEN;
+
+  afterEach(() => {
+    if (originalDiscordToken === undefined) {
+      delete process.env.DISCORD_TOKEN;
+    } else {
+      process.env.DISCORD_TOKEN = originalDiscordToken;
+    }
+  });
+
+  it('registers event handlers before logging in', async () => {
+    process.env.DISCORD_TOKEN = 'test-token';
+    const client = {
+      login: jest.fn().mockResolvedValue('logged-in'),
+      destroy: jest.fn().mockResolvedValue(undefined),
+    } as any;
+    const eventHandler = {
+      setupEventHandlers: jest.fn().mockResolvedValue(undefined),
+    } as any;
+    const bot = new Bot(client, eventHandler);
+
+    await bot.startBot();
+
+    expect(eventHandler.setupEventHandlers).toHaveBeenCalledTimes(1);
+    expect(client.login).toHaveBeenCalledWith('test-token');
+    expect(eventHandler.setupEventHandlers.mock.invocationCallOrder[0]).toBeLessThan(
+      client.login.mock.invocationCallOrder[0]
+    );
+  });
+});

--- a/src/__tests__/unit/CommandHandler.unit.test.ts
+++ b/src/__tests__/unit/CommandHandler.unit.test.ts
@@ -979,7 +979,7 @@ describe('CommandHandler (unit)', () => {
     });
     expect(interaction.editReply).toHaveBeenCalledWith({
       content:
-        'Setup complete.\nRestricted role: <@&role-1>\nAdmin channel: <#channel-1>\nCreated or reused verification channel: <#created-channel-1>',
+        'Setup complete.\nRestricted role: <@&role-1>\nAdmin channel: <#channel-1>\nCreated verification channel: <#created-channel-1>',
       allowedMentions: { parse: [] },
     });
   });
@@ -1048,6 +1048,9 @@ describe('CommandHandler (unit)', () => {
       false,
       expect.any(Function),
       'configured-channel-1'
+    );
+    expect(interaction.editReply.mock.calls[0][0].content).toContain(
+      'Synced verification channel permissions: <#configured-channel-1>'
     );
   });
 
@@ -1378,6 +1381,9 @@ describe('CommandHandler (unit)', () => {
       expect.any(Function),
       'configured-channel-1'
     );
+    expect(interaction.editReply.mock.calls[0][0].content).toContain(
+      'Synced verification channel permissions: <#configured-channel-1>'
+    );
   });
 
   it('handles /config setup by creating the default restricted role and verification channel', async () => {
@@ -1449,7 +1455,7 @@ describe('CommandHandler (unit)', () => {
       allowedMentions: { parse: [] },
     });
     expect(interaction.editReply.mock.calls[0][0].content).toContain(
-      'Created or reused verification channel: <#created-channel-1>'
+      'Created verification channel: <#created-channel-1>'
     );
   });
 

--- a/src/__tests__/unit/CommandHandler.unit.test.ts
+++ b/src/__tests__/unit/CommandHandler.unit.test.ts
@@ -1755,6 +1755,60 @@ describe('CommandHandler (unit)', () => {
     });
   });
 
+  it('reports /config setup preflight failures after deferring', async () => {
+    const consoleError = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+    const validateSetupCandidate = jest
+      .fn()
+      .mockRejectedValue(new Error('diagnostics unavailable'));
+    const updateServerConfig = jest.fn().mockResolvedValue({});
+    const { handler, configService, notificationManager } = buildHandler({
+      validateSetupCandidate,
+      updateServerConfig,
+    });
+    const adminChannel = { id: 'admin-channel-1', type: ChannelType.GuildText } as any;
+    const restrictedRole = { id: 'role-1' } as any;
+    const guild = {
+      id: 'guild-1',
+      members: {
+        fetch: jest.fn().mockResolvedValue({
+          permissions: {
+            has: jest.fn().mockReturnValue(true),
+          },
+        }),
+      },
+      roles: {
+        create: jest.fn(),
+      },
+    } as any;
+    const interaction = {
+      commandName: 'config',
+      user: { id: 'admin-1', tag: 'Admin#0001' },
+      guild,
+      options: {
+        getSubcommandGroup: jest.fn().mockReturnValue(null),
+        getSubcommand: jest.fn().mockReturnValue('setup'),
+        getChannel: jest.fn((name: string) => (name === 'admin-channel' ? adminChannel : null)),
+        getRole: jest.fn().mockReturnValue(restrictedRole),
+        getString: jest.fn().mockReturnValue(null),
+      },
+      reply: jest.fn().mockResolvedValue(undefined),
+      deferReply: jest.fn().mockResolvedValue(undefined),
+      editReply: jest.fn().mockResolvedValue(undefined),
+    } as any;
+
+    await handler.handleSlashCommand(interaction);
+
+    expect(interaction.deferReply).toHaveBeenCalledWith({ flags: MessageFlags.Ephemeral });
+    expect(guild.roles.create).not.toHaveBeenCalled();
+    expect(notificationManager.setupVerificationChannel).not.toHaveBeenCalled();
+    expect(configService.updateServerConfig).not.toHaveBeenCalled();
+    expect(interaction.editReply).toHaveBeenCalledWith({
+      content: 'Failed to complete setup. Please check permissions and try again.',
+      allowedMentions: { parse: [] },
+    });
+    consoleError.mockRestore();
+  });
+
   it('updates the existing report instructions message instead of sending a duplicate', async () => {
     const existingMessage = {
       id: 'message-1',

--- a/src/__tests__/unit/CommandHandler.unit.test.ts
+++ b/src/__tests__/unit/CommandHandler.unit.test.ts
@@ -37,6 +37,8 @@ describe('CommandHandler (unit)', () => {
     handleUserReport: jest.Mock;
     handleMessageReport: jest.Mock;
     setupVerificationChannel: jest.Mock;
+    validateGuildSetup: jest.Mock;
+    validateSetupCandidate: jest.Mock;
     excludeDetectionFromAccounting: jest.Mock;
     restoreDetectionAccounting: jest.Mock;
   }>;
@@ -101,6 +103,26 @@ describe('CommandHandler (unit)', () => {
       setupVerificationChannel:
         overrides.setupVerificationChannel ?? jest.fn().mockResolvedValue('created-channel-1'),
     } as any;
+    const setupDiagnosticsService = {
+      validateGuildSetup:
+        overrides.validateGuildSetup ??
+        jest.fn().mockResolvedValue({
+          guildId: 'guild-1',
+          checkedAt: new Date('2026-01-01T00:00:00.000Z'),
+          issues: [],
+          errorCount: 0,
+          warningCount: 0,
+        }),
+      validateSetupCandidate:
+        overrides.validateSetupCandidate ??
+        jest.fn().mockResolvedValue({
+          guildId: 'guild-1',
+          checkedAt: new Date('2026-01-01T00:00:00.000Z'),
+          issues: [],
+          errorCount: 0,
+          warningCount: 0,
+        }),
+    } as any;
     const client = {
       user: { id: 'client-1' },
     } as any;
@@ -113,13 +135,16 @@ describe('CommandHandler (unit)', () => {
         notificationManager,
         configService,
         userModerationService,
-        securityActionService
+        securityActionService,
+        undefined,
+        setupDiagnosticsService
       ),
       client,
       userModerationService,
       notificationManager,
       configService,
       securityActionService,
+      setupDiagnosticsService,
     };
   };
 
@@ -196,6 +221,15 @@ describe('CommandHandler (unit)', () => {
       'ignore-detection',
       'restore-detection',
     ]);
+  });
+
+  it('registers /config setup and validate', () => {
+    const { handler } = buildHandler();
+    const commands = (handler as any).commands as any[];
+    const configCommand = commands.find((c) => c.name === 'config');
+
+    expect(configCommand.options.map((option: any) => option.name)).toContain('validate');
+    expect(configCommand.options.map((option: any) => option.name)).toContain('setup');
   });
 
   it('explains when a guild-only slash command is used before Drasil is installed', async () => {
@@ -994,6 +1028,394 @@ describe('CommandHandler (unit)', () => {
     });
   });
 
+  it('blocks setupverification when candidate diagnostics have hard errors', async () => {
+    const validateSetupCandidate = jest.fn().mockResolvedValue({
+      guildId: 'guild-1',
+      checkedAt: new Date('2026-01-01T00:00:00.000Z'),
+      issues: [
+        {
+          severity: 'error',
+          code: 'restricted-role-hierarchy',
+          message: "Drasil's highest role must be above restricted role <@&role-1>.",
+        },
+      ],
+      errorCount: 1,
+      warningCount: 0,
+    });
+    const updateServerConfig = jest.fn().mockResolvedValue({});
+    const { handler, configService, notificationManager } = buildHandler({
+      validateSetupCandidate,
+      updateServerConfig,
+    });
+    const guild = {
+      id: 'guild-1',
+    } as any;
+    const interaction = {
+      commandName: 'setupverification',
+      guild,
+      memberPermissions: {
+        has: jest.fn().mockReturnValue(true),
+      },
+      options: {
+        getRole: jest.fn().mockReturnValue({ id: 'role-1' }),
+        getChannel: jest.fn((name: string) => {
+          if (name === 'admin-channel') {
+            return { id: 'channel-1', type: ChannelType.GuildText };
+          }
+          if (name === 'verification-channel') {
+            return { id: 'channel-2', type: ChannelType.GuildText };
+          }
+          return null;
+        }),
+      },
+      reply: jest.fn().mockResolvedValue(undefined),
+      deferReply: jest.fn().mockResolvedValue(undefined),
+      editReply: jest.fn().mockResolvedValue(undefined),
+    } as any;
+
+    await handler.handleSlashCommand(interaction);
+
+    expect(configService.updateServerConfig).not.toHaveBeenCalled();
+    expect(notificationManager.setupVerificationChannel).not.toHaveBeenCalled();
+    expect(interaction.editReply).toHaveBeenCalledWith({
+      content: expect.stringContaining('Setup not saved.'),
+      allowedMentions: { parse: [] },
+    });
+  });
+
+  it('handles /config setup with an existing restricted role and channels', async () => {
+    const validateSetupCandidate = jest.fn().mockResolvedValue({
+      guildId: 'guild-1',
+      checkedAt: new Date('2026-01-01T00:00:00.000Z'),
+      issues: [],
+      errorCount: 0,
+      warningCount: 0,
+    });
+    const updateServerConfig = jest.fn().mockResolvedValue({});
+    const { handler, configService, notificationManager, setupDiagnosticsService } = buildHandler({
+      validateSetupCandidate,
+      updateServerConfig,
+    });
+    const adminChannel = { id: 'admin-channel-1', type: ChannelType.GuildText } as any;
+    const verificationChannel = {
+      id: 'verification-channel-1',
+      type: ChannelType.GuildText,
+    } as any;
+    const restrictedRole = { id: 'role-1' } as any;
+    const guild = {
+      id: 'guild-1',
+      members: {
+        fetch: jest.fn().mockResolvedValue({
+          permissions: {
+            has: jest.fn().mockReturnValue(true),
+          },
+        }),
+      },
+      roles: {
+        create: jest.fn(),
+      },
+    } as any;
+    const interaction = {
+      commandName: 'config',
+      user: { id: 'admin-1', tag: 'Admin#0001' },
+      guild,
+      options: {
+        getSubcommandGroup: jest.fn().mockReturnValue(null),
+        getSubcommand: jest.fn().mockReturnValue('setup'),
+        getChannel: jest.fn((name: string) => {
+          if (name === 'admin-channel') {
+            return adminChannel;
+          }
+          if (name === 'verification-channel') {
+            return verificationChannel;
+          }
+          return null;
+        }),
+        getRole: jest.fn().mockReturnValue(restrictedRole),
+        getString: jest.fn().mockReturnValue(null),
+      },
+      reply: jest.fn().mockResolvedValue(undefined),
+      deferReply: jest.fn().mockResolvedValue(undefined),
+      editReply: jest.fn().mockResolvedValue(undefined),
+    } as any;
+
+    await handler.handleSlashCommand(interaction);
+
+    expect(interaction.deferReply).toHaveBeenCalledWith({ flags: MessageFlags.Ephemeral });
+    expect(setupDiagnosticsService.validateSetupCandidate).toHaveBeenCalledWith(guild, {
+      restrictedRoleId: 'role-1',
+      willCreateRestrictedRole: false,
+      adminChannelId: 'admin-channel-1',
+      verificationChannelId: 'verification-channel-1',
+      willCreateVerificationChannel: false,
+      reportInstructionsChannelId: null,
+    });
+    expect(guild.roles.create).not.toHaveBeenCalled();
+    expect(notificationManager.setupVerificationChannel).not.toHaveBeenCalled();
+    expect(configService.updateServerConfig).toHaveBeenCalledWith('guild-1', {
+      restricted_role_id: 'role-1',
+      admin_channel_id: 'admin-channel-1',
+      verification_channel_id: 'verification-channel-1',
+    });
+    expect(interaction.editReply).toHaveBeenCalledWith({
+      content: expect.stringContaining('Setup complete.'),
+      allowedMentions: { parse: [] },
+    });
+  });
+
+  it('handles /config setup by creating the default restricted role and verification channel', async () => {
+    const setupVerificationChannel = jest.fn().mockResolvedValue('created-channel-1');
+    const validateSetupCandidate = jest.fn().mockResolvedValue({
+      guildId: 'guild-1',
+      checkedAt: new Date('2026-01-01T00:00:00.000Z'),
+      issues: [],
+      errorCount: 0,
+      warningCount: 0,
+    });
+    const updateServerConfig = jest.fn().mockResolvedValue({});
+    const { handler, configService, notificationManager } = buildHandler({
+      setupVerificationChannel,
+      validateSetupCandidate,
+      updateServerConfig,
+    });
+    const adminChannel = { id: 'admin-channel-1', type: ChannelType.GuildText } as any;
+    const createdRole = { id: 'created-role-1' } as any;
+    const guild = {
+      id: 'guild-1',
+      members: {
+        fetch: jest.fn().mockResolvedValue({
+          permissions: {
+            has: jest.fn().mockReturnValue(true),
+          },
+        }),
+      },
+      roles: {
+        create: jest.fn().mockResolvedValue(createdRole),
+      },
+    } as any;
+    const interaction = {
+      commandName: 'config',
+      user: { id: 'admin-1', tag: 'Admin#0001' },
+      guild,
+      options: {
+        getSubcommandGroup: jest.fn().mockReturnValue(null),
+        getSubcommand: jest.fn().mockReturnValue('setup'),
+        getChannel: jest.fn((name: string) => (name === 'admin-channel' ? adminChannel : null)),
+        getRole: jest.fn().mockReturnValue(null),
+        getString: jest.fn().mockReturnValue(null),
+      },
+      reply: jest.fn().mockResolvedValue(undefined),
+      deferReply: jest.fn().mockResolvedValue(undefined),
+      editReply: jest.fn().mockResolvedValue(undefined),
+    } as any;
+
+    await handler.handleSlashCommand(interaction);
+
+    expect(guild.roles.create).toHaveBeenCalledWith({
+      name: 'Drasil Restricted',
+      permissions: [],
+      reason: 'Drasil setup requested by Admin#0001',
+    });
+    expect(notificationManager.setupVerificationChannel).toHaveBeenCalledWith(
+      guild,
+      'created-role-1',
+      false
+    );
+    expect(configService.updateServerConfig).toHaveBeenCalledWith('guild-1', {
+      restricted_role_id: 'created-role-1',
+      admin_channel_id: 'admin-channel-1',
+      verification_channel_id: 'created-channel-1',
+    });
+    expect(interaction.editReply).toHaveBeenCalledWith({
+      content: expect.stringContaining('Created restricted role: <@&created-role-1>'),
+      allowedMentions: { parse: [] },
+    });
+    expect(interaction.editReply.mock.calls[0][0].content).toContain(
+      'Created verification channel: <#created-channel-1>'
+    );
+  });
+
+  it('blocks /config setup when candidate diagnostics have hard errors', async () => {
+    const validateSetupCandidate = jest.fn().mockResolvedValue({
+      guildId: 'guild-1',
+      checkedAt: new Date('2026-01-01T00:00:00.000Z'),
+      issues: [
+        {
+          severity: 'error',
+          code: 'admin-channel-send',
+          message:
+            'Drasil is missing Send Messages in Admin notification channel <#admin-channel-1>.',
+        },
+      ],
+      errorCount: 1,
+      warningCount: 0,
+    });
+    const updateServerConfig = jest.fn().mockResolvedValue({});
+    const { handler, configService, notificationManager } = buildHandler({
+      validateSetupCandidate,
+      updateServerConfig,
+    });
+    const adminChannel = { id: 'admin-channel-1', type: ChannelType.GuildText } as any;
+    const restrictedRole = { id: 'role-1' } as any;
+    const guild = {
+      id: 'guild-1',
+      members: {
+        fetch: jest.fn().mockResolvedValue({
+          permissions: {
+            has: jest.fn().mockReturnValue(true),
+          },
+        }),
+      },
+      roles: {
+        create: jest.fn(),
+      },
+    } as any;
+    const interaction = {
+      commandName: 'config',
+      user: { id: 'admin-1', tag: 'Admin#0001' },
+      guild,
+      options: {
+        getSubcommandGroup: jest.fn().mockReturnValue(null),
+        getSubcommand: jest.fn().mockReturnValue('setup'),
+        getChannel: jest.fn((name: string) => (name === 'admin-channel' ? adminChannel : null)),
+        getRole: jest.fn().mockReturnValue(restrictedRole),
+        getString: jest.fn().mockReturnValue(null),
+      },
+      reply: jest.fn().mockResolvedValue(undefined),
+      deferReply: jest.fn().mockResolvedValue(undefined),
+      editReply: jest.fn().mockResolvedValue(undefined),
+    } as any;
+
+    await handler.handleSlashCommand(interaction);
+
+    expect(guild.roles.create).not.toHaveBeenCalled();
+    expect(notificationManager.setupVerificationChannel).not.toHaveBeenCalled();
+    expect(configService.updateServerConfig).not.toHaveBeenCalled();
+    expect(interaction.editReply).toHaveBeenCalledWith({
+      content: expect.stringContaining('Setup not saved.'),
+      allowedMentions: { parse: [] },
+    });
+  });
+
+  it('updates the existing report instructions message instead of sending a duplicate', async () => {
+    const existingMessage = {
+      id: 'message-1',
+      edit: jest.fn().mockResolvedValue(undefined),
+    };
+    const targetChannel = {
+      id: 'channel-1',
+      type: ChannelType.GuildText,
+      messages: {
+        fetch: jest.fn().mockResolvedValue(existingMessage),
+      },
+      send: jest.fn().mockResolvedValue({ id: 'message-2' }),
+      toString: () => '<#channel-1>',
+    } as any;
+    const getServerConfig = jest.fn().mockResolvedValue({
+      settings: {
+        report_instructions_channel_id: 'channel-1',
+        report_instructions_message_id: 'message-1',
+      },
+    });
+    const updateServerSettings = jest.fn().mockResolvedValue({});
+    const { handler, configService } = buildHandler({ getServerConfig, updateServerSettings });
+
+    const guild = {
+      id: 'guild-1',
+      members: {
+        fetch: jest.fn().mockResolvedValue({
+          permissions: {
+            has: jest.fn().mockReturnValue(true),
+          },
+        }),
+      },
+    } as any;
+    const interaction = {
+      commandName: 'setupreportbutton',
+      user: { id: 'admin-1' },
+      guild,
+      options: {
+        getChannel: jest.fn().mockReturnValue(targetChannel),
+      },
+      reply: jest.fn().mockResolvedValue(undefined),
+      deferReply: jest.fn().mockResolvedValue(undefined),
+      editReply: jest.fn().mockResolvedValue(undefined),
+    } as any;
+
+    await handler.handleSlashCommand(interaction);
+
+    expect(interaction.deferReply).toHaveBeenCalledWith({ flags: MessageFlags.Ephemeral });
+    expect(targetChannel.messages.fetch).toHaveBeenCalledWith('message-1');
+    expect(existingMessage.edit).toHaveBeenCalledWith({
+      embeds: expect.any(Array),
+      components: expect.any(Array),
+    });
+    expect(targetChannel.send).not.toHaveBeenCalled();
+    expect(configService.updateServerSettings).toHaveBeenCalledWith('guild-1', {
+      report_instructions_channel_id: 'channel-1',
+      report_instructions_message_id: 'message-1',
+    });
+    expect(interaction.editReply).toHaveBeenCalledWith({
+      content: 'Report instructions updated successfully in <#channel-1>.',
+    });
+  });
+
+  it('recreates report instructions when the stored message no longer exists', async () => {
+    const targetChannel = {
+      id: 'channel-1',
+      type: ChannelType.GuildText,
+      messages: {
+        fetch: jest.fn().mockRejectedValue(new Error('missing')),
+      },
+      send: jest.fn().mockResolvedValue({ id: 'message-2' }),
+      toString: () => '<#channel-1>',
+    } as any;
+    const getServerConfig = jest.fn().mockResolvedValue({
+      settings: {
+        report_instructions_channel_id: 'channel-1',
+        report_instructions_message_id: 'message-1',
+      },
+    });
+    const updateServerSettings = jest.fn().mockResolvedValue({});
+    const { handler, configService } = buildHandler({ getServerConfig, updateServerSettings });
+
+    const guild = {
+      id: 'guild-1',
+      members: {
+        fetch: jest.fn().mockResolvedValue({
+          permissions: {
+            has: jest.fn().mockReturnValue(true),
+          },
+        }),
+      },
+    } as any;
+    const interaction = {
+      commandName: 'setupreportbutton',
+      user: { id: 'admin-1' },
+      guild,
+      options: {
+        getChannel: jest.fn().mockReturnValue(targetChannel),
+      },
+      reply: jest.fn().mockResolvedValue(undefined),
+      deferReply: jest.fn().mockResolvedValue(undefined),
+      editReply: jest.fn().mockResolvedValue(undefined),
+    } as any;
+
+    await handler.handleSlashCommand(interaction);
+
+    expect(targetChannel.send).toHaveBeenCalledWith({
+      embeds: expect.any(Array),
+      components: expect.any(Array),
+    });
+    expect(configService.updateServerSettings).toHaveBeenCalledWith('guild-1', {
+      report_instructions_channel_id: 'channel-1',
+      report_instructions_message_id: 'message-2',
+    });
+    expect(interaction.editReply).toHaveBeenCalledWith({
+      content: 'Report instructions recreated successfully in <#channel-1>.',
+    });
+  });
+
   it('handles /config heuristic set-threshold', async () => {
     const updateHeuristicSettings = jest.fn().mockResolvedValue({
       messageThreshold: 8,
@@ -1034,6 +1456,66 @@ describe('CommandHandler (unit)', () => {
       content: expect.stringContaining('Updated heuristic threshold'),
       flags: MessageFlags.Ephemeral,
     });
+  });
+
+  it('handles /config validate', async () => {
+    const validateGuildSetup = jest.fn().mockResolvedValue({
+      guildId: 'guild-1',
+      checkedAt: new Date('2026-01-01T00:00:00.000Z'),
+      issues: [
+        {
+          severity: 'error',
+          code: 'restricted-role-missing',
+          message: 'Restricted role is not configured.',
+        },
+        {
+          severity: 'warning',
+          code: 'guild-view-audit-log',
+          message: 'Drasil is missing View Audit Log.',
+        },
+      ],
+      errorCount: 1,
+      warningCount: 1,
+    });
+    const { handler, setupDiagnosticsService } = buildHandler({ validateGuildSetup });
+
+    const guild = {
+      id: 'guild-1',
+      members: {
+        fetch: jest.fn().mockResolvedValue({
+          permissions: {
+            has: jest.fn().mockReturnValue(true),
+          },
+        }),
+      },
+    } as any;
+    const interaction = {
+      commandName: 'config',
+      user: { id: 'admin-1' },
+      guild,
+      options: {
+        getSubcommandGroup: jest.fn().mockReturnValue(null),
+        getSubcommand: jest.fn().mockReturnValue('validate'),
+      },
+      reply: jest.fn().mockResolvedValue(undefined),
+      deferReply: jest.fn().mockResolvedValue(undefined),
+      editReply: jest.fn().mockResolvedValue(undefined),
+    } as any;
+
+    await handler.handleSlashCommand(interaction);
+
+    expect(interaction.deferReply).toHaveBeenCalledWith({ flags: MessageFlags.Ephemeral });
+    expect(setupDiagnosticsService.validateGuildSetup).toHaveBeenCalledWith(guild);
+    expect(interaction.editReply).toHaveBeenCalledWith({
+      content: expect.stringContaining('[ERROR] Restricted role is not configured.'),
+      allowedMentions: { parse: [] },
+    });
+    expect(interaction.editReply.mock.calls[0][0].content).toContain(
+      'Setup validation failed with 1 error(s) and 1 warning(s).'
+    );
+    expect(interaction.editReply.mock.calls[0][0].content).toContain(
+      '[WARNING] Drasil is missing View Audit Log.'
+    );
   });
 
   it('handles /config detection set-mode', async () => {

--- a/src/__tests__/unit/CommandHandler.unit.test.ts
+++ b/src/__tests__/unit/CommandHandler.unit.test.ts
@@ -1576,6 +1576,76 @@ describe('CommandHandler (unit)', () => {
     });
   });
 
+  it('deletes old report instructions when moving them to a new channel', async () => {
+    const oldMessage = {
+      delete: jest.fn().mockResolvedValue(undefined),
+    };
+    const oldChannel = {
+      messages: {
+        fetch: jest.fn().mockResolvedValue(oldMessage),
+      },
+    };
+    const targetChannel = {
+      id: 'new-channel-1',
+      type: ChannelType.GuildText,
+      messages: {
+        fetch: jest.fn(),
+      },
+      send: jest.fn().mockResolvedValue({ id: 'new-message-1' }),
+      toString: () => '<#new-channel-1>',
+    } as any;
+    const getServerConfig = jest.fn().mockResolvedValue({
+      settings: {
+        report_instructions_channel_id: 'old-channel-1',
+        report_instructions_message_id: 'old-message-1',
+      },
+    });
+    const updateServerSettings = jest.fn().mockResolvedValue({});
+    const { handler, configService, client } = buildHandler({
+      getServerConfig,
+      updateServerSettings,
+    });
+    client.channels = {
+      fetch: jest.fn().mockResolvedValue(oldChannel),
+    };
+
+    const guild = {
+      id: 'guild-1',
+      members: {
+        fetch: jest.fn().mockResolvedValue({
+          permissions: {
+            has: jest.fn().mockReturnValue(true),
+          },
+        }),
+      },
+    } as any;
+    const interaction = {
+      commandName: 'setupreportbutton',
+      user: { id: 'admin-1' },
+      guild,
+      options: {
+        getChannel: jest.fn().mockReturnValue(targetChannel),
+      },
+      reply: jest.fn().mockResolvedValue(undefined),
+      deferReply: jest.fn().mockResolvedValue(undefined),
+      editReply: jest.fn().mockResolvedValue(undefined),
+    } as any;
+
+    await handler.handleSlashCommand(interaction);
+
+    expect(client.channels.fetch).toHaveBeenCalledWith('old-channel-1');
+    expect(oldChannel.messages.fetch).toHaveBeenCalledWith('old-message-1');
+    expect(oldMessage.delete).toHaveBeenCalledTimes(1);
+    expect(targetChannel.send).toHaveBeenCalledWith({
+      embeds: expect.any(Array),
+      components: expect.any(Array),
+    });
+    expect(configService.updateServerSettings).toHaveBeenCalledWith('guild-1', {
+      report_instructions_channel_id: 'new-channel-1',
+      report_instructions_message_id: 'new-message-1',
+    });
+  });
+
   it('handles /config heuristic set-threshold', async () => {
     const updateHeuristicSettings = jest.fn().mockResolvedValue({
       messageThreshold: 8,

--- a/src/__tests__/unit/CommandHandler.unit.test.ts
+++ b/src/__tests__/unit/CommandHandler.unit.test.ts
@@ -1238,6 +1238,69 @@ describe('CommandHandler (unit)', () => {
     );
   });
 
+  it('rolls back a created restricted role when verification channel setup fails', async () => {
+    const consoleError = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+    const setupVerificationChannel = jest.fn().mockResolvedValue(null);
+    const validateSetupCandidate = jest.fn().mockResolvedValue({
+      guildId: 'guild-1',
+      checkedAt: new Date('2026-01-01T00:00:00.000Z'),
+      issues: [],
+      errorCount: 0,
+      warningCount: 0,
+    });
+    const updateServerConfig = jest.fn().mockResolvedValue({});
+    const { handler, configService } = buildHandler({
+      setupVerificationChannel,
+      validateSetupCandidate,
+      updateServerConfig,
+    });
+    const adminChannel = { id: 'admin-channel-1', type: ChannelType.GuildText } as any;
+    const createdRole = {
+      id: 'created-role-1',
+      delete: jest.fn().mockResolvedValue(undefined),
+    } as any;
+    const guild = {
+      id: 'guild-1',
+      members: {
+        fetch: jest.fn().mockResolvedValue({
+          permissions: {
+            has: jest.fn().mockReturnValue(true),
+          },
+        }),
+      },
+      roles: {
+        create: jest.fn().mockResolvedValue(createdRole),
+      },
+    } as any;
+    const interaction = {
+      commandName: 'config',
+      user: { id: 'admin-1', tag: 'Admin#0001' },
+      guild,
+      options: {
+        getSubcommandGroup: jest.fn().mockReturnValue(null),
+        getSubcommand: jest.fn().mockReturnValue('setup'),
+        getChannel: jest.fn((name: string) => (name === 'admin-channel' ? adminChannel : null)),
+        getRole: jest.fn().mockReturnValue(null),
+        getString: jest.fn().mockReturnValue(null),
+      },
+      reply: jest.fn().mockResolvedValue(undefined),
+      deferReply: jest.fn().mockResolvedValue(undefined),
+      editReply: jest.fn().mockResolvedValue(undefined),
+    } as any;
+
+    await handler.handleSlashCommand(interaction);
+
+    expect(configService.updateServerConfig).not.toHaveBeenCalled();
+    expect(createdRole.delete).toHaveBeenCalledWith(
+      'Rolling back Drasil setup after verification channel setup failed'
+    );
+    expect(interaction.editReply).toHaveBeenCalledWith({
+      content: expect.stringContaining('newly created restricted role was removed'),
+      allowedMentions: { parse: [] },
+    });
+    consoleError.mockRestore();
+  });
+
   it('keeps /config setup saved when optional report instructions fail', async () => {
     const consoleError = jest.spyOn(console, 'error').mockImplementation(() => undefined);
     const validateSetupCandidate = jest.fn().mockResolvedValue({

--- a/src/__tests__/unit/CommandHandler.unit.test.ts
+++ b/src/__tests__/unit/CommandHandler.unit.test.ts
@@ -973,7 +973,7 @@ describe('CommandHandler (unit)', () => {
     });
     expect(interaction.editReply).toHaveBeenCalledWith({
       content:
-        'Setup complete.\nRestricted role: <@&role-1>\nAdmin channel: <#channel-1>\nCreated verification channel: <#created-channel-1>',
+        'Setup complete.\nRestricted role: <@&role-1>\nAdmin channel: <#channel-1>\nCreated or reused verification channel: <#created-channel-1>',
     });
   });
 
@@ -1231,7 +1231,7 @@ describe('CommandHandler (unit)', () => {
       allowedMentions: { parse: [] },
     });
     expect(interaction.editReply.mock.calls[0][0].content).toContain(
-      'Created verification channel: <#created-channel-1>'
+      'Created or reused verification channel: <#created-channel-1>'
     );
   });
 

--- a/src/__tests__/unit/CommandHandler.unit.test.ts
+++ b/src/__tests__/unit/CommandHandler.unit.test.ts
@@ -1350,6 +1350,13 @@ describe('CommandHandler (unit)', () => {
       embeds: expect.any(Array),
       components: expect.any(Array),
     });
+    const messagePayload = (existingMessage.edit as jest.Mock).mock.calls[0][0] as any;
+    expect(messagePayload.embeds[0].toJSON().title).toBe('Report a User');
+    const buttonJson = messagePayload.components[0].toJSON().components[0];
+    expect(buttonJson).toMatchObject({
+      custom_id: 'report_user_initiate',
+      label: 'Report a user',
+    });
     expect(targetChannel.send).not.toHaveBeenCalled();
     expect(configService.updateServerSettings).toHaveBeenCalledWith('guild-1', {
       report_instructions_channel_id: 'channel-1',

--- a/src/__tests__/unit/CommandHandler.unit.test.ts
+++ b/src/__tests__/unit/CommandHandler.unit.test.ts
@@ -979,6 +979,67 @@ describe('CommandHandler (unit)', () => {
     });
   });
 
+  it('validates setupverification against a configured verification channel when omitted', async () => {
+    const setupVerificationChannel = jest.fn().mockResolvedValue('configured-channel-1');
+    const validateSetupCandidate = jest.fn().mockResolvedValue({
+      guildId: 'guild-1',
+      checkedAt: new Date('2026-01-01T00:00:00.000Z'),
+      issues: [],
+      errorCount: 0,
+      warningCount: 0,
+    });
+    const getServerConfig = jest.fn().mockResolvedValue({
+      verification_channel_id: 'configured-channel-1',
+      settings: {},
+    });
+    const { handler, setupDiagnosticsService } = buildHandler({
+      setupVerificationChannel,
+      validateSetupCandidate,
+      getServerConfig,
+    });
+    const guild = {
+      id: 'guild-1',
+      channels: {
+        fetch: jest.fn().mockResolvedValue({
+          id: 'configured-channel-1',
+          type: ChannelType.GuildText,
+        }),
+      },
+    } as any;
+    const interaction = {
+      commandName: 'setupverification',
+      guild,
+      memberPermissions: {
+        has: jest.fn().mockReturnValue(true),
+      },
+      options: {
+        getRole: jest.fn().mockReturnValue({ id: 'role-1' }),
+        getChannel: jest.fn((name: string) => {
+          if (name === 'admin-channel') {
+            return { id: 'channel-1', type: ChannelType.GuildText };
+          }
+          return null;
+        }),
+      },
+      reply: jest.fn().mockResolvedValue(undefined),
+      deferReply: jest.fn().mockResolvedValue(undefined),
+      editReply: jest.fn().mockResolvedValue(undefined),
+    } as any;
+
+    await handler.handleSlashCommand(interaction);
+
+    expect(setupDiagnosticsService.validateSetupCandidate).toHaveBeenCalledWith(guild, {
+      restrictedRoleId: 'role-1',
+      willCreateRestrictedRole: false,
+      adminChannelId: 'channel-1',
+      verificationChannelId: 'configured-channel-1',
+      willCreateVerificationChannel: false,
+      willSyncVerificationChannelPermissions: true,
+      reportInstructionsChannelId: null,
+    });
+    expect(setupVerificationChannel).toHaveBeenCalledWith(guild, 'role-1', false);
+  });
+
   it('falls back to member fetch when setupverification memberPermissions is null', async () => {
     const permissionsIn = jest.fn().mockReturnValue({
       has: jest.fn().mockReturnValue(true),
@@ -1164,6 +1225,80 @@ describe('CommandHandler (unit)', () => {
       content: expect.stringContaining('Setup complete.'),
       allowedMentions: { parse: [] },
     });
+  });
+
+  it('validates /config setup against a configured verification channel when omitted', async () => {
+    const setupVerificationChannel = jest.fn().mockResolvedValue('configured-channel-1');
+    const validateSetupCandidate = jest.fn().mockResolvedValue({
+      guildId: 'guild-1',
+      checkedAt: new Date('2026-01-01T00:00:00.000Z'),
+      issues: [],
+      errorCount: 0,
+      warningCount: 0,
+    });
+    const getServerConfig = jest.fn().mockResolvedValue({
+      verification_channel_id: 'configured-channel-1',
+      settings: {},
+    });
+    const { handler, setupDiagnosticsService } = buildHandler({
+      setupVerificationChannel,
+      validateSetupCandidate,
+      getServerConfig,
+    });
+    const adminChannel = { id: 'admin-channel-1', type: ChannelType.GuildText } as any;
+    const restrictedRole = { id: 'role-1' } as any;
+    const guild = {
+      id: 'guild-1',
+      members: {
+        fetch: jest.fn().mockResolvedValue({
+          permissions: {
+            has: jest.fn().mockReturnValue(true),
+          },
+        }),
+      },
+      roles: {
+        create: jest.fn(),
+      },
+      channels: {
+        fetch: jest.fn().mockResolvedValue({
+          id: 'configured-channel-1',
+          type: ChannelType.GuildText,
+        }),
+      },
+    } as any;
+    const interaction = {
+      commandName: 'config',
+      user: { id: 'admin-1', tag: 'Admin#0001' },
+      guild,
+      options: {
+        getSubcommandGroup: jest.fn().mockReturnValue(null),
+        getSubcommand: jest.fn().mockReturnValue('setup'),
+        getChannel: jest.fn((name: string) => (name === 'admin-channel' ? adminChannel : null)),
+        getRole: jest.fn().mockReturnValue(restrictedRole),
+        getString: jest.fn().mockReturnValue(null),
+      },
+      reply: jest.fn().mockResolvedValue(undefined),
+      deferReply: jest.fn().mockResolvedValue(undefined),
+      editReply: jest.fn().mockResolvedValue(undefined),
+    } as any;
+
+    await handler.handleSlashCommand(interaction);
+
+    expect(setupDiagnosticsService.validateSetupCandidate).toHaveBeenCalledWith(guild, {
+      restrictedRoleId: 'role-1',
+      willCreateRestrictedRole: false,
+      adminChannelId: 'admin-channel-1',
+      verificationChannelId: 'configured-channel-1',
+      willCreateVerificationChannel: false,
+      willSyncVerificationChannelPermissions: true,
+      reportInstructionsChannelId: null,
+    });
+    expect(setupVerificationChannel).toHaveBeenCalledWith(
+      guild,
+      'role-1',
+      false,
+      expect.any(Function)
+    );
   });
 
   it('handles /config setup by creating the default restricted role and verification channel', async () => {

--- a/src/__tests__/unit/CommandHandler.unit.test.ts
+++ b/src/__tests__/unit/CommandHandler.unit.test.ts
@@ -1222,7 +1222,8 @@ describe('CommandHandler (unit)', () => {
     expect(notificationManager.setupVerificationChannel).toHaveBeenCalledWith(
       guild,
       'created-role-1',
-      false
+      false,
+      expect.any(Function)
     );
     expect(configService.updateServerConfig).toHaveBeenCalledWith('guild-1', {
       restricted_role_id: 'created-role-1',
@@ -1298,6 +1299,98 @@ describe('CommandHandler (unit)', () => {
       content: expect.stringContaining('newly created restricted role was removed'),
       allowedMentions: { parse: [] },
     });
+    consoleError.mockRestore();
+  });
+
+  it('rolls back created setup artifacts when config saving fails', async () => {
+    const consoleError = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+    const createdChannel = {
+      id: 'created-channel-1',
+      type: ChannelType.GuildText,
+      delete: jest.fn().mockResolvedValue(undefined),
+    } as any;
+    const setupVerificationChannel = jest
+      .fn()
+      .mockImplementation(async (_guild, _roleId, _persistConfig, onChannelCreated) => {
+        onChannelCreated?.('created-channel-1');
+        return 'created-channel-1';
+      });
+    const validateSetupCandidate = jest.fn().mockResolvedValue({
+      guildId: 'guild-1',
+      checkedAt: new Date('2026-01-01T00:00:00.000Z'),
+      issues: [],
+      errorCount: 0,
+      warningCount: 0,
+    });
+    const updateServerConfig = jest.fn().mockRejectedValue(new Error('database unavailable'));
+    const { handler, configService } = buildHandler({
+      setupVerificationChannel,
+      validateSetupCandidate,
+      updateServerConfig,
+    });
+    const adminChannel = { id: 'admin-channel-1', type: ChannelType.GuildText } as any;
+    const createdRole = {
+      id: 'created-role-1',
+      delete: jest.fn().mockResolvedValue(undefined),
+    } as any;
+    const guild = {
+      id: 'guild-1',
+      members: {
+        fetch: jest.fn().mockResolvedValue({
+          permissions: {
+            has: jest.fn().mockReturnValue(true),
+          },
+        }),
+      },
+      roles: {
+        create: jest.fn().mockResolvedValue(createdRole),
+      },
+      channels: {
+        cache: {
+          get: jest.fn().mockReturnValue(createdChannel),
+        },
+        fetch: jest.fn(),
+      },
+    } as any;
+    const interaction = {
+      commandName: 'config',
+      user: { id: 'admin-1', tag: 'Admin#0001' },
+      guild,
+      options: {
+        getSubcommandGroup: jest.fn().mockReturnValue(null),
+        getSubcommand: jest.fn().mockReturnValue('setup'),
+        getChannel: jest.fn((name: string) => (name === 'admin-channel' ? adminChannel : null)),
+        getRole: jest.fn().mockReturnValue(null),
+        getString: jest.fn().mockReturnValue(null),
+      },
+      reply: jest.fn().mockResolvedValue(undefined),
+      deferReply: jest.fn().mockResolvedValue(undefined),
+      editReply: jest.fn().mockResolvedValue(undefined),
+    } as any;
+
+    await handler.handleSlashCommand(interaction);
+
+    expect(configService.updateServerConfig).toHaveBeenCalledWith('guild-1', {
+      restricted_role_id: 'created-role-1',
+      admin_channel_id: 'admin-channel-1',
+      verification_channel_id: 'created-channel-1',
+    });
+    expect(createdChannel.delete).toHaveBeenCalledWith(
+      'Rolling back Drasil setup after config save failed'
+    );
+    expect(createdRole.delete).toHaveBeenCalledWith(
+      'Rolling back Drasil setup after config save failed'
+    );
+    expect(interaction.editReply).toHaveBeenCalledWith({
+      content: expect.stringContaining('Configuration could not be saved.'),
+      allowedMentions: { parse: [] },
+    });
+    expect(interaction.editReply.mock.calls[0][0].content).toContain(
+      'newly created verification channel was removed'
+    );
+    expect(interaction.editReply.mock.calls[0][0].content).toContain(
+      'newly created restricted role was removed'
+    );
     consoleError.mockRestore();
   });
 

--- a/src/__tests__/unit/CommandHandler.unit.test.ts
+++ b/src/__tests__/unit/CommandHandler.unit.test.ts
@@ -966,7 +966,12 @@ describe('CommandHandler (unit)', () => {
     expect((interaction.deferReply as jest.Mock).mock.invocationCallOrder[0]).toBeLessThan(
       setupVerificationChannel.mock.invocationCallOrder[0]
     );
-    expect(setupVerificationChannel).toHaveBeenCalledWith(guild, 'role-1', false);
+    expect(setupVerificationChannel).toHaveBeenCalledWith(
+      guild,
+      'role-1',
+      false,
+      expect.any(Function)
+    );
     expect(configService.updateServerConfig).toHaveBeenCalledWith('guild-1', {
       restricted_role_id: 'role-1',
       admin_channel_id: 'channel-1',
@@ -1037,7 +1042,79 @@ describe('CommandHandler (unit)', () => {
       willSyncVerificationChannelPermissions: true,
       reportInstructionsChannelId: null,
     });
-    expect(setupVerificationChannel).toHaveBeenCalledWith(guild, 'role-1', false);
+    expect(setupVerificationChannel).toHaveBeenCalledWith(
+      guild,
+      'role-1',
+      false,
+      expect.any(Function)
+    );
+  });
+
+  it('rolls back a created setupverification channel when config saving fails', async () => {
+    const consoleError = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+    const createdChannel = {
+      id: 'created-channel-1',
+      type: ChannelType.GuildText,
+      delete: jest.fn().mockResolvedValue(undefined),
+    } as any;
+    const setupVerificationChannel = jest
+      .fn()
+      .mockImplementation(async (_guild, _roleId, _persistConfig, onChannelCreated) => {
+        onChannelCreated?.('created-channel-1');
+        return 'created-channel-1';
+      });
+    const updateServerConfig = jest.fn().mockRejectedValue(new Error('database unavailable'));
+    const { handler, configService } = buildHandler({
+      setupVerificationChannel,
+      updateServerConfig,
+    });
+    const guild = {
+      id: 'guild-1',
+      channels: {
+        cache: {
+          get: jest.fn().mockReturnValue(createdChannel),
+        },
+        fetch: jest.fn(),
+      },
+    } as any;
+    const interaction: any = {
+      commandName: 'setupverification',
+      guild,
+      memberPermissions: {
+        has: jest.fn().mockReturnValue(true),
+      },
+      options: {
+        getRole: jest.fn().mockReturnValue({ id: 'role-1' }),
+        getChannel: jest.fn((name: string) => {
+          if (name === 'admin-channel') {
+            return { id: 'channel-1', type: ChannelType.GuildText };
+          }
+          return null;
+        }),
+      },
+      reply: jest.fn().mockResolvedValue(undefined),
+      deferReply: jest.fn().mockImplementation(async () => {
+        interaction.deferred = true;
+      }),
+      editReply: jest.fn().mockResolvedValue(undefined),
+      replied: false,
+      deferred: false,
+    };
+
+    await handler.handleSlashCommand(interaction);
+
+    expect(configService.updateServerConfig).toHaveBeenCalledWith('guild-1', {
+      restricted_role_id: 'role-1',
+      admin_channel_id: 'channel-1',
+      verification_channel_id: 'created-channel-1',
+    });
+    expect(createdChannel.delete).toHaveBeenCalledWith(
+      'Rolling back Drasil setup after config save failed'
+    );
+    expect(interaction.editReply).toHaveBeenCalledWith({
+      content: expect.stringContaining('newly created verification channel was removed'),
+    });
+    consoleError.mockRestore();
   });
 
   it('falls back to member fetch when setupverification memberPermissions is null', async () => {

--- a/src/__tests__/unit/CommandHandler.unit.test.ts
+++ b/src/__tests__/unit/CommandHandler.unit.test.ts
@@ -928,6 +928,7 @@ describe('CommandHandler (unit)', () => {
     expect(interaction.editReply).toHaveBeenCalledWith({
       content:
         'Setup complete.\nRestricted role: <@&role-1>\nAdmin channel: <#channel-1>\nVerification channel: <#channel-2>',
+      allowedMentions: { parse: [] },
     });
   });
 
@@ -974,6 +975,7 @@ describe('CommandHandler (unit)', () => {
     expect(interaction.editReply).toHaveBeenCalledWith({
       content:
         'Setup complete.\nRestricted role: <@&role-1>\nAdmin channel: <#channel-1>\nCreated or reused verification channel: <#created-channel-1>',
+      allowedMentions: { parse: [] },
     });
   });
 
@@ -1025,6 +1027,7 @@ describe('CommandHandler (unit)', () => {
     expect(interaction.editReply).toHaveBeenCalledWith({
       content:
         'Setup complete.\nRestricted role: <@&role-1>\nAdmin channel: <#channel-1>\nVerification channel: <#channel-2>',
+      allowedMentions: { parse: [] },
     });
   });
 
@@ -1233,6 +1236,93 @@ describe('CommandHandler (unit)', () => {
     expect(interaction.editReply.mock.calls[0][0].content).toContain(
       'Created or reused verification channel: <#created-channel-1>'
     );
+  });
+
+  it('keeps /config setup saved when optional report instructions fail', async () => {
+    const consoleError = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+    const validateSetupCandidate = jest.fn().mockResolvedValue({
+      guildId: 'guild-1',
+      checkedAt: new Date('2026-01-01T00:00:00.000Z'),
+      issues: [],
+      errorCount: 0,
+      warningCount: 0,
+    });
+    const updateServerConfig = jest.fn().mockResolvedValue({});
+    const updateServerSettings = jest.fn().mockResolvedValue({});
+    const getServerConfig = jest.fn().mockResolvedValue({ settings: {} });
+    const { handler, configService } = buildHandler({
+      validateSetupCandidate,
+      updateServerConfig,
+      updateServerSettings,
+      getServerConfig,
+    });
+    const adminChannel = { id: 'admin-channel-1', type: ChannelType.GuildText } as any;
+    const verificationChannel = {
+      id: 'verification-channel-1',
+      type: ChannelType.GuildText,
+    } as any;
+    const reportChannel = {
+      id: 'report-channel-1',
+      type: ChannelType.GuildText,
+      send: jest.fn().mockRejectedValue(new Error('missing embed links')),
+    } as any;
+    const restrictedRole = { id: 'role-1' } as any;
+    const guild = {
+      id: 'guild-1',
+      members: {
+        fetch: jest.fn().mockResolvedValue({
+          permissions: {
+            has: jest.fn().mockReturnValue(true),
+          },
+        }),
+      },
+      roles: {
+        create: jest.fn(),
+      },
+    } as any;
+    const interaction = {
+      commandName: 'config',
+      user: { id: 'admin-1', tag: 'Admin#0001' },
+      guild,
+      options: {
+        getSubcommandGroup: jest.fn().mockReturnValue(null),
+        getSubcommand: jest.fn().mockReturnValue('setup'),
+        getChannel: jest.fn((name: string) => {
+          if (name === 'admin-channel') {
+            return adminChannel;
+          }
+          if (name === 'verification-channel') {
+            return verificationChannel;
+          }
+          if (name === 'report-channel') {
+            return reportChannel;
+          }
+          return null;
+        }),
+        getRole: jest.fn().mockReturnValue(restrictedRole),
+        getString: jest.fn().mockReturnValue(null),
+      },
+      reply: jest.fn().mockResolvedValue(undefined),
+      deferReply: jest.fn().mockResolvedValue(undefined),
+      editReply: jest.fn().mockResolvedValue(undefined),
+    } as any;
+
+    await handler.handleSlashCommand(interaction);
+
+    expect(configService.updateServerConfig).toHaveBeenCalledWith('guild-1', {
+      restricted_role_id: 'role-1',
+      admin_channel_id: 'admin-channel-1',
+      verification_channel_id: 'verification-channel-1',
+    });
+    expect(reportChannel.send).toHaveBeenCalledTimes(1);
+    expect(configService.updateServerSettings).not.toHaveBeenCalled();
+    expect(interaction.editReply).toHaveBeenCalledWith({
+      content: expect.stringContaining(
+        'Core setup was saved, but report instructions were not updated'
+      ),
+      allowedMentions: { parse: [] },
+    });
+    consoleError.mockRestore();
   });
 
   it('blocks /config setup when candidate diagnostics have hard errors', async () => {

--- a/src/__tests__/unit/CommandHandler.unit.test.ts
+++ b/src/__tests__/unit/CommandHandler.unit.test.ts
@@ -1046,7 +1046,8 @@ describe('CommandHandler (unit)', () => {
       guild,
       'role-1',
       false,
-      expect.any(Function)
+      expect.any(Function),
+      'configured-channel-1'
     );
   });
 
@@ -1374,7 +1375,8 @@ describe('CommandHandler (unit)', () => {
       guild,
       'role-1',
       false,
-      expect.any(Function)
+      expect.any(Function),
+      'configured-channel-1'
     );
   });
 

--- a/src/__tests__/unit/CommandHandler.unit.test.ts
+++ b/src/__tests__/unit/CommandHandler.unit.test.ts
@@ -37,6 +37,7 @@ describe('CommandHandler (unit)', () => {
     handleUserReport: jest.Mock;
     handleMessageReport: jest.Mock;
     setupVerificationChannel: jest.Mock;
+    setupDiagnosticsService: any | null;
     validateGuildSetup: jest.Mock;
     validateSetupCandidate: jest.Mock;
     excludeDetectionFromAccounting: jest.Mock;
@@ -103,26 +104,29 @@ describe('CommandHandler (unit)', () => {
       setupVerificationChannel:
         overrides.setupVerificationChannel ?? jest.fn().mockResolvedValue('created-channel-1'),
     } as any;
-    const setupDiagnosticsService = {
-      validateGuildSetup:
-        overrides.validateGuildSetup ??
-        jest.fn().mockResolvedValue({
-          guildId: 'guild-1',
-          checkedAt: new Date('2026-01-01T00:00:00.000Z'),
-          issues: [],
-          errorCount: 0,
-          warningCount: 0,
-        }),
-      validateSetupCandidate:
-        overrides.validateSetupCandidate ??
-        jest.fn().mockResolvedValue({
-          guildId: 'guild-1',
-          checkedAt: new Date('2026-01-01T00:00:00.000Z'),
-          issues: [],
-          errorCount: 0,
-          warningCount: 0,
-        }),
-    } as any;
+    const setupDiagnosticsService =
+      overrides.setupDiagnosticsService === null
+        ? undefined
+        : ({
+            validateGuildSetup:
+              overrides.validateGuildSetup ??
+              jest.fn().mockResolvedValue({
+                guildId: 'guild-1',
+                checkedAt: new Date('2026-01-01T00:00:00.000Z'),
+                issues: [],
+                errorCount: 0,
+                warningCount: 0,
+              }),
+            validateSetupCandidate:
+              overrides.validateSetupCandidate ??
+              jest.fn().mockResolvedValue({
+                guildId: 'guild-1',
+                checkedAt: new Date('2026-01-01T00:00:00.000Z'),
+                issues: [],
+                errorCount: 0,
+                warningCount: 0,
+              }),
+          } as any);
     const client = {
       user: { id: 'client-1' },
     } as any;
@@ -1052,6 +1056,44 @@ describe('CommandHandler (unit)', () => {
     expect(interaction.editReply.mock.calls[0][0].content).toContain(
       'Synced verification channel permissions: <#configured-channel-1>'
     );
+  });
+
+  it('blocks setupverification when setup diagnostics are unavailable', async () => {
+    const { handler, configService, notificationManager } = buildHandler({
+      setupDiagnosticsService: null,
+    });
+    const guild = {
+      id: 'guild-1',
+    } as any;
+    const interaction = {
+      commandName: 'setupverification',
+      guild,
+      memberPermissions: {
+        has: jest.fn().mockReturnValue(true),
+      },
+      options: {
+        getRole: jest.fn().mockReturnValue({ id: 'role-1' }),
+        getChannel: jest.fn((name: string) => {
+          if (name === 'admin-channel') {
+            return { id: 'channel-1', type: ChannelType.GuildText };
+          }
+          return null;
+        }),
+      },
+      reply: jest.fn().mockResolvedValue(undefined),
+      deferReply: jest.fn().mockResolvedValue(undefined),
+      editReply: jest.fn().mockResolvedValue(undefined),
+    } as any;
+
+    await handler.handleSlashCommand(interaction);
+
+    expect(interaction.reply).toHaveBeenCalledWith({
+      content: 'Setup diagnostics are not available in this runtime.',
+      flags: MessageFlags.Ephemeral,
+    });
+    expect(interaction.deferReply).not.toHaveBeenCalled();
+    expect(notificationManager.setupVerificationChannel).not.toHaveBeenCalled();
+    expect(configService.updateServerConfig).not.toHaveBeenCalled();
   });
 
   it('rolls back a created setupverification channel when config saving fails', async () => {

--- a/src/__tests__/unit/CommandHandler.unit.test.ts
+++ b/src/__tests__/unit/CommandHandler.unit.test.ts
@@ -1259,7 +1259,7 @@ describe('CommandHandler (unit)', () => {
     } as any;
     const interaction = {
       commandName: 'config',
-      user: { id: 'admin-1', tag: 'Admin#0001' },
+      user: { id: 'admin-1', username: 'Admin', tag: 'Admin#0001' },
       guild,
       options: {
         getSubcommandGroup: jest.fn().mockReturnValue(null),
@@ -1346,7 +1346,7 @@ describe('CommandHandler (unit)', () => {
     } as any;
     const interaction = {
       commandName: 'config',
-      user: { id: 'admin-1', tag: 'Admin#0001' },
+      user: { id: 'admin-1', username: 'Admin', tag: 'Admin#0001' },
       guild,
       options: {
         getSubcommandGroup: jest.fn().mockReturnValue(null),
@@ -1412,7 +1412,7 @@ describe('CommandHandler (unit)', () => {
     } as any;
     const interaction = {
       commandName: 'config',
-      user: { id: 'admin-1', tag: 'Admin#0001' },
+      user: { id: 'admin-1', username: 'Admin', tag: 'Admin#0001' },
       guild,
       options: {
         getSubcommandGroup: jest.fn().mockReturnValue(null),
@@ -1431,7 +1431,7 @@ describe('CommandHandler (unit)', () => {
     expect(guild.roles.create).toHaveBeenCalledWith({
       name: 'Drasil Restricted',
       permissions: [],
-      reason: 'Drasil setup requested by Admin#0001',
+      reason: 'Drasil setup requested by Admin',
     });
     expect(notificationManager.setupVerificationChannel).toHaveBeenCalledWith(
       guild,
@@ -1489,7 +1489,7 @@ describe('CommandHandler (unit)', () => {
     } as any;
     const interaction = {
       commandName: 'config',
-      user: { id: 'admin-1', tag: 'Admin#0001' },
+      user: { id: 'admin-1', username: 'Admin', tag: 'Admin#0001' },
       guild,
       options: {
         getSubcommandGroup: jest.fn().mockReturnValue(null),
@@ -1568,7 +1568,7 @@ describe('CommandHandler (unit)', () => {
     } as any;
     const interaction = {
       commandName: 'config',
-      user: { id: 'admin-1', tag: 'Admin#0001' },
+      user: { id: 'admin-1', username: 'Admin', tag: 'Admin#0001' },
       guild,
       options: {
         getSubcommandGroup: jest.fn().mockReturnValue(null),
@@ -1652,7 +1652,7 @@ describe('CommandHandler (unit)', () => {
     } as any;
     const interaction = {
       commandName: 'config',
-      user: { id: 'admin-1', tag: 'Admin#0001' },
+      user: { id: 'admin-1', username: 'Admin', tag: 'Admin#0001' },
       guild,
       options: {
         getSubcommandGroup: jest.fn().mockReturnValue(null),
@@ -1732,7 +1732,7 @@ describe('CommandHandler (unit)', () => {
     } as any;
     const interaction = {
       commandName: 'config',
-      user: { id: 'admin-1', tag: 'Admin#0001' },
+      user: { id: 'admin-1', username: 'Admin', tag: 'Admin#0001' },
       guild,
       options: {
         getSubcommandGroup: jest.fn().mockReturnValue(null),
@@ -1784,7 +1784,7 @@ describe('CommandHandler (unit)', () => {
     } as any;
     const interaction = {
       commandName: 'config',
-      user: { id: 'admin-1', tag: 'Admin#0001' },
+      user: { id: 'admin-1', username: 'Admin', tag: 'Admin#0001' },
       guild,
       options: {
         getSubcommandGroup: jest.fn().mockReturnValue(null),

--- a/src/__tests__/unit/EventHandler.unit.test.ts
+++ b/src/__tests__/unit/EventHandler.unit.test.ts
@@ -4,9 +4,12 @@ import { DetectionType } from '../../repositories/types';
 
 describe('EventHandler (unit)', () => {
   function buildHandler(overrides?: {
+    client?: Record<string, unknown>;
     detectionOrchestrator?: Record<string, jest.Mock>;
     configService?: Record<string, jest.Mock>;
+    notificationManager?: Record<string, jest.Mock>;
   }): EventHandler {
+    const client = overrides?.client ?? { on: jest.fn(), user: { id: 'bot-1' } };
     const detectionOrchestrator = overrides?.detectionOrchestrator ?? {
       detectMessage: jest.fn().mockResolvedValue({
         label: 'OK',
@@ -28,20 +31,26 @@ describe('EventHandler (unit)', () => {
       initialize: jest.fn().mockResolvedValue(undefined),
       getCachedServerConfig: jest.fn().mockReturnValue({}),
       getServerConfig: jest.fn().mockResolvedValue({
+        restricted_role_id: null,
+        admin_channel_id: null,
+        verification_channel_id: null,
         settings: {
           detection_response_mode: 'notify_only',
           min_confidence_threshold: 70,
         },
       }),
+      updateServerConfig: jest.fn().mockResolvedValue({}),
+      updateServerSettings: jest.fn().mockResolvedValue({}),
+    };
+    const notificationManager = overrides?.notificationManager ?? {
+      upsertObservedDetectionNotification: jest.fn(),
+      setupVerificationChannel: jest.fn(),
     };
 
     return new EventHandler(
-      { on: jest.fn() } as any,
+      client as any,
       detectionOrchestrator as any,
-      {
-        upsertObservedDetectionNotification: jest.fn(),
-        setupVerificationChannel: jest.fn(),
-      } as any,
+      notificationManager as any,
       configService as any,
       { handleSuspiciousMessage: jest.fn(), openCaseForSuspiciousMessage: jest.fn() } as any,
       { handleTestCommands: jest.fn(), registerCommands: jest.fn() } as any,
@@ -349,5 +358,133 @@ describe('EventHandler (unit)', () => {
         username: 'test-user',
       })
     );
+  });
+
+  it('sends a setup nudge to the audit-log installer on guild create', async () => {
+    const installer = {
+      id: 'installer-1',
+      bot: false,
+      send: jest.fn().mockResolvedValue(undefined),
+    };
+    const configService = {
+      initialize: jest.fn().mockResolvedValue(undefined),
+      getCachedServerConfig: jest.fn().mockReturnValue({}),
+      getServerConfig: jest.fn().mockResolvedValue({
+        guild_id: 'guild-1',
+        restricted_role_id: null,
+        admin_channel_id: null,
+        verification_channel_id: null,
+        settings: {},
+      }),
+      updateServerConfig: jest.fn().mockResolvedValue({}),
+      updateServerSettings: jest.fn().mockResolvedValue({}),
+    };
+    const notificationManager = {
+      upsertObservedDetectionNotification: jest.fn(),
+      setupVerificationChannel: jest.fn(),
+    };
+    const handler = buildHandler({ configService, notificationManager });
+    const auditEntries = [
+      {
+        target: { id: 'bot-1' },
+        executor: installer,
+      },
+    ];
+    const guild = {
+      id: 'guild-1',
+      name: 'Test Guild',
+      fetchAuditLogs: jest.fn().mockResolvedValue({
+        entries: {
+          find: jest.fn((predicate: NonNullable<Parameters<typeof auditEntries.find>[0]>) =>
+            auditEntries.find(predicate)
+          ),
+        },
+      }),
+      fetchOwner: jest.fn(),
+    } as any;
+
+    await (handler as any).handleGuildCreate(guild);
+
+    expect(installer.send).toHaveBeenCalledWith(expect.stringContaining('/config setup'));
+    expect(configService.updateServerSettings).toHaveBeenCalledWith('guild-1', {
+      setup_nudge_last_attempt_at: expect.any(String),
+      setup_nudge_last_recipient_id: 'installer-1',
+      setup_nudge_last_result: 'sent',
+      setup_nudge_last_source: 'audit_log_installer',
+    });
+    expect(guild.fetchOwner).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the guild owner when installer attribution is unavailable', async () => {
+    const ownerUser = {
+      id: 'owner-1',
+      send: jest.fn().mockResolvedValue(undefined),
+    };
+    const configService = {
+      initialize: jest.fn().mockResolvedValue(undefined),
+      getCachedServerConfig: jest.fn().mockReturnValue({}),
+      getServerConfig: jest.fn().mockResolvedValue({
+        guild_id: 'guild-1',
+        restricted_role_id: null,
+        admin_channel_id: null,
+        verification_channel_id: null,
+        settings: {},
+      }),
+      updateServerConfig: jest.fn().mockResolvedValue({}),
+      updateServerSettings: jest.fn().mockResolvedValue({}),
+    };
+    const handler = buildHandler({ configService });
+    const guild = {
+      id: 'guild-1',
+      name: 'Test Guild',
+      fetchAuditLogs: jest.fn().mockRejectedValue(new Error('missing permission')),
+      fetchOwner: jest.fn().mockResolvedValue({ user: ownerUser }),
+    } as any;
+
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+    try {
+      await (handler as any).handleGuildCreate(guild);
+    } finally {
+      warnSpy.mockRestore();
+    }
+
+    expect(ownerUser.send).toHaveBeenCalledWith(expect.stringContaining('/config validate'));
+    expect(configService.updateServerSettings).toHaveBeenCalledWith('guild-1', {
+      setup_nudge_last_attempt_at: expect.any(String),
+      setup_nudge_last_recipient_id: 'owner-1',
+      setup_nudge_last_result: 'sent',
+      setup_nudge_last_source: 'owner',
+    });
+  });
+
+  it('suppresses repeated setup nudges after a recent attempt', async () => {
+    const configService = {
+      initialize: jest.fn().mockResolvedValue(undefined),
+      getCachedServerConfig: jest.fn().mockReturnValue({}),
+      getServerConfig: jest.fn().mockResolvedValue({
+        guild_id: 'guild-1',
+        restricted_role_id: null,
+        admin_channel_id: null,
+        verification_channel_id: null,
+        settings: {
+          setup_nudge_last_attempt_at: new Date().toISOString(),
+        },
+      }),
+      updateServerConfig: jest.fn().mockResolvedValue({}),
+      updateServerSettings: jest.fn().mockResolvedValue({}),
+    };
+    const handler = buildHandler({ configService });
+    const guild = {
+      id: 'guild-1',
+      name: 'Test Guild',
+      fetchAuditLogs: jest.fn(),
+      fetchOwner: jest.fn(),
+    } as any;
+
+    await (handler as any).handleGuildCreate(guild);
+
+    expect(guild.fetchAuditLogs).not.toHaveBeenCalled();
+    expect(guild.fetchOwner).not.toHaveBeenCalled();
+    expect(configService.updateServerSettings).not.toHaveBeenCalled();
   });
 });

--- a/src/__tests__/unit/EventHandler.unit.test.ts
+++ b/src/__tests__/unit/EventHandler.unit.test.ts
@@ -457,6 +457,49 @@ describe('EventHandler (unit)', () => {
     });
   });
 
+  it('skips setup nudge when the fallback owner is a bot', async () => {
+    const ownerUser = {
+      id: 'owner-bot-1',
+      bot: true,
+      send: jest.fn().mockResolvedValue(undefined),
+    };
+    const configService = {
+      initialize: jest.fn().mockResolvedValue(undefined),
+      getCachedServerConfig: jest.fn().mockReturnValue({}),
+      getServerConfig: jest.fn().mockResolvedValue({
+        guild_id: 'guild-1',
+        restricted_role_id: null,
+        admin_channel_id: null,
+        verification_channel_id: null,
+        settings: {},
+      }),
+      updateServerConfig: jest.fn().mockResolvedValue({}),
+      updateServerSettings: jest.fn().mockResolvedValue({}),
+    };
+    const handler = buildHandler({ configService });
+    const guild = {
+      id: 'guild-1',
+      name: 'Test Guild',
+      fetchAuditLogs: jest.fn().mockRejectedValue(new Error('missing permission')),
+      fetchOwner: jest.fn().mockResolvedValue({ user: ownerUser }),
+    } as any;
+
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+    try {
+      await (handler as any).handleGuildCreate(guild);
+    } finally {
+      warnSpy.mockRestore();
+    }
+
+    expect(ownerUser.send).not.toHaveBeenCalled();
+    expect(configService.updateServerSettings).toHaveBeenCalledWith('guild-1', {
+      setup_nudge_last_attempt_at: expect.any(String),
+      setup_nudge_last_recipient_id: null,
+      setup_nudge_last_result: 'no_recipient',
+      setup_nudge_last_source: null,
+    });
+  });
+
   it('suppresses repeated setup nudges after a recent attempt', async () => {
     const configService = {
       initialize: jest.fn().mockResolvedValue(undefined),

--- a/src/__tests__/unit/EventHandler.unit.test.ts
+++ b/src/__tests__/unit/EventHandler.unit.test.ts
@@ -500,6 +500,61 @@ describe('EventHandler (unit)', () => {
     });
   });
 
+  it('does not fail guild create when setup nudge metadata cannot be saved', async () => {
+    const installer = {
+      id: 'installer-1',
+      bot: false,
+      send: jest.fn().mockResolvedValue(undefined),
+    };
+    const configService = {
+      initialize: jest.fn().mockResolvedValue(undefined),
+      getCachedServerConfig: jest.fn().mockReturnValue({}),
+      getServerConfig: jest.fn().mockResolvedValue({
+        guild_id: 'guild-1',
+        restricted_role_id: null,
+        admin_channel_id: null,
+        verification_channel_id: null,
+        settings: {},
+      }),
+      updateServerConfig: jest.fn().mockResolvedValue({}),
+      updateServerSettings: jest.fn().mockRejectedValue(new Error('database unavailable')),
+    };
+    const handler = buildHandler({ configService });
+    const auditEntries = [
+      {
+        target: { id: 'bot-1' },
+        executor: installer,
+      },
+    ];
+    const guild = {
+      id: 'guild-1',
+      name: 'Test Guild',
+      fetchAuditLogs: jest.fn().mockResolvedValue({
+        entries: {
+          find: jest.fn((predicate: NonNullable<Parameters<typeof auditEntries.find>[0]>) =>
+            auditEntries.find(predicate)
+          ),
+        },
+      }),
+      fetchOwner: jest.fn(),
+    } as any;
+
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+    try {
+      await (handler as any).handleGuildCreate(guild);
+    } finally {
+      warnSpy.mockRestore();
+    }
+
+    expect(installer.send).toHaveBeenCalledWith(expect.stringContaining('/config setup'));
+    expect(configService.updateServerSettings).toHaveBeenCalledWith('guild-1', {
+      setup_nudge_last_attempt_at: expect.any(String),
+      setup_nudge_last_recipient_id: 'installer-1',
+      setup_nudge_last_result: 'sent',
+      setup_nudge_last_source: 'audit_log_installer',
+    });
+  });
+
   it('suppresses repeated setup nudges after a recent attempt', async () => {
     const configService = {
       initialize: jest.fn().mockResolvedValue(undefined),

--- a/src/__tests__/unit/InteractionHandler.unit.test.ts
+++ b/src/__tests__/unit/InteractionHandler.unit.test.ts
@@ -858,6 +858,8 @@ describe('InteractionHandler (unit)', () => {
           return 'reported';
         }),
       },
+      deferReply: jest.fn().mockResolvedValue(undefined),
+      editReply: jest.fn().mockResolvedValue(undefined),
       reply: jest.fn().mockResolvedValue(undefined),
       followUp: jest.fn().mockResolvedValue(undefined),
       replied: false,
@@ -871,10 +873,13 @@ describe('InteractionHandler (unit)', () => {
       interaction.user,
       'reported'
     );
-    expect(interaction.reply).toHaveBeenCalledWith({
+    expect(interaction.deferReply).toHaveBeenCalledWith({ flags: MessageFlags.Ephemeral });
+    expect((interaction.deferReply as jest.Mock).mock.invocationCallOrder[0]).toBeLessThan(
+      (client.guilds.fetch as jest.Mock).mock.invocationCallOrder[0]
+    );
+    expect(interaction.editReply).toHaveBeenCalledWith({
       content:
         'Thank you for your report regarding <@123456789012345678>. It has been submitted for review.',
-      flags: MessageFlags.Ephemeral,
       allowedMentions: { parse: [] },
     });
   });
@@ -914,6 +919,8 @@ describe('InteractionHandler (unit)', () => {
           return 'reported';
         }),
       },
+      deferReply: jest.fn().mockResolvedValue(undefined),
+      editReply: jest.fn().mockResolvedValue(undefined),
       reply: jest.fn().mockResolvedValue(undefined),
       followUp: jest.fn().mockResolvedValue(undefined),
       replied: false,
@@ -923,9 +930,8 @@ describe('InteractionHandler (unit)', () => {
     await handler.handleModalSubmit(interaction);
 
     expect(securityActionService.handleUserReport).not.toHaveBeenCalled();
-    expect(interaction.reply).toHaveBeenCalledWith({
+    expect(interaction.editReply).toHaveBeenCalledWith({
       content: 'Could not find a user matching "123456789012345678" in this server.',
-      flags: MessageFlags.Ephemeral,
     });
   });
 
@@ -1041,6 +1047,8 @@ describe('InteractionHandler (unit)', () => {
           return 'reported';
         }),
       },
+      deferReply: jest.fn().mockResolvedValue(undefined),
+      editReply: jest.fn().mockResolvedValue(undefined),
       reply: jest.fn().mockResolvedValue(undefined),
       followUp: jest.fn().mockResolvedValue(undefined),
       replied: false,
@@ -1108,6 +1116,8 @@ describe('InteractionHandler (unit)', () => {
           return 'reported';
         }),
       },
+      deferReply: jest.fn().mockResolvedValue(undefined),
+      editReply: jest.fn().mockResolvedValue(undefined),
       reply: jest.fn().mockResolvedValue(undefined),
       followUp: jest.fn().mockResolvedValue(undefined),
       replied: false,
@@ -1182,6 +1192,8 @@ describe('InteractionHandler (unit)', () => {
           return 'reported';
         }),
       },
+      deferReply: jest.fn().mockResolvedValue(undefined),
+      editReply: jest.fn().mockResolvedValue(undefined),
       reply: jest.fn().mockResolvedValue(undefined),
       followUp: jest.fn().mockResolvedValue(undefined),
       replied: false,
@@ -1191,9 +1203,8 @@ describe('InteractionHandler (unit)', () => {
     await handler.handleModalSubmit(interaction);
 
     expect(securityActionService.handleUserReport).not.toHaveBeenCalled();
-    expect(interaction.reply).toHaveBeenCalledWith({
+    expect(interaction.editReply).toHaveBeenCalledWith({
       content: 'Multiple users match that name. Please use their ID or @mention instead.',
-      flags: MessageFlags.Ephemeral,
     });
   });
 
@@ -1227,6 +1238,8 @@ describe('InteractionHandler (unit)', () => {
           return '   ';
         }),
       },
+      deferReply: jest.fn().mockResolvedValue(undefined),
+      editReply: jest.fn().mockResolvedValue(undefined),
       reply: jest.fn().mockResolvedValue(undefined),
       followUp: jest.fn().mockResolvedValue(undefined),
       replied: false,
@@ -1236,9 +1249,8 @@ describe('InteractionHandler (unit)', () => {
     await handler.handleModalSubmit(interaction);
 
     expect(securityActionService.handleUserReport).not.toHaveBeenCalled();
-    expect(interaction.reply).toHaveBeenCalledWith({
+    expect(interaction.editReply).toHaveBeenCalledWith({
       content: 'Please include a reason for this report.',
-      flags: MessageFlags.Ephemeral,
     });
   });
 
@@ -1273,6 +1285,8 @@ describe('InteractionHandler (unit)', () => {
           return 'reported';
         }),
       },
+      deferReply: jest.fn().mockResolvedValue(undefined),
+      editReply: jest.fn().mockResolvedValue(undefined),
       reply: jest.fn().mockResolvedValue(undefined),
       followUp: jest.fn().mockResolvedValue(undefined),
       replied: false,
@@ -1282,9 +1296,8 @@ describe('InteractionHandler (unit)', () => {
     await handler.handleModalSubmit(interaction);
 
     expect(securityActionService.handleUserReport).not.toHaveBeenCalled();
-    expect(interaction.reply).toHaveBeenCalledWith({
+    expect(interaction.editReply).toHaveBeenCalledWith({
       content: 'You cannot report yourself.',
-      flags: MessageFlags.Ephemeral,
     });
   });
 
@@ -1607,6 +1620,8 @@ describe('InteractionHandler (unit)', () => {
       fields: {
         getTextInputValue: jest.fn(() => 'selected report reason'),
       },
+      deferReply: jest.fn().mockResolvedValue(undefined),
+      editReply: jest.fn().mockResolvedValue(undefined),
       reply: jest.fn().mockResolvedValue(undefined),
       followUp: jest.fn().mockResolvedValue(undefined),
       replied: false,
@@ -1620,10 +1635,13 @@ describe('InteractionHandler (unit)', () => {
       interaction.user,
       'selected report reason'
     );
-    expect(interaction.reply).toHaveBeenCalledWith({
+    expect(interaction.deferReply).toHaveBeenCalledWith({ flags: MessageFlags.Ephemeral });
+    expect((interaction.deferReply as jest.Mock).mock.invocationCallOrder[0]).toBeLessThan(
+      (client.guilds.fetch as jest.Mock).mock.invocationCallOrder[0]
+    );
+    expect(interaction.editReply).toHaveBeenCalledWith({
       content:
         'Thank you for your report regarding <@123456789012345678>. It has been submitted for review.',
-      flags: MessageFlags.Ephemeral,
       allowedMentions: { parse: [] },
     });
   });

--- a/src/__tests__/unit/InteractionHandler.unit.test.ts
+++ b/src/__tests__/unit/InteractionHandler.unit.test.ts
@@ -8,6 +8,7 @@ import {
   ModalSubmitInteraction,
   PermissionFlagsBits,
   User,
+  UserSelectMenuInteraction,
 } from 'discord.js';
 import { InteractionHandler } from '../../controllers/InteractionHandler';
 import { INotificationManager } from '../../services/NotificationManager';
@@ -60,6 +61,28 @@ const buildInteraction = (customId: string, guildId: string, user: User): Button
     showModal: jest.fn().mockResolvedValue(undefined),
   };
   return interaction as unknown as ButtonInteraction;
+};
+
+const buildUserSelectInteraction = (
+  customId: string,
+  guildId: string,
+  user: User,
+  values: string[]
+): UserSelectMenuInteraction => {
+  const interaction = {
+    customId,
+    guildId,
+    user,
+    values,
+    deferred: false,
+    replied: false,
+    reply: jest.fn().mockImplementation(async () => {
+      interaction.replied = true;
+    }),
+    followUp: jest.fn().mockResolvedValue(undefined),
+    showModal: jest.fn().mockResolvedValue(undefined),
+  };
+  return interaction as unknown as UserSelectMenuInteraction;
 };
 
 const grantInteractionPermissions = (
@@ -1494,7 +1517,7 @@ describe('InteractionHandler (unit)', () => {
     });
   });
 
-  it('routes report button clicks to typed report command guidance', async () => {
+  it('routes report button clicks to a user picker', async () => {
     const handler = new InteractionHandler(
       client,
       notificationManager,
@@ -1511,13 +1534,97 @@ describe('InteractionHandler (unit)', () => {
 
     await handler.handleButtonInteraction(interaction);
 
-    expect(interaction.reply).toHaveBeenCalledWith({
-      content:
-        "Use `/report` and choose the user from Discord's user picker, or right-click the user and choose `Apps` -> `Report User`. Discord buttons cannot collect a typed user argument safely.",
-      flags: MessageFlags.Ephemeral,
-    });
+    expect(interaction.reply).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: 'Choose the user you want to report. Only you can see this picker.',
+        flags: MessageFlags.Ephemeral,
+      })
+    );
+    const replyPayload = (interaction.reply as jest.Mock).mock.calls[0][0] as any;
+    const selectJson = replyPayload.components[0].toJSON().components[0];
+    expect(selectJson.custom_id).toBe('report_user_select');
+    expect(selectJson.placeholder).toBe('Choose the user to report');
     expect(interaction.showModal).not.toHaveBeenCalled();
     expect(configService.getCachedServerConfig).not.toHaveBeenCalled();
     expect(configService.getServerConfig).not.toHaveBeenCalled();
+  });
+
+  it('opens a report reason modal after report user picker selection', async () => {
+    const handler = new InteractionHandler(
+      client,
+      notificationManager,
+      userModerationService,
+      securityActionService,
+      configService,
+      verificationEventRepository,
+      threadManager,
+      adminActionRepository
+    );
+    const interaction = buildUserSelectInteraction(
+      'report_user_select',
+      'guild-1',
+      { id: 'reporter-1' } as User,
+      ['123456789012345678']
+    );
+
+    await handler.handleUserSelectMenuInteraction(interaction);
+
+    expect(interaction.showModal).toHaveBeenCalledTimes(1);
+    const modal = (interaction.showModal as jest.Mock).mock.calls[0][0] as any;
+    const modalJson = modal.toJSON();
+    expect(modalJson.custom_id).toBe('report_user_reason_modal:123456789012345678');
+    expect(modalJson.title).toBe('Report User');
+    expect(modalJson.components[0].components[0]).toMatchObject({
+      custom_id: 'report_reason',
+      label: 'Reason (optional)',
+      required: false,
+    });
+  });
+
+  it('submits a report from the selected user reason modal', async () => {
+    const member = buildMember('guild-1', '123456789012345678');
+    (client.guilds.fetch as jest.Mock).mockResolvedValue({
+      members: {
+        fetch: jest.fn().mockResolvedValue(member),
+      },
+    });
+
+    const handler = new InteractionHandler(
+      client,
+      notificationManager,
+      userModerationService,
+      securityActionService,
+      configService,
+      verificationEventRepository,
+      threadManager,
+      adminActionRepository
+    );
+
+    const interaction = {
+      customId: 'report_user_reason_modal:123456789012345678',
+      guildId: 'guild-1',
+      user: { id: 'reporter-1' } as User,
+      fields: {
+        getTextInputValue: jest.fn(() => 'selected report reason'),
+      },
+      reply: jest.fn().mockResolvedValue(undefined),
+      followUp: jest.fn().mockResolvedValue(undefined),
+      replied: false,
+      deferred: false,
+    } as unknown as ModalSubmitInteraction;
+
+    await handler.handleModalSubmit(interaction);
+
+    expect(securityActionService.handleUserReport).toHaveBeenCalledWith(
+      member,
+      interaction.user,
+      'selected report reason'
+    );
+    expect(interaction.reply).toHaveBeenCalledWith({
+      content:
+        'Thank you for your report regarding <@123456789012345678>. It has been submitted for review.',
+      flags: MessageFlags.Ephemeral,
+      allowedMentions: { parse: [] },
+    });
   });
 });

--- a/src/__tests__/unit/InteractionHandler.unit.test.ts
+++ b/src/__tests__/unit/InteractionHandler.unit.test.ts
@@ -1592,6 +1592,8 @@ describe('InteractionHandler (unit)', () => {
       label: 'Reason (optional)',
       required: false,
     });
+    expect(configService.getCachedServerConfig).not.toHaveBeenCalled();
+    expect(configService.getServerConfig).not.toHaveBeenCalled();
   });
 
   it('submits a report from the selected user reason modal', async () => {

--- a/src/__tests__/unit/NotificationManager.unit.test.ts
+++ b/src/__tests__/unit/NotificationManager.unit.test.ts
@@ -891,6 +891,54 @@ describe('NotificationManager (unit)', () => {
     });
   });
 
+  it('syncs an already resolved verification channel without rereading config', async () => {
+    const overwriteSet = jest.fn().mockResolvedValue(undefined);
+    const existingChannel = {
+      id: 'verification-channel-1',
+      type: ChannelType.GuildText,
+      permissionOverwrites: {
+        set: overwriteSet,
+      },
+    };
+    const createChannel = jest.fn();
+    const fetchChannel = jest.fn().mockResolvedValue(existingChannel);
+    configService.getServerConfig = jest.fn();
+    const guild = {
+      id: 'guild-1',
+      roles: {
+        everyone: { id: 'guild-1' },
+        cache: {
+          filter: jest.fn().mockReturnValue([]),
+        },
+      },
+      channels: {
+        cache: buildChannelCollection([]),
+        fetch: fetchChannel,
+        create: createChannel,
+      },
+    } as unknown as Guild;
+
+    const manager = new NotificationManager({} as any, configService, detectionRepository);
+
+    const channelId = await manager.setupVerificationChannel(
+      guild,
+      'restricted-role-1',
+      false,
+      undefined,
+      'verification-channel-1'
+    );
+
+    expect(channelId).toBe('verification-channel-1');
+    expect(configService.getServerConfig).not.toHaveBeenCalled();
+    expect(fetchChannel).toHaveBeenCalledWith('verification-channel-1');
+    expect(overwriteSet).toHaveBeenCalledWith(
+      expect.arrayContaining([expect.objectContaining({ id: 'restricted-role-1' })]),
+      'Sync Drasil verification channel permissions'
+    );
+    expect(createChannel).not.toHaveBeenCalled();
+    expect(configService.updateServerConfig).not.toHaveBeenCalled();
+  });
+
   it('does not reuse an arbitrary channel named verification without a stored config id', async () => {
     const overwriteSet = jest.fn().mockResolvedValue(undefined);
     const existingChannel = {

--- a/src/__tests__/unit/NotificationManager.unit.test.ts
+++ b/src/__tests__/unit/NotificationManager.unit.test.ts
@@ -842,15 +842,25 @@ describe('NotificationManager (unit)', () => {
   });
 
   it('reuses an existing verification text channel instead of creating a duplicate', async () => {
+    const overwriteSet = jest.fn().mockResolvedValue(undefined);
     const existingChannel = {
       id: 'verification-channel-1',
       name: 'verification',
       type: ChannelType.GuildText,
+      permissionOverwrites: {
+        set: overwriteSet,
+      },
     };
     const createChannel = jest.fn();
     const fetchChannels = jest.fn().mockResolvedValue(buildChannelCollection([existingChannel]));
     const guild = {
       id: 'guild-1',
+      roles: {
+        everyone: { id: 'guild-1' },
+        cache: {
+          filter: jest.fn().mockReturnValue([]),
+        },
+      },
       channels: {
         cache: buildChannelCollection([]),
         fetch: fetchChannels,
@@ -864,6 +874,13 @@ describe('NotificationManager (unit)', () => {
 
     expect(channelId).toBe('verification-channel-1');
     expect(fetchChannels).toHaveBeenCalledTimes(1);
+    expect(overwriteSet).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        expect.objectContaining({ id: 'guild-1' }),
+        expect.objectContaining({ id: 'restricted-role-1' }),
+      ]),
+      'Sync Drasil verification channel permissions'
+    );
     expect(createChannel).not.toHaveBeenCalled();
     expect(configService.updateServerConfig).toHaveBeenCalledWith('guild-1', {
       verification_channel_id: 'verification-channel-1',

--- a/src/__tests__/unit/NotificationManager.unit.test.ts
+++ b/src/__tests__/unit/NotificationManager.unit.test.ts
@@ -841,7 +841,7 @@ describe('NotificationManager (unit)', () => {
     );
   });
 
-  it('reuses an existing verification text channel instead of creating a duplicate', async () => {
+  it('reuses the configured verification text channel instead of creating a duplicate', async () => {
     const overwriteSet = jest.fn().mockResolvedValue(undefined);
     const existingChannel = {
       id: 'verification-channel-1',
@@ -852,7 +852,11 @@ describe('NotificationManager (unit)', () => {
       },
     };
     const createChannel = jest.fn();
-    const fetchChannels = jest.fn().mockResolvedValue(buildChannelCollection([existingChannel]));
+    const fetchChannel = jest.fn().mockResolvedValue(existingChannel);
+    configService.getServerConfig = jest.fn().mockResolvedValue({
+      verification_channel_id: 'verification-channel-1',
+      settings: {},
+    } as any);
     const guild = {
       id: 'guild-1',
       roles: {
@@ -863,7 +867,7 @@ describe('NotificationManager (unit)', () => {
       },
       channels: {
         cache: buildChannelCollection([]),
-        fetch: fetchChannels,
+        fetch: fetchChannel,
         create: createChannel,
       },
     } as unknown as Guild;
@@ -873,7 +877,7 @@ describe('NotificationManager (unit)', () => {
     const channelId = await manager.setupVerificationChannel(guild, 'restricted-role-1');
 
     expect(channelId).toBe('verification-channel-1');
-    expect(fetchChannels).toHaveBeenCalledTimes(1);
+    expect(fetchChannel).toHaveBeenCalledWith('verification-channel-1');
     expect(overwriteSet).toHaveBeenCalledWith(
       expect.arrayContaining([
         expect.objectContaining({ id: 'guild-1' }),
@@ -885,5 +889,47 @@ describe('NotificationManager (unit)', () => {
     expect(configService.updateServerConfig).toHaveBeenCalledWith('guild-1', {
       verification_channel_id: 'verification-channel-1',
     });
+  });
+
+  it('does not reuse an arbitrary channel named verification without a stored config id', async () => {
+    const overwriteSet = jest.fn().mockResolvedValue(undefined);
+    const existingChannel = {
+      id: 'unrelated-verification-channel',
+      name: 'verification',
+      type: ChannelType.GuildText,
+      permissionOverwrites: {
+        set: overwriteSet,
+      },
+    };
+    const createdChannel = { id: 'created-channel-1' };
+    const createChannel = jest.fn().mockResolvedValue(createdChannel);
+    const fetchChannel = jest.fn();
+    configService.getServerConfig = jest.fn().mockResolvedValue({
+      verification_channel_id: null,
+      settings: {},
+    } as any);
+    const guild = {
+      id: 'guild-1',
+      roles: {
+        everyone: { id: 'guild-1' },
+        cache: {
+          filter: jest.fn().mockReturnValue([]),
+        },
+      },
+      channels: {
+        cache: buildChannelCollection([existingChannel]),
+        fetch: fetchChannel,
+        create: createChannel,
+      },
+    } as unknown as Guild;
+
+    const manager = new NotificationManager({} as any, configService, detectionRepository);
+
+    const channelId = await manager.setupVerificationChannel(guild, 'restricted-role-1');
+
+    expect(channelId).toBe('created-channel-1');
+    expect(fetchChannel).not.toHaveBeenCalled();
+    expect(overwriteSet).not.toHaveBeenCalled();
+    expect(createChannel).toHaveBeenCalledWith(expect.objectContaining({ name: 'verification' }));
   });
 });

--- a/src/__tests__/unit/NotificationManager.unit.test.ts
+++ b/src/__tests__/unit/NotificationManager.unit.test.ts
@@ -1,4 +1,12 @@
-import { EmbedBuilder, Guild, GuildMember, Message, TextChannel, User } from 'discord.js';
+import {
+  ChannelType,
+  EmbedBuilder,
+  Guild,
+  GuildMember,
+  Message,
+  TextChannel,
+  User,
+} from 'discord.js';
 import { NotificationManager } from '../../services/NotificationManager';
 import { InMemoryDetectionEventsRepository } from '../fakes/inMemoryRepositories';
 import { DetectionResult } from '../../services/DetectionOrchestrator';
@@ -22,6 +30,20 @@ type MockMessage = {
   embeds?: EmbedBuilder[];
   edit: jest.Mock;
 };
+
+type MockGuildChannel = {
+  id: string;
+  name?: string;
+  type?: ChannelType;
+};
+
+type MockChannelPredicate = Parameters<MockGuildChannel[]['find']>[0];
+
+const buildChannelCollection = (channels: MockGuildChannel[]) => ({
+  find: jest.fn((predicate: MockChannelPredicate) =>
+    channels.find((channel, index, array) => predicate(channel, index, array))
+  ),
+});
 
 const buildMember = (guildId: string, userId: string): GuildMember =>
   ({
@@ -80,6 +102,7 @@ describe('NotificationManager (unit)', () => {
         admin_notification_role_id: null,
         settings: {},
       } as any),
+      updateServerConfig: jest.fn().mockResolvedValue({}),
     } as unknown as IConfigService;
   });
 
@@ -816,5 +839,34 @@ describe('NotificationManager (unit)', () => {
     expect(analysisField?.value).toContain(
       'Responses match what legitimate users normally say here.'
     );
+  });
+
+  it('reuses an existing verification text channel instead of creating a duplicate', async () => {
+    const existingChannel = {
+      id: 'verification-channel-1',
+      name: 'verification',
+      type: ChannelType.GuildText,
+    };
+    const createChannel = jest.fn();
+    const fetchChannels = jest.fn().mockResolvedValue(buildChannelCollection([existingChannel]));
+    const guild = {
+      id: 'guild-1',
+      channels: {
+        cache: buildChannelCollection([]),
+        fetch: fetchChannels,
+        create: createChannel,
+      },
+    } as unknown as Guild;
+
+    const manager = new NotificationManager({} as any, configService, detectionRepository);
+
+    const channelId = await manager.setupVerificationChannel(guild, 'restricted-role-1');
+
+    expect(channelId).toBe('verification-channel-1');
+    expect(fetchChannels).toHaveBeenCalledTimes(1);
+    expect(createChannel).not.toHaveBeenCalled();
+    expect(configService.updateServerConfig).toHaveBeenCalledWith('guild-1', {
+      verification_channel_id: 'verification-channel-1',
+    });
   });
 });

--- a/src/__tests__/unit/SetupDiagnosticsService.unit.test.ts
+++ b/src/__tests__/unit/SetupDiagnosticsService.unit.test.ts
@@ -122,6 +122,29 @@ describe('SetupDiagnosticsService (unit)', () => {
     expect(report.errorCount).toBeGreaterThanOrEqual(3);
   });
 
+  it('requires thread-send permission in configured verification channels', async () => {
+    const { guild } = buildConfiguredGuild({
+      channelHas: (permission) => permission !== PermissionFlagsBits.SendMessagesInThreads,
+    });
+    const configService = {
+      getServerConfig: jest.fn().mockResolvedValue({
+        guild_id: 'guild-1',
+        restricted_role_id: 'role-1',
+        admin_channel_id: 'admin-channel-1',
+        verification_channel_id: 'verification-channel-1',
+        settings: {},
+      }),
+    } as any;
+    const service = new SetupDiagnosticsService(configService);
+
+    const report = await service.validateGuildSetup(guild);
+
+    expect(report.issues.map((issue) => issue.code)).toContain(
+      'verification-channel-send-messages-in-threads'
+    );
+    expect(report.errorCount).toBeGreaterThanOrEqual(1);
+  });
+
   it('validates setup candidates that create the restricted role and verification channel', async () => {
     const { guild } = buildConfiguredGuild();
     const configService = {

--- a/src/__tests__/unit/SetupDiagnosticsService.unit.test.ts
+++ b/src/__tests__/unit/SetupDiagnosticsService.unit.test.ts
@@ -191,4 +191,34 @@ describe('SetupDiagnosticsService (unit)', () => {
       'verification-channel-create-manage-channels'
     );
   });
+
+  it('does not require Manage Channels when setup will sync a configured verification channel', async () => {
+    const { guild, botMember } = buildConfiguredGuild({
+      channelHas: (permission) => permission !== PermissionFlagsBits.SendMessages,
+    });
+    botMember.permissions.has.mockImplementation(
+      (permission: bigint) =>
+        permission !== PermissionFlagsBits.Administrator &&
+        permission !== PermissionFlagsBits.ManageChannels
+    );
+    const configService = {
+      getServerConfig: jest.fn(),
+    } as any;
+    const service = new SetupDiagnosticsService(configService);
+
+    const report = await service.validateSetupCandidate(guild, {
+      restrictedRoleId: 'role-1',
+      willCreateRestrictedRole: false,
+      adminChannelId: 'admin-channel-1',
+      verificationChannelId: 'verification-channel-1',
+      willCreateVerificationChannel: false,
+      willSyncVerificationChannelPermissions: true,
+      reportInstructionsChannelId: null,
+    });
+
+    expect(report.issues.map((issue) => issue.code)).not.toContain(
+      'verification-channel-create-manage-channels'
+    );
+    expect(report.issues.map((issue) => issue.code)).not.toContain('verification-channel-send');
+  });
 });

--- a/src/__tests__/unit/SetupDiagnosticsService.unit.test.ts
+++ b/src/__tests__/unit/SetupDiagnosticsService.unit.test.ts
@@ -1,0 +1,171 @@
+import { ChannelType, PermissionFlagsBits } from 'discord.js';
+import { SetupDiagnosticsService } from '../../services/SetupDiagnosticsService';
+
+describe('SetupDiagnosticsService (unit)', () => {
+  const defaultChannelHas = (permission: bigint): boolean => typeof permission === 'bigint';
+
+  const buildConfiguredGuild = (overrides: { channelHas?: typeof defaultChannelHas } = {}) => {
+    const restrictedRole = { id: 'role-1', managed: false };
+    const botMember = {
+      permissions: {
+        has: jest.fn((permission: bigint) => permission !== PermissionFlagsBits.Administrator),
+      },
+      roles: {
+        highest: {
+          comparePositionTo: jest.fn().mockReturnValue(1),
+        },
+      },
+    };
+    const channel = {
+      id: 'channel-1',
+      type: ChannelType.GuildText,
+      permissionsFor: jest.fn().mockReturnValue({
+        has: jest.fn(overrides.channelHas ?? defaultChannelHas),
+      }),
+    };
+
+    return {
+      guild: {
+        id: 'guild-1',
+        members: {
+          me: botMember,
+          fetchMe: jest.fn(),
+        },
+        roles: {
+          fetch: jest.fn().mockResolvedValue(restrictedRole),
+        },
+        channels: {
+          fetch: jest.fn().mockResolvedValue(channel),
+        },
+      } as any,
+      botMember,
+      restrictedRole,
+      channel,
+    };
+  };
+
+  it('passes when configured role, channels, hierarchy, and permissions are valid', async () => {
+    const { guild } = buildConfiguredGuild();
+    const configService = {
+      getServerConfig: jest.fn().mockResolvedValue({
+        guild_id: 'guild-1',
+        restricted_role_id: 'role-1',
+        admin_channel_id: 'admin-channel-1',
+        verification_channel_id: 'verification-channel-1',
+        settings: {},
+      }),
+    } as any;
+    const service = new SetupDiagnosticsService(configService);
+
+    const report = await service.validateGuildSetup(guild);
+
+    expect(report.errorCount).toBe(0);
+    expect(report.warningCount).toBe(0);
+    expect(report.issues).toEqual([]);
+  });
+
+  it('reports missing required setup and recommended permissions', async () => {
+    const { guild, botMember } = buildConfiguredGuild();
+    botMember.permissions.has.mockReturnValue(false);
+    const configService = {
+      getServerConfig: jest.fn().mockResolvedValue({
+        guild_id: 'guild-1',
+        restricted_role_id: null,
+        admin_channel_id: null,
+        verification_channel_id: null,
+        settings: {},
+      }),
+    } as any;
+    const service = new SetupDiagnosticsService(configService);
+
+    const report = await service.validateGuildSetup(guild);
+
+    expect(report.errorCount).toBe(4);
+    expect(report.warningCount).toBe(2);
+    expect(report.issues.map((issue) => issue.code)).toEqual(
+      expect.arrayContaining([
+        'guild-manage-roles',
+        'guild-ban-members',
+        'guild-view-audit-log',
+        'restricted-role-missing',
+        'admin-channel-missing',
+        'verification-channel-missing',
+      ])
+    );
+  });
+
+  it('reports role hierarchy and channel permission problems', async () => {
+    const { guild, botMember } = buildConfiguredGuild({
+      channelHas: (permission) => permission !== PermissionFlagsBits.SendMessages,
+    });
+    botMember.roles.highest.comparePositionTo.mockReturnValue(0);
+    const configService = {
+      getServerConfig: jest.fn().mockResolvedValue({
+        guild_id: 'guild-1',
+        restricted_role_id: 'role-1',
+        admin_channel_id: 'admin-channel-1',
+        verification_channel_id: 'verification-channel-1',
+        settings: {},
+      }),
+    } as any;
+    const service = new SetupDiagnosticsService(configService);
+
+    const report = await service.validateGuildSetup(guild);
+
+    expect(report.issues.map((issue) => issue.code)).toEqual(
+      expect.arrayContaining([
+        'restricted-role-hierarchy',
+        'admin-channel-send',
+        'verification-channel-send',
+      ])
+    );
+    expect(report.errorCount).toBeGreaterThanOrEqual(3);
+  });
+
+  it('validates setup candidates that create the restricted role and verification channel', async () => {
+    const { guild } = buildConfiguredGuild();
+    const configService = {
+      getServerConfig: jest.fn(),
+    } as any;
+    const service = new SetupDiagnosticsService(configService);
+
+    const report = await service.validateSetupCandidate(guild, {
+      restrictedRoleId: null,
+      willCreateRestrictedRole: true,
+      adminChannelId: 'admin-channel-1',
+      verificationChannelId: null,
+      willCreateVerificationChannel: true,
+      reportInstructionsChannelId: null,
+    });
+
+    expect(report.errorCount).toBe(0);
+    expect(report.warningCount).toBe(0);
+  });
+
+  it('requires Manage Channels when setup will create the verification channel', async () => {
+    const { guild, botMember } = buildConfiguredGuild();
+    botMember.permissions.has.mockImplementation(
+      (permission: bigint) =>
+        permission !== PermissionFlagsBits.Administrator &&
+        permission !== PermissionFlagsBits.ManageChannels
+    );
+    const configService = {
+      getServerConfig: jest.fn(),
+    } as any;
+    const service = new SetupDiagnosticsService(configService);
+
+    const report = await service.validateSetupCandidate(guild, {
+      restrictedRoleId: null,
+      willCreateRestrictedRole: true,
+      adminChannelId: 'admin-channel-1',
+      verificationChannelId: null,
+      willCreateVerificationChannel: true,
+      reportInstructionsChannelId: null,
+    });
+
+    expect(report.errorCount).toBe(1);
+    expect(report.issues.map((issue) => issue.code)).toContain(
+      'verification-channel-create-manage-channels'
+    );
+  });
+});

--- a/src/__tests__/unit/SetupDiagnosticsService.unit.test.ts
+++ b/src/__tests__/unit/SetupDiagnosticsService.unit.test.ts
@@ -192,15 +192,12 @@ describe('SetupDiagnosticsService (unit)', () => {
     );
   });
 
-  it('requires Manage Channels when setup will sync a configured verification channel', async () => {
-    const { guild, botMember } = buildConfiguredGuild({
-      channelHas: (permission) => permission !== PermissionFlagsBits.SendMessages,
+  it('requires channel-level Manage Channels when setup will sync a configured verification channel', async () => {
+    const { guild } = buildConfiguredGuild({
+      channelHas: (permission) =>
+        permission !== PermissionFlagsBits.SendMessages &&
+        permission !== PermissionFlagsBits.ManageChannels,
     });
-    botMember.permissions.has.mockImplementation(
-      (permission: bigint) =>
-        permission !== PermissionFlagsBits.Administrator &&
-        permission !== PermissionFlagsBits.ManageChannels
-    );
     const configService = {
       getServerConfig: jest.fn(),
     } as any;

--- a/src/__tests__/unit/SetupDiagnosticsService.unit.test.ts
+++ b/src/__tests__/unit/SetupDiagnosticsService.unit.test.ts
@@ -192,7 +192,7 @@ describe('SetupDiagnosticsService (unit)', () => {
     );
   });
 
-  it('does not require Manage Channels when setup will sync a configured verification channel', async () => {
+  it('requires Manage Channels when setup will sync a configured verification channel', async () => {
     const { guild, botMember } = buildConfiguredGuild({
       channelHas: (permission) => permission !== PermissionFlagsBits.SendMessages,
     });
@@ -216,8 +216,8 @@ describe('SetupDiagnosticsService (unit)', () => {
       reportInstructionsChannelId: null,
     });
 
-    expect(report.issues.map((issue) => issue.code)).not.toContain(
-      'verification-channel-create-manage-channels'
+    expect(report.issues.map((issue) => issue.code)).toContain(
+      'verification-channel-sync-manage-channels'
     );
     expect(report.issues.map((issue) => issue.code)).not.toContain('verification-channel-send');
   });

--- a/src/controllers/CommandHandler.ts
+++ b/src/controllers/CommandHandler.ts
@@ -1377,14 +1377,23 @@ export class CommandHandler implements ICommandHandler {
       const createdSetupArtifacts: { verificationChannelId?: string } = {};
 
       if (!verificationChannelId) {
-        const createdChannelId = await this.notificationManager.setupVerificationChannel(
-          guild,
-          restrictedRole.id,
-          false,
-          (channelId) => {
-            createdSetupArtifacts.verificationChannelId = channelId;
-          }
-        );
+        const onChannelCreated = (channelId: string): void => {
+          createdSetupArtifacts.verificationChannelId = channelId;
+        };
+        const createdChannelId = verificationChannelCandidate.channelId
+          ? await this.notificationManager.setupVerificationChannel(
+              guild,
+              restrictedRole.id,
+              false,
+              onChannelCreated,
+              verificationChannelCandidate.channelId
+            )
+          : await this.notificationManager.setupVerificationChannel(
+              guild,
+              restrictedRole.id,
+              false,
+              onChannelCreated
+            );
         if (!createdChannelId) {
           throw new Error('Failed to create a verification channel during setup.');
         }
@@ -1740,14 +1749,23 @@ export class CommandHandler implements ICommandHandler {
       let verificationChannelWasCreated = false;
 
       if (!verificationChannelId) {
-        verificationChannelId = await this.notificationManager.setupVerificationChannel(
-          guild,
-          restrictedRole.id,
-          false,
-          (channelId) => {
-            createdSetupArtifacts.verificationChannelId = channelId;
-          }
-        );
+        const onChannelCreated = (channelId: string): void => {
+          createdSetupArtifacts.verificationChannelId = channelId;
+        };
+        verificationChannelId = verificationChannelCandidate.channelId
+          ? await this.notificationManager.setupVerificationChannel(
+              guild,
+              restrictedRole.id,
+              false,
+              onChannelCreated,
+              verificationChannelCandidate.channelId
+            )
+          : await this.notificationManager.setupVerificationChannel(
+              guild,
+              restrictedRole.id,
+              false,
+              onChannelCreated
+            );
         if (!verificationChannelId) {
           if (createdRestrictedRole) {
             const rolledBack = await this.rollbackCreatedRestrictedRole(

--- a/src/controllers/CommandHandler.ts
+++ b/src/controllers/CommandHandler.ts
@@ -21,6 +21,7 @@ import {
   ChannelType, // Added
   EmbedBuilder, // Added
   TextChannel, // Added
+  Role,
   ModalBuilder,
   TextInputBuilder,
   TextInputStyle,
@@ -1659,15 +1660,21 @@ export class CommandHandler implements ICommandHandler {
       return;
     }
 
+    let setupFailureDetail: string | null = null;
+
     try {
-      const restrictedRole =
-        existingRestrictedRole ??
-        (await guild.roles.create({
+      let createdRestrictedRole: Role | null = null;
+      let restrictedRole = existingRestrictedRole;
+      if (!restrictedRole) {
+        createdRestrictedRole = await guild.roles.create({
           name: requestedRoleName ?? DEFAULT_RESTRICTED_ROLE_NAME,
           permissions: [],
           reason: `Drasil setup requested by ${interaction.user.tag}`,
-        }));
-      const restrictedRoleWasCreated = !existingRestrictedRole;
+        });
+        restrictedRole = createdRestrictedRole;
+      }
+
+      const restrictedRoleWasCreated = Boolean(createdRestrictedRole);
       let verificationChannelId = verificationChannel?.id ?? null;
       let verificationChannelWasCreated = false;
 
@@ -1678,6 +1685,15 @@ export class CommandHandler implements ICommandHandler {
           false
         );
         if (!verificationChannelId) {
+          if (createdRestrictedRole) {
+            const rolledBack = await this.rollbackCreatedRestrictedRole(
+              createdRestrictedRole,
+              guild.id
+            );
+            setupFailureDetail = rolledBack
+              ? 'Verification channel setup failed. The newly created restricted role was removed.'
+              : `Verification channel setup failed. The newly created restricted role <@&${restrictedRole.id}> could not be removed; delete it or pass it as restricted-role when rerunning setup.`;
+          }
           throw new Error('Failed to create a verification channel during setup.');
         }
         verificationChannelWasCreated = true;
@@ -1732,8 +1748,21 @@ export class CommandHandler implements ICommandHandler {
     } catch (error) {
       console.error(`Failed to complete config setup for guild ${guild.id}:`, error);
       await interaction.editReply({
-        content: 'Failed to complete setup. Please check permissions and try again.',
+        content: setupFailureDetail
+          ? `Failed to complete setup. ${setupFailureDetail}`
+          : 'Failed to complete setup. Please check permissions and try again.',
+        allowedMentions: { parse: [] },
       });
+    }
+  }
+
+  private async rollbackCreatedRestrictedRole(role: Role, guildId: string): Promise<boolean> {
+    try {
+      await role.delete('Rolling back Drasil setup after verification channel setup failed');
+      return true;
+    } catch (error) {
+      console.error(`Failed to roll back restricted role ${role.id} for guild ${guildId}:`, error);
+      return false;
     }
   }
 

--- a/src/controllers/CommandHandler.ts
+++ b/src/controllers/CommandHandler.ts
@@ -3026,6 +3026,7 @@ export class CommandHandler implements ICommandHandler {
         action = 'recreated';
       }
     } else {
+      await this.deleteStaleReportInstructionsMessage(existingChannelId, existingMessageId);
       const sentMessage = await targetChannel.send(messagePayload);
       messageId = sentMessage.id;
     }
@@ -3036,6 +3037,32 @@ export class CommandHandler implements ICommandHandler {
     });
 
     return { action, messageId };
+  }
+
+  private async deleteStaleReportInstructionsMessage(
+    existingChannelId: string | null | undefined,
+    existingMessageId: string | null | undefined
+  ): Promise<void> {
+    const channelManager = (this.client as unknown as { channels?: Client['channels'] }).channels;
+    if (!existingChannelId || !existingMessageId || !channelManager) {
+      return;
+    }
+
+    try {
+      const existingChannel = await channelManager.fetch(existingChannelId).catch(() => null);
+      if (!existingChannel || !('messages' in existingChannel)) {
+        return;
+      }
+
+      const existingMessage = await existingChannel.messages
+        .fetch(existingMessageId)
+        .catch(() => null);
+      await existingMessage?.delete().catch((error) => {
+        console.warn('Failed to delete stale report instructions message:', error);
+      });
+    } catch (error) {
+      console.warn('Failed to clean up stale report instructions message:', error);
+    }
   }
 
   private buildReportInstructionsMessagePayload(): {

--- a/src/controllers/CommandHandler.ts
+++ b/src/controllers/CommandHandler.ts
@@ -1695,34 +1695,34 @@ export class CommandHandler implements ICommandHandler {
 
     await interaction.deferReply({ flags: MessageFlags.Ephemeral });
 
-    const verificationChannelCandidate = await this.resolveVerificationChannelCandidate(
-      guild,
-      verificationChannel?.id ?? null
-    );
-
-    const candidateReport = await this.setupDiagnosticsService.validateSetupCandidate(guild, {
-      restrictedRoleId: existingRestrictedRole?.id ?? null,
-      willCreateRestrictedRole: !existingRestrictedRole,
-      adminChannelId: adminChannel.id,
-      verificationChannelId: verificationChannelCandidate.channelId,
-      willCreateVerificationChannel: !verificationChannelCandidate.channelId,
-      ...(verificationChannelCandidate.willSyncPermissions
-        ? { willSyncVerificationChannelPermissions: true }
-        : {}),
-      reportInstructionsChannelId: reportChannel?.id ?? null,
-    });
-
-    if (candidateReport.errorCount > 0) {
-      await interaction.editReply({
-        content: `Setup not saved. Fix the errors below and rerun /config setup.\n\n${this.formatSetupDiagnosticsReport(candidateReport)}`,
-        allowedMentions: { parse: [] },
-      });
-      return;
-    }
-
     let setupFailureDetail: string | null = null;
 
     try {
+      const verificationChannelCandidate = await this.resolveVerificationChannelCandidate(
+        guild,
+        verificationChannel?.id ?? null
+      );
+
+      const candidateReport = await this.setupDiagnosticsService.validateSetupCandidate(guild, {
+        restrictedRoleId: existingRestrictedRole?.id ?? null,
+        willCreateRestrictedRole: !existingRestrictedRole,
+        adminChannelId: adminChannel.id,
+        verificationChannelId: verificationChannelCandidate.channelId,
+        willCreateVerificationChannel: !verificationChannelCandidate.channelId,
+        ...(verificationChannelCandidate.willSyncPermissions
+          ? { willSyncVerificationChannelPermissions: true }
+          : {}),
+        reportInstructionsChannelId: reportChannel?.id ?? null,
+      });
+
+      if (candidateReport.errorCount > 0) {
+        await interaction.editReply({
+          content: `Setup not saved. Fix the errors below and rerun /config setup.\n\n${this.formatSetupDiagnosticsReport(candidateReport)}`,
+          allowedMentions: { parse: [] },
+        });
+        return;
+      }
+
       let createdRestrictedRole: Role | null = null;
       const createdSetupArtifacts: { verificationChannelId?: string } = {};
       let restrictedRole = existingRestrictedRole;

--- a/src/controllers/CommandHandler.ts
+++ b/src/controllers/CommandHandler.ts
@@ -3043,13 +3043,12 @@ export class CommandHandler implements ICommandHandler {
     existingChannelId: string | null | undefined,
     existingMessageId: string | null | undefined
   ): Promise<void> {
-    const channelManager = (this.client as unknown as { channels?: Client['channels'] }).channels;
-    if (!existingChannelId || !existingMessageId || !channelManager) {
+    if (!existingChannelId || !existingMessageId) {
       return;
     }
 
     try {
-      const existingChannel = await channelManager.fetch(existingChannelId).catch(() => null);
+      const existingChannel = await this.client.channels.fetch(existingChannelId).catch(() => null);
       if (!existingChannel || !('messages' in existingChannel)) {
         return;
       }

--- a/src/controllers/CommandHandler.ts
+++ b/src/controllers/CommandHandler.ts
@@ -1320,6 +1320,14 @@ export class CommandHandler implements ICommandHandler {
       return;
     }
 
+    if (!this.setupDiagnosticsService) {
+      await interaction.reply({
+        content: 'Setup diagnostics are not available in this runtime.',
+        flags: MessageFlags.Ephemeral,
+      });
+      return;
+    }
+
     let setupFailureDetail = 'Please check permissions and try again.';
 
     try {
@@ -1338,14 +1346,6 @@ export class CommandHandler implements ICommandHandler {
       if (verificationChannel && verificationChannel.type !== ChannelType.GuildText) {
         await interaction.reply({
           content: 'Verification channel must be a text channel.',
-          flags: MessageFlags.Ephemeral,
-        });
-        return;
-      }
-
-      if (!this.setupDiagnosticsService) {
-        await interaction.reply({
-          content: 'Setup diagnostics are not available in this runtime.',
           flags: MessageFlags.Ephemeral,
         });
         return;

--- a/src/controllers/CommandHandler.ts
+++ b/src/controllers/CommandHandler.ts
@@ -1394,7 +1394,7 @@ export class CommandHandler implements ICommandHandler {
       );
 
       const verificationChannelMessage = verificationChannelWasCreated
-        ? `Created verification channel: <#${verificationChannelId}>`
+        ? `Created or reused verification channel: <#${verificationChannelId}>`
         : `Verification channel: <#${verificationChannelId}>`;
 
       const responseLines = [
@@ -1701,7 +1701,7 @@ export class CommandHandler implements ICommandHandler {
         'Setup complete.',
         `${restrictedRoleWasCreated ? 'Created restricted role' : 'Restricted role'}: <@&${restrictedRole.id}>`,
         `Admin channel: <#${adminChannel.id}>`,
-        `${verificationChannelWasCreated ? 'Created verification channel' : 'Verification channel'}: <#${verificationChannelId}>`,
+        `${verificationChannelWasCreated ? 'Created or reused verification channel' : 'Verification channel'}: <#${verificationChannelId}>`,
       ];
 
       if (reportInstructionsLine) {

--- a/src/controllers/CommandHandler.ts
+++ b/src/controllers/CommandHandler.ts
@@ -1739,7 +1739,7 @@ export class CommandHandler implements ICommandHandler {
         createdRestrictedRole = await guild.roles.create({
           name: requestedRoleName ?? DEFAULT_RESTRICTED_ROLE_NAME,
           permissions: [],
-          reason: `Drasil setup requested by ${interaction.user.tag}`,
+          reason: `Drasil setup requested by ${interaction.user.username}`,
         });
         restrictedRole = createdRestrictedRole;
       }

--- a/src/controllers/CommandHandler.ts
+++ b/src/controllers/CommandHandler.ts
@@ -1343,13 +1343,21 @@ export class CommandHandler implements ICommandHandler {
 
       await interaction.deferReply({ flags: MessageFlags.Ephemeral });
 
+      const verificationChannelCandidate = await this.resolveVerificationChannelCandidate(
+        guild,
+        verificationChannel?.id ?? null
+      );
+
       const candidateReport = this.setupDiagnosticsService
         ? await this.setupDiagnosticsService.validateSetupCandidate(guild, {
             restrictedRoleId: restrictedRole.id,
             willCreateRestrictedRole: false,
             adminChannelId: adminChannel.id,
-            verificationChannelId: verificationChannel?.id ?? null,
-            willCreateVerificationChannel: !verificationChannel,
+            verificationChannelId: verificationChannelCandidate.channelId,
+            willCreateVerificationChannel: !verificationChannelCandidate.channelId,
+            ...(verificationChannelCandidate.willSyncPermissions
+              ? { willSyncVerificationChannelPermissions: true }
+              : {}),
             reportInstructionsChannelId: null,
           })
         : null;
@@ -1591,6 +1599,30 @@ export class CommandHandler implements ICommandHandler {
     }
   }
 
+  private async resolveVerificationChannelCandidate(
+    guild: NonNullable<ChatInputCommandInteraction['guild']>,
+    explicitVerificationChannelId: string | null
+  ): Promise<{ channelId: string | null; willSyncPermissions: boolean }> {
+    if (explicitVerificationChannelId) {
+      return { channelId: explicitVerificationChannelId, willSyncPermissions: false };
+    }
+
+    const serverConfig = await this.configService.getServerConfig(guild.id).catch(() => null);
+    const configuredVerificationChannelId = serverConfig?.verification_channel_id ?? null;
+    if (!configuredVerificationChannelId) {
+      return { channelId: null, willSyncPermissions: false };
+    }
+
+    const configuredChannel = await guild.channels
+      .fetch(configuredVerificationChannelId)
+      .catch(() => null);
+    if (configuredChannel?.type !== ChannelType.GuildText) {
+      return { channelId: null, willSyncPermissions: false };
+    }
+
+    return { channelId: configuredVerificationChannelId, willSyncPermissions: true };
+  }
+
   private async handleConfigSetupCommand(
     interaction: ChatInputCommandInteraction,
     guild: NonNullable<ChatInputCommandInteraction['guild']>
@@ -1643,12 +1675,20 @@ export class CommandHandler implements ICommandHandler {
 
     await interaction.deferReply({ flags: MessageFlags.Ephemeral });
 
+    const verificationChannelCandidate = await this.resolveVerificationChannelCandidate(
+      guild,
+      verificationChannel?.id ?? null
+    );
+
     const candidateReport = await this.setupDiagnosticsService.validateSetupCandidate(guild, {
       restrictedRoleId: existingRestrictedRole?.id ?? null,
       willCreateRestrictedRole: !existingRestrictedRole,
       adminChannelId: adminChannel.id,
-      verificationChannelId: verificationChannel?.id ?? null,
-      willCreateVerificationChannel: !verificationChannel,
+      verificationChannelId: verificationChannelCandidate.channelId,
+      willCreateVerificationChannel: !verificationChannelCandidate.channelId,
+      ...(verificationChannelCandidate.willSyncPermissions
+        ? { willSyncVerificationChannelPermissions: true }
+        : {}),
       reportInstructionsChannelId: reportChannel?.id ?? null,
     });
 

--- a/src/controllers/CommandHandler.ts
+++ b/src/controllers/CommandHandler.ts
@@ -1664,6 +1664,7 @@ export class CommandHandler implements ICommandHandler {
 
     try {
       let createdRestrictedRole: Role | null = null;
+      const createdSetupArtifacts: { verificationChannelId?: string } = {};
       let restrictedRole = existingRestrictedRole;
       if (!restrictedRole) {
         createdRestrictedRole = await guild.roles.create({
@@ -1682,7 +1683,10 @@ export class CommandHandler implements ICommandHandler {
         verificationChannelId = await this.notificationManager.setupVerificationChannel(
           guild,
           restrictedRole.id,
-          false
+          false,
+          (channelId) => {
+            createdSetupArtifacts.verificationChannelId = channelId;
+          }
         );
         if (!verificationChannelId) {
           if (createdRestrictedRole) {
@@ -1699,11 +1703,44 @@ export class CommandHandler implements ICommandHandler {
         verificationChannelWasCreated = true;
       }
 
-      await this.configService.updateServerConfig(guild.id, {
-        restricted_role_id: restrictedRole.id,
-        admin_channel_id: adminChannel.id,
-        verification_channel_id: verificationChannelId,
-      });
+      try {
+        await this.configService.updateServerConfig(guild.id, {
+          restricted_role_id: restrictedRole.id,
+          admin_channel_id: adminChannel.id,
+          verification_channel_id: verificationChannelId,
+        });
+      } catch (error) {
+        const rollbackDetails = ['Configuration could not be saved.'];
+        const createdVerificationChannelId = createdSetupArtifacts.verificationChannelId;
+
+        if (createdVerificationChannelId) {
+          const rolledBack = await this.rollbackCreatedVerificationChannel(
+            guild,
+            createdVerificationChannelId
+          );
+          rollbackDetails.push(
+            rolledBack
+              ? 'The newly created verification channel was removed.'
+              : `The newly created verification channel <#${createdVerificationChannelId}> could not be removed; delete it before rerunning setup.`
+          );
+        }
+
+        if (createdRestrictedRole) {
+          const rolledBack = await this.rollbackCreatedRestrictedRole(
+            createdRestrictedRole,
+            guild.id,
+            'Rolling back Drasil setup after config save failed'
+          );
+          rollbackDetails.push(
+            rolledBack
+              ? 'The newly created restricted role was removed.'
+              : `The newly created restricted role <@&${restrictedRole.id}> could not be removed; delete it or pass it as restricted-role when rerunning setup.`
+          );
+        }
+
+        setupFailureDetail = rollbackDetails.join(' ');
+        throw error;
+      }
 
       let reportInstructionsLine: string | null = null;
       let reportInstructionsWarningLine: string | null = null;
@@ -1756,12 +1793,41 @@ export class CommandHandler implements ICommandHandler {
     }
   }
 
-  private async rollbackCreatedRestrictedRole(role: Role, guildId: string): Promise<boolean> {
+  private async rollbackCreatedRestrictedRole(
+    role: Role,
+    guildId: string,
+    reason = 'Rolling back Drasil setup after verification channel setup failed'
+  ): Promise<boolean> {
     try {
-      await role.delete('Rolling back Drasil setup after verification channel setup failed');
+      await role.delete(reason);
       return true;
     } catch (error) {
       console.error(`Failed to roll back restricted role ${role.id} for guild ${guildId}:`, error);
+      return false;
+    }
+  }
+
+  private async rollbackCreatedVerificationChannel(
+    guild: NonNullable<ChatInputCommandInteraction['guild']>,
+    channelId: string
+  ): Promise<boolean> {
+    try {
+      const channel =
+        guild.channels.cache.get(channelId) ?? (await guild.channels.fetch(channelId));
+      if (!channel || channel.type !== ChannelType.GuildText) {
+        console.error(
+          `Could not find text verification channel ${channelId} to roll back for guild ${guild.id}`
+        );
+        return false;
+      }
+
+      await channel.delete('Rolling back Drasil setup after config save failed');
+      return true;
+    } catch (error) {
+      console.error(
+        `Failed to roll back verification channel ${channelId} for guild ${guild.id}:`,
+        error
+      );
       return false;
     }
   }

--- a/src/controllers/CommandHandler.ts
+++ b/src/controllers/CommandHandler.ts
@@ -1343,6 +1343,14 @@ export class CommandHandler implements ICommandHandler {
         return;
       }
 
+      if (!this.setupDiagnosticsService) {
+        await interaction.reply({
+          content: 'Setup diagnostics are not available in this runtime.',
+          flags: MessageFlags.Ephemeral,
+        });
+        return;
+      }
+
       await interaction.deferReply({ flags: MessageFlags.Ephemeral });
 
       const verificationChannelCandidate = await this.resolveVerificationChannelCandidate(
@@ -1350,21 +1358,19 @@ export class CommandHandler implements ICommandHandler {
         verificationChannel?.id ?? null
       );
 
-      const candidateReport = this.setupDiagnosticsService
-        ? await this.setupDiagnosticsService.validateSetupCandidate(guild, {
-            restrictedRoleId: restrictedRole.id,
-            willCreateRestrictedRole: false,
-            adminChannelId: adminChannel.id,
-            verificationChannelId: verificationChannelCandidate.channelId,
-            willCreateVerificationChannel: !verificationChannelCandidate.channelId,
-            ...(verificationChannelCandidate.willSyncPermissions
-              ? { willSyncVerificationChannelPermissions: true }
-              : {}),
-            reportInstructionsChannelId: null,
-          })
-        : null;
+      const candidateReport = await this.setupDiagnosticsService.validateSetupCandidate(guild, {
+        restrictedRoleId: restrictedRole.id,
+        willCreateRestrictedRole: false,
+        adminChannelId: adminChannel.id,
+        verificationChannelId: verificationChannelCandidate.channelId,
+        willCreateVerificationChannel: !verificationChannelCandidate.channelId,
+        ...(verificationChannelCandidate.willSyncPermissions
+          ? { willSyncVerificationChannelPermissions: true }
+          : {}),
+        reportInstructionsChannelId: null,
+      });
 
-      if (candidateReport && candidateReport.errorCount > 0) {
+      if (candidateReport.errorCount > 0) {
         await interaction.editReply({
           content: `Setup not saved. Fix the errors below and rerun setup.\n\n${this.formatSetupDiagnosticsReport(candidateReport)}`,
           allowedMentions: { parse: [] },
@@ -1447,7 +1453,7 @@ export class CommandHandler implements ICommandHandler {
         verificationChannelMessage,
       ];
 
-      if (candidateReport && candidateReport.warningCount > 0) {
+      if (candidateReport.warningCount > 0) {
         this.appendSetupDiagnosticsReport(responseLines, candidateReport);
       }
 

--- a/src/controllers/CommandHandler.ts
+++ b/src/controllers/CommandHandler.ts
@@ -1405,11 +1405,12 @@ export class CommandHandler implements ICommandHandler {
       ];
 
       if (candidateReport && candidateReport.warningCount > 0) {
-        responseLines.push('', this.formatSetupDiagnosticsReport(candidateReport));
+        this.appendSetupDiagnosticsReport(responseLines, candidateReport);
       }
 
       await interaction.editReply({
         content: this.truncatePreview(responseLines.join('\n'), 1900),
+        allowedMentions: { parse: [] },
       });
     } catch (error) {
       console.error('Failed to complete setup verification command:', error);
@@ -1689,12 +1690,20 @@ export class CommandHandler implements ICommandHandler {
       });
 
       let reportInstructionsLine: string | null = null;
+      let reportInstructionsWarningLine: string | null = null;
       if (reportChannel) {
-        const result = await this.upsertReportInstructionsMessage(
-          guild.id,
-          reportChannel as TextChannel
-        );
-        reportInstructionsLine = `Report instructions ${result.action}: <#${reportChannel.id}>`;
+        try {
+          const result = await this.upsertReportInstructionsMessage(
+            guild.id,
+            reportChannel as TextChannel
+          );
+          reportInstructionsLine = `Report instructions ${result.action}: <#${reportChannel.id}>`;
+        } catch (error) {
+          console.error(`Failed to upsert report instructions for guild ${guild.id}:`, error);
+          reportInstructionsWarningLine =
+            `[WARNING] Core setup was saved, but report instructions were not updated in <#${reportChannel.id}>. ` +
+            'Check Drasil can send messages and embeds there, then rerun setup.';
+        }
       }
 
       const lines = [
@@ -1708,8 +1717,12 @@ export class CommandHandler implements ICommandHandler {
         lines.push(reportInstructionsLine);
       }
 
+      if (reportInstructionsWarningLine) {
+        lines.push(reportInstructionsWarningLine);
+      }
+
       if (candidateReport.warningCount > 0) {
-        lines.push('', this.formatSetupDiagnosticsReport(candidateReport));
+        this.appendSetupDiagnosticsReport(lines, candidateReport);
       }
 
       await interaction.editReply({
@@ -1752,7 +1765,7 @@ export class CommandHandler implements ICommandHandler {
     }
   }
 
-  private formatSetupDiagnosticsReport(report: SetupDiagnosticReport): string {
+  private formatSetupDiagnosticsReport(report: SetupDiagnosticReport, maxLength = 1900): string {
     const status =
       report.errorCount > 0
         ? `Setup validation failed with ${report.errorCount} error(s) and ${report.warningCount} warning(s).`
@@ -1769,8 +1782,19 @@ export class CommandHandler implements ICommandHandler {
     );
     return this.truncatePreview(
       [status, `Guild ID: \`${report.guildId}\``, ...issueLines].join('\n'),
-      1900
+      maxLength
     );
+  }
+
+  private appendSetupDiagnosticsReport(
+    lines: string[],
+    report: SetupDiagnosticReport,
+    maxLength = 1900
+  ): void {
+    const prefix = lines.join('\n');
+    const separatorLength = prefix.length > 0 ? 2 : 0;
+    const budget = Math.max(200, maxLength - prefix.length - separatorLength);
+    lines.push('', this.formatSetupDiagnosticsReport(report, budget));
   }
 
   private formatKeywordSummary(keywords: readonly string[]): string {

--- a/src/controllers/CommandHandler.ts
+++ b/src/controllers/CommandHandler.ts
@@ -90,6 +90,10 @@ import {
   NOOP_PRODUCT_ANALYTICS_SERVICE,
 } from '../services/ProductAnalyticsService';
 import {
+  ISetupDiagnosticsService,
+  SetupDiagnosticReport,
+} from '../services/SetupDiagnosticsService';
+import {
   CASE_RESPONDER_ROLE_IDS_SETTING_KEY,
   CASE_RESPONDER_ROUTING_MODE_SETTING_KEY,
   CASE_RESPONDER_ROUTING_MODES,
@@ -119,10 +123,15 @@ const USER_INSTALL_REPORTING_ENABLED_ENV = 'DRASIL_USER_INSTALL_REPORTING_ENABLE
 const DRASIL_GUILD_INSTALL_PERMISSIONS =
   PermissionFlagsBits.ManageRoles |
   PermissionFlagsBits.BanMembers |
+  PermissionFlagsBits.ViewAuditLog |
+  PermissionFlagsBits.ManageChannels |
   PermissionFlagsBits.ViewChannel |
   PermissionFlagsBits.SendMessages |
   PermissionFlagsBits.ManageThreads |
   PermissionFlagsBits.CreatePrivateThreads;
+const REPORT_INSTRUCTIONS_CHANNEL_ID_SETTING_KEY = 'report_instructions_channel_id';
+const REPORT_INSTRUCTIONS_MESSAGE_ID_SETTING_KEY = 'report_instructions_message_id';
+const DEFAULT_RESTRICTED_ROLE_NAME = 'Drasil Restricted';
 
 function isUserInstallReportingEnabled(): boolean {
   return process.env[USER_INSTALL_REPORTING_ENABLED_ENV] === 'true';
@@ -163,6 +172,7 @@ export class CommandHandler implements ICommandHandler {
   private userModerationService: IUserModerationService;
   private securityActionService: ISecurityActionService;
   private productAnalyticsService: IProductAnalyticsService;
+  private setupDiagnosticsService?: ISetupDiagnosticsService;
   private commands: RESTPostAPIApplicationCommandsJSONBody[];
 
   constructor(
@@ -175,7 +185,10 @@ export class CommandHandler implements ICommandHandler {
     @inject(TYPES.SecurityActionService) securityActionService: ISecurityActionService,
     @inject(TYPES.ProductAnalyticsService)
     @optional()
-    productAnalyticsService?: IProductAnalyticsService
+    productAnalyticsService?: IProductAnalyticsService,
+    @inject(TYPES.SetupDiagnosticsService)
+    @optional()
+    setupDiagnosticsService?: ISetupDiagnosticsService
   ) {
     this.client = client;
     this.heuristicService = heuristicService;
@@ -185,6 +198,7 @@ export class CommandHandler implements ICommandHandler {
     this.userModerationService = userModerationService;
     this.securityActionService = securityActionService;
     this.productAnalyticsService = productAnalyticsService ?? NOOP_PRODUCT_ANALYTICS_SERVICE;
+    this.setupDiagnosticsService = setupDiagnosticsService;
 
     // Define slash commands
     this.commands = [
@@ -244,6 +258,50 @@ export class CommandHandler implements ICommandHandler {
       new SlashCommandBuilder()
         .setName('config')
         .setDescription('Configure server settings')
+        .addSubcommand((subcommand) =>
+          subcommand
+            .setName('validate')
+            .setDescription('Check Drasil setup, permissions, channels, and role hierarchy')
+        )
+        .addSubcommand((subcommand) =>
+          subcommand
+            .setName('setup')
+            .setDescription('Configure required Drasil channels and restricted role')
+            .addChannelOption((option) =>
+              option
+                .setName('admin-channel')
+                .setDescription('Moderator-only channel for Drasil alerts')
+                .addChannelTypes(ChannelType.GuildText)
+                .setRequired(true)
+            )
+            .addRoleOption((option) =>
+              option
+                .setName('restricted-role')
+                .setDescription('Existing restricted role; omit to create a default one')
+                .setRequired(false)
+            )
+            .addStringOption((option) =>
+              option
+                .setName('restricted-role-name')
+                .setDescription('Name to use when creating the default restricted role')
+                .setRequired(false)
+                .setMaxLength(100)
+            )
+            .addChannelOption((option) =>
+              option
+                .setName('verification-channel')
+                .setDescription('Existing verification channel; omit to auto-create')
+                .addChannelTypes(ChannelType.GuildText)
+                .setRequired(false)
+            )
+            .addChannelOption((option) =>
+              option
+                .setName('report-channel')
+                .setDescription('Optional channel for Drasil report instructions')
+                .addChannelTypes(ChannelType.GuildText)
+                .setRequired(false)
+            )
+        )
         .addSubcommand((subcommand) =>
           subcommand
             .setName('set')
@@ -1284,6 +1342,25 @@ export class CommandHandler implements ICommandHandler {
 
       await interaction.deferReply({ flags: MessageFlags.Ephemeral });
 
+      const candidateReport = this.setupDiagnosticsService
+        ? await this.setupDiagnosticsService.validateSetupCandidate(guild, {
+            restrictedRoleId: restrictedRole.id,
+            willCreateRestrictedRole: false,
+            adminChannelId: adminChannel.id,
+            verificationChannelId: verificationChannel?.id ?? null,
+            willCreateVerificationChannel: !verificationChannel,
+            reportInstructionsChannelId: null,
+          })
+        : null;
+
+      if (candidateReport && candidateReport.errorCount > 0) {
+        await interaction.editReply({
+          content: `Setup not saved. Fix the errors below and rerun setup.\n\n${this.formatSetupDiagnosticsReport(candidateReport)}`,
+          allowedMentions: { parse: [] },
+        });
+        return;
+      }
+
       let verificationChannelId = verificationChannel?.id ?? null;
       let verificationChannelWasCreated = false;
 
@@ -1320,12 +1397,19 @@ export class CommandHandler implements ICommandHandler {
         ? `Created verification channel: <#${verificationChannelId}>`
         : `Verification channel: <#${verificationChannelId}>`;
 
+      const responseLines = [
+        'Setup complete.',
+        `Restricted role: <@&${restrictedRole.id}>`,
+        `Admin channel: <#${adminChannel.id}>`,
+        verificationChannelMessage,
+      ];
+
+      if (candidateReport && candidateReport.warningCount > 0) {
+        responseLines.push('', this.formatSetupDiagnosticsReport(candidateReport));
+      }
+
       await interaction.editReply({
-        content:
-          'Setup complete.\n' +
-          `Restricted role: <@&${restrictedRole.id}>\n` +
-          `Admin channel: <#${adminChannel.id}>\n` +
-          `${verificationChannelMessage}`,
+        content: this.truncatePreview(responseLines.join('\n'), 1900),
       });
     } catch (error) {
       console.error('Failed to complete setup verification command:', error);
@@ -1466,6 +1550,16 @@ export class CommandHandler implements ICommandHandler {
     }
 
     const subcommand = interaction.options.getSubcommand(false);
+    if (subcommand === 'setup') {
+      await this.handleConfigSetupCommand(interaction, guild);
+      return;
+    }
+
+    if (subcommand === 'validate') {
+      await this.handleConfigValidateCommand(interaction, guild);
+      return;
+    }
+
     if (subcommand !== 'set') {
       await interaction.reply({
         content: 'Unsupported /config subcommand.',
@@ -1493,6 +1587,190 @@ export class CommandHandler implements ICommandHandler {
         flags: MessageFlags.Ephemeral,
       });
     }
+  }
+
+  private async handleConfigSetupCommand(
+    interaction: ChatInputCommandInteraction,
+    guild: NonNullable<ChatInputCommandInteraction['guild']>
+  ): Promise<void> {
+    if (!this.setupDiagnosticsService) {
+      await interaction.reply({
+        content: 'Setup diagnostics are not available in this runtime.',
+        flags: MessageFlags.Ephemeral,
+      });
+      return;
+    }
+
+    const adminChannel = interaction.options.getChannel('admin-channel', true);
+    const existingRestrictedRole = interaction.options.getRole('restricted-role');
+    const requestedRoleName = interaction.options.getString('restricted-role-name')?.trim() || null;
+    const verificationChannel = interaction.options.getChannel('verification-channel');
+    const reportChannel = interaction.options.getChannel('report-channel');
+
+    if (adminChannel.type !== ChannelType.GuildText) {
+      await interaction.reply({
+        content: 'Admin channel must be a text channel.',
+        flags: MessageFlags.Ephemeral,
+      });
+      return;
+    }
+
+    if (verificationChannel && verificationChannel.type !== ChannelType.GuildText) {
+      await interaction.reply({
+        content: 'Verification channel must be a text channel.',
+        flags: MessageFlags.Ephemeral,
+      });
+      return;
+    }
+
+    if (reportChannel && reportChannel.type !== ChannelType.GuildText) {
+      await interaction.reply({
+        content: 'Report channel must be a text channel.',
+        flags: MessageFlags.Ephemeral,
+      });
+      return;
+    }
+
+    if (existingRestrictedRole && requestedRoleName) {
+      await interaction.reply({
+        content: '`restricted-role-name` only applies when Drasil creates the restricted role.',
+        flags: MessageFlags.Ephemeral,
+      });
+      return;
+    }
+
+    await interaction.deferReply({ flags: MessageFlags.Ephemeral });
+
+    const candidateReport = await this.setupDiagnosticsService.validateSetupCandidate(guild, {
+      restrictedRoleId: existingRestrictedRole?.id ?? null,
+      willCreateRestrictedRole: !existingRestrictedRole,
+      adminChannelId: adminChannel.id,
+      verificationChannelId: verificationChannel?.id ?? null,
+      willCreateVerificationChannel: !verificationChannel,
+      reportInstructionsChannelId: reportChannel?.id ?? null,
+    });
+
+    if (candidateReport.errorCount > 0) {
+      await interaction.editReply({
+        content: `Setup not saved. Fix the errors below and rerun /config setup.\n\n${this.formatSetupDiagnosticsReport(candidateReport)}`,
+        allowedMentions: { parse: [] },
+      });
+      return;
+    }
+
+    try {
+      const restrictedRole =
+        existingRestrictedRole ??
+        (await guild.roles.create({
+          name: requestedRoleName ?? DEFAULT_RESTRICTED_ROLE_NAME,
+          permissions: [],
+          reason: `Drasil setup requested by ${interaction.user.tag}`,
+        }));
+      const restrictedRoleWasCreated = !existingRestrictedRole;
+      let verificationChannelId = verificationChannel?.id ?? null;
+      let verificationChannelWasCreated = false;
+
+      if (!verificationChannelId) {
+        verificationChannelId = await this.notificationManager.setupVerificationChannel(
+          guild,
+          restrictedRole.id,
+          false
+        );
+        if (!verificationChannelId) {
+          throw new Error('Failed to create a verification channel during setup.');
+        }
+        verificationChannelWasCreated = true;
+      }
+
+      await this.configService.updateServerConfig(guild.id, {
+        restricted_role_id: restrictedRole.id,
+        admin_channel_id: adminChannel.id,
+        verification_channel_id: verificationChannelId,
+      });
+
+      let reportInstructionsLine: string | null = null;
+      if (reportChannel) {
+        const result = await this.upsertReportInstructionsMessage(
+          guild.id,
+          reportChannel as TextChannel
+        );
+        reportInstructionsLine = `Report instructions ${result.action}: <#${reportChannel.id}>`;
+      }
+
+      const lines = [
+        'Setup complete.',
+        `${restrictedRoleWasCreated ? 'Created restricted role' : 'Restricted role'}: <@&${restrictedRole.id}>`,
+        `Admin channel: <#${adminChannel.id}>`,
+        `${verificationChannelWasCreated ? 'Created verification channel' : 'Verification channel'}: <#${verificationChannelId}>`,
+      ];
+
+      if (reportInstructionsLine) {
+        lines.push(reportInstructionsLine);
+      }
+
+      if (candidateReport.warningCount > 0) {
+        lines.push('', this.formatSetupDiagnosticsReport(candidateReport));
+      }
+
+      await interaction.editReply({
+        content: this.truncatePreview(lines.join('\n'), 1900),
+        allowedMentions: { parse: [] },
+      });
+    } catch (error) {
+      console.error(`Failed to complete config setup for guild ${guild.id}:`, error);
+      await interaction.editReply({
+        content: 'Failed to complete setup. Please check permissions and try again.',
+      });
+    }
+  }
+
+  private async handleConfigValidateCommand(
+    interaction: ChatInputCommandInteraction,
+    guild: NonNullable<ChatInputCommandInteraction['guild']>
+  ): Promise<void> {
+    if (!this.setupDiagnosticsService) {
+      await interaction.reply({
+        content: 'Setup diagnostics are not available in this runtime.',
+        flags: MessageFlags.Ephemeral,
+      });
+      return;
+    }
+
+    await interaction.deferReply({ flags: MessageFlags.Ephemeral });
+
+    try {
+      const report = await this.setupDiagnosticsService.validateGuildSetup(guild);
+      await interaction.editReply({
+        content: this.formatSetupDiagnosticsReport(report),
+        allowedMentions: { parse: [] },
+      });
+    } catch (error) {
+      console.error(`Failed to validate setup for guild ${guild.id}:`, error);
+      await interaction.editReply({
+        content: 'Failed to validate setup. Please try again later.',
+      });
+    }
+  }
+
+  private formatSetupDiagnosticsReport(report: SetupDiagnosticReport): string {
+    const status =
+      report.errorCount > 0
+        ? `Setup validation failed with ${report.errorCount} error(s) and ${report.warningCount} warning(s).`
+        : report.warningCount > 0
+          ? `Setup validation passed with ${report.warningCount} warning(s).`
+          : 'Setup validation passed with no issues.';
+
+    if (report.issues.length === 0) {
+      return `${status}\nGuild ID: \`${report.guildId}\``;
+    }
+
+    const issueLines = report.issues.map(
+      (issue) => `[${issue.severity.toUpperCase()}] ${issue.message}`
+    );
+    return this.truncatePreview(
+      [status, `Guild ID: \`${report.guildId}\``, ...issueLines].join('\n'),
+      1900
+    );
   }
 
   private formatKeywordSummary(keywords: readonly string[]): string {
@@ -2652,6 +2930,65 @@ export class CommandHandler implements ICommandHandler {
 
     const targetChannel = channel as TextChannel;
 
+    await interaction.deferReply({ flags: MessageFlags.Ephemeral });
+
+    try {
+      const result = await this.upsertReportInstructionsMessage(guild.id, targetChannel);
+
+      await interaction.editReply({
+        content: `Report instructions ${result.action} successfully in ${channel}.`,
+      });
+    } catch (error) {
+      console.error('Failed to upsert report button message:', error);
+      await interaction.editReply({
+        content:
+          '❌ Failed to send or update the message. Please ensure the bot has permissions to send messages in that channel.',
+      });
+    }
+  }
+
+  private async upsertReportInstructionsMessage(
+    guildId: string,
+    targetChannel: TextChannel
+  ): Promise<{ action: 'sent' | 'updated' | 'recreated'; messageId: string }> {
+    const messagePayload = this.buildReportInstructionsMessagePayload();
+    const serverConfig = await this.configService.getServerConfig(guildId);
+    const existingChannelId = serverConfig.settings[REPORT_INSTRUCTIONS_CHANNEL_ID_SETTING_KEY];
+    const existingMessageId = serverConfig.settings[REPORT_INSTRUCTIONS_MESSAGE_ID_SETTING_KEY];
+    let messageId: string;
+    let action: 'sent' | 'updated' | 'recreated' = 'sent';
+
+    if (existingChannelId === targetChannel.id && existingMessageId) {
+      const existingMessage = await targetChannel.messages
+        .fetch(existingMessageId)
+        .catch(() => null);
+
+      if (existingMessage) {
+        await existingMessage.edit(messagePayload);
+        messageId = existingMessage.id;
+        action = 'updated';
+      } else {
+        const sentMessage = await targetChannel.send(messagePayload);
+        messageId = sentMessage.id;
+        action = 'recreated';
+      }
+    } else {
+      const sentMessage = await targetChannel.send(messagePayload);
+      messageId = sentMessage.id;
+    }
+
+    await this.configService.updateServerSettings(guildId, {
+      [REPORT_INSTRUCTIONS_CHANNEL_ID_SETTING_KEY]: targetChannel.id,
+      [REPORT_INSTRUCTIONS_MESSAGE_ID_SETTING_KEY]: messageId,
+    });
+
+    return { action, messageId };
+  }
+
+  private buildReportInstructionsMessagePayload(): {
+    embeds: EmbedBuilder[];
+    components: ActionRowBuilder<ButtonBuilder>[];
+  } {
     // Create the embed
     const embed = new EmbedBuilder()
       .setColor(0x0099ff)
@@ -2674,23 +3011,7 @@ export class CommandHandler implements ICommandHandler {
     // Create an action row for the button
     const row = new ActionRowBuilder<ButtonBuilder>().addComponents(reportButton);
 
-    try {
-      // Send the message to the target channel
-      await targetChannel.send({ embeds: [embed], components: [row] });
-
-      // Confirm to the admin
-      await interaction.reply({
-        content: `Report instructions sent successfully to ${channel}.`,
-        flags: MessageFlags.Ephemeral,
-      });
-    } catch (error) {
-      console.error('Failed to send report button message:', error);
-      await interaction.reply({
-        content:
-          '❌ Failed to send the message. Please ensure the bot has permissions to send messages in that channel.',
-        flags: MessageFlags.Ephemeral,
-      });
-    }
+    return { embeds: [embed], components: [row] };
   }
 
   private async replyGuildInstallRequired(

--- a/src/controllers/CommandHandler.ts
+++ b/src/controllers/CommandHandler.ts
@@ -1373,7 +1373,9 @@ export class CommandHandler implements ICommandHandler {
       }
 
       let verificationChannelId = verificationChannel?.id ?? null;
-      let verificationChannelWasCreated = false;
+      let verificationChannelAction: 'configured' | 'created' | 'synced' = verificationChannel
+        ? 'configured'
+        : 'created';
       const createdSetupArtifacts: { verificationChannelId?: string } = {};
 
       if (!verificationChannelId) {
@@ -1398,7 +1400,7 @@ export class CommandHandler implements ICommandHandler {
           throw new Error('Failed to create a verification channel during setup.');
         }
         verificationChannelId = createdChannelId;
-        verificationChannelWasCreated = true;
+        verificationChannelAction = verificationChannelCandidate.channelId ? 'synced' : 'created';
       }
 
       try {
@@ -1424,16 +1426,19 @@ export class CommandHandler implements ICommandHandler {
         guild.id,
         'verification setup completed',
         {
-          verification_channel_created: verificationChannelWasCreated,
+          verification_channel_created: verificationChannelAction === 'created',
           verification_channel_configured: Boolean(verificationChannelId),
           admin_channel_configured: true,
           restricted_role_configured: true,
         }
       );
 
-      const verificationChannelMessage = verificationChannelWasCreated
-        ? `Created or reused verification channel: <#${verificationChannelId}>`
-        : `Verification channel: <#${verificationChannelId}>`;
+      const verificationChannelMessage =
+        verificationChannelAction === 'created'
+          ? `Created verification channel: <#${verificationChannelId}>`
+          : verificationChannelAction === 'synced'
+            ? `Synced verification channel permissions: <#${verificationChannelId}>`
+            : `Verification channel: <#${verificationChannelId}>`;
 
       const responseLines = [
         'Setup complete.',
@@ -1746,7 +1751,9 @@ export class CommandHandler implements ICommandHandler {
 
       const restrictedRoleWasCreated = Boolean(createdRestrictedRole);
       let verificationChannelId = verificationChannel?.id ?? null;
-      let verificationChannelWasCreated = false;
+      let verificationChannelAction: 'configured' | 'created' | 'synced' = verificationChannel
+        ? 'configured'
+        : 'created';
 
       if (!verificationChannelId) {
         const onChannelCreated = (channelId: string): void => {
@@ -1778,7 +1785,7 @@ export class CommandHandler implements ICommandHandler {
           }
           throw new Error('Failed to create a verification channel during setup.');
         }
-        verificationChannelWasCreated = true;
+        verificationChannelAction = verificationChannelCandidate.channelId ? 'synced' : 'created';
       }
 
       try {
@@ -1841,7 +1848,7 @@ export class CommandHandler implements ICommandHandler {
         'Setup complete.',
         `${restrictedRoleWasCreated ? 'Created restricted role' : 'Restricted role'}: <@&${restrictedRole.id}>`,
         `Admin channel: <#${adminChannel.id}>`,
-        `${verificationChannelWasCreated ? 'Created or reused verification channel' : 'Verification channel'}: <#${verificationChannelId}>`,
+        `${verificationChannelAction === 'created' ? 'Created verification channel' : verificationChannelAction === 'synced' ? 'Synced verification channel permissions' : 'Verification channel'}: <#${verificationChannelId}>`,
       ];
 
       if (reportInstructionsLine) {

--- a/src/controllers/CommandHandler.ts
+++ b/src/controllers/CommandHandler.ts
@@ -1320,6 +1320,8 @@ export class CommandHandler implements ICommandHandler {
       return;
     }
 
+    let setupFailureDetail = 'Please check permissions and try again.';
+
     try {
       const restrictedRole = interaction.options.getRole('restricted-role', true);
       const adminChannel = interaction.options.getChannel('admin-channel', true);
@@ -1372,12 +1374,16 @@ export class CommandHandler implements ICommandHandler {
 
       let verificationChannelId = verificationChannel?.id ?? null;
       let verificationChannelWasCreated = false;
+      const createdSetupArtifacts: { verificationChannelId?: string } = {};
 
       if (!verificationChannelId) {
         const createdChannelId = await this.notificationManager.setupVerificationChannel(
           guild,
           restrictedRole.id,
-          false
+          false,
+          (channelId) => {
+            createdSetupArtifacts.verificationChannelId = channelId;
+          }
         );
         if (!createdChannelId) {
           throw new Error('Failed to create a verification channel during setup.');
@@ -1386,11 +1392,25 @@ export class CommandHandler implements ICommandHandler {
         verificationChannelWasCreated = true;
       }
 
-      await this.configService.updateServerConfig(guild.id, {
-        restricted_role_id: restrictedRole.id,
-        admin_channel_id: adminChannel.id,
-        verification_channel_id: verificationChannelId,
-      });
+      try {
+        await this.configService.updateServerConfig(guild.id, {
+          restricted_role_id: restrictedRole.id,
+          admin_channel_id: adminChannel.id,
+          verification_channel_id: verificationChannelId,
+        });
+      } catch (error) {
+        const createdVerificationChannelId = createdSetupArtifacts.verificationChannelId;
+        if (createdVerificationChannelId) {
+          const rolledBack = await this.rollbackCreatedVerificationChannel(
+            guild,
+            createdVerificationChannelId
+          );
+          setupFailureDetail = rolledBack
+            ? 'Configuration could not be saved. The newly created verification channel was removed.'
+            : `Configuration could not be saved. The newly created verification channel <#${createdVerificationChannelId}> could not be removed; delete it before rerunning setup.`;
+        }
+        throw error;
+      }
       void this.productAnalyticsService.captureGuildEvent(
         guild.id,
         'verification setup completed',
@@ -1424,7 +1444,7 @@ export class CommandHandler implements ICommandHandler {
     } catch (error) {
       console.error('Failed to complete setup verification command:', error);
       const errorResponse = {
-        content: 'Failed to complete setup verification. Please check permissions and try again.',
+        content: `Failed to complete setup verification. ${setupFailureDetail}`,
       } as const;
 
       if (interaction.replied || interaction.deferred) {

--- a/src/controllers/CommandHandler.ts
+++ b/src/controllers/CommandHandler.ts
@@ -2992,11 +2992,12 @@ export class CommandHandler implements ICommandHandler {
     // Create the embed
     const embed = new EmbedBuilder()
       .setColor(0x0099ff)
-      .setTitle('How to Report a User')
+      .setTitle('Report a User')
       .setDescription(
         'If you see a user violating server rules or engaging in suspicious activity, ' +
-          'use `/report` so Discord gives you a user picker and reason field. ' +
-          'You can also right-click a user and choose `Apps` -> `Report User`. ' +
+          'use the button below to choose the user and submit the report. ' +
+          'You can also use `/report` for the same user picker and reason field, or ' +
+          'right-click a user and choose `Apps` -> `Report User`. ' +
           'Your report will be reviewed by the moderation team.'
       )
       .setFooter({ text: 'Your reports help keep the community safe!' });
@@ -3004,9 +3005,8 @@ export class CommandHandler implements ICommandHandler {
     // Create the button
     const reportButton = new ButtonBuilder()
       .setCustomId('report_user_initiate') // Unique ID for the button interaction
-      .setLabel('How to report')
-      .setStyle(ButtonStyle.Secondary)
-      .setEmoji('ℹ️');
+      .setLabel('Report a user')
+      .setStyle(ButtonStyle.Primary);
 
     // Create an action row for the button
     const row = new ActionRowBuilder<ButtonBuilder>().addComponents(reportButton);

--- a/src/controllers/EventHandler.ts
+++ b/src/controllers/EventHandler.ts
@@ -651,7 +651,8 @@ export class EventHandler implements IEventHandler {
         verification_channel_auto_created: verificationChannelWasCreated,
       });
 
-      await this.maybeSendSetupNudge(guild, config);
+      const finalConfig = await this.configService.getServerConfig(guild.id).catch(() => config);
+      await this.maybeSendSetupNudge(guild, finalConfig);
     } catch (error) {
       console.error(`Failed to handle new guild ${guild.id}:`, error);
     }

--- a/src/controllers/EventHandler.ts
+++ b/src/controllers/EventHandler.ts
@@ -149,6 +149,8 @@ export class EventHandler implements IEventHandler {
         await this.commandHandler.handleMessageContextMenuCommand(interaction);
       } else if (interaction.isButton()) {
         await this.interactionHandler.handleButtonInteraction(interaction);
+      } else if (interaction.isUserSelectMenu()) {
+        await this.interactionHandler.handleUserSelectMenuInteraction(interaction);
       } else if (interaction.isModalSubmit()) {
         // Added check for modal submit
         await this.interactionHandler.handleModalSubmit(interaction);

--- a/src/controllers/EventHandler.ts
+++ b/src/controllers/EventHandler.ts
@@ -681,12 +681,16 @@ export class EventHandler implements IEventHandler {
       }
     }
 
-    await this.configService.updateServerSettings(guild.id, {
-      setup_nudge_last_attempt_at: attemptedAt,
-      setup_nudge_last_recipient_id: recipient?.user.id ?? null,
-      setup_nudge_last_result: result,
-      setup_nudge_last_source: recipient?.source ?? null,
-    });
+    try {
+      await this.configService.updateServerSettings(guild.id, {
+        setup_nudge_last_attempt_at: attemptedAt,
+        setup_nudge_last_recipient_id: recipient?.user.id ?? null,
+        setup_nudge_last_result: result,
+        setup_nudge_last_source: recipient?.source ?? null,
+      });
+    } catch (error) {
+      console.warn(`Failed to record setup nudge metadata for guild ${guild.id}:`, error);
+    }
   }
 
   private isSetupIncomplete(config: Server): boolean {

--- a/src/controllers/EventHandler.ts
+++ b/src/controllers/EventHandler.ts
@@ -1,4 +1,5 @@
 import {
+  AuditLogEvent,
   Client,
   Message,
   GuildMember,
@@ -27,6 +28,7 @@ import {
   IProductAnalyticsService,
   NOOP_PRODUCT_ANALYTICS_SERVICE,
 } from '../services/ProductAnalyticsService';
+import { Server } from '../repositories/types';
 
 const RECENT_USER_CONTEXT_MESSAGE_LIMIT = 5;
 const RECENT_USER_CONTEXT_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
@@ -34,6 +36,21 @@ const RECENT_USER_CONTEXT_CLEANUP_INTERVAL_MS = 60 * 1000;
 const RECENT_USER_CONTEXT_MAX_USERS_PER_SERVER = 1000;
 const RECENT_USER_CONTEXT_MAX_SERVERS = 100;
 const CHANNEL_CONTEXT_MESSAGE_LIMIT = 5;
+const SETUP_NUDGE_SUPPRESSION_MS = 7 * 24 * 60 * 60 * 1000;
+
+type SetupNudgeSource = 'audit_log_installer' | 'owner';
+type SetupNudgeResult = 'sent' | 'dm_failed' | 'no_recipient';
+
+interface SetupNudgeRecipient {
+  readonly user: SetupNudgeUser;
+  readonly source: SetupNudgeSource;
+}
+
+interface SetupNudgeUser {
+  readonly id: string;
+  readonly bot?: boolean;
+  send(content: string): Promise<unknown>;
+}
 
 interface RecentUserMessageContext {
   content: string;
@@ -602,7 +619,7 @@ export class EventHandler implements IEventHandler {
       console.log(`Bot joined new guild: ${guild.name} (${guild.id})`);
 
       // Create default configuration for the new guild
-      const config = await this.configService.getServerConfig(guild.id);
+      let config = await this.configService.getServerConfig(guild.id);
       console.log(`Created default configuration for guild: ${guild.name} (${guild.id})`);
 
       // Set up verification channel if auto_setup is enabled globally
@@ -620,6 +637,7 @@ export class EventHandler implements IEventHandler {
             await this.configService.updateServerConfig(guild.id, {
               verification_channel_id: channelId,
             });
+            config = { ...config, verification_channel_id: channelId };
             verificationChannelWasCreated = true;
             console.log(`Set up verification channel for guild: ${guild.name} (${guild.id})`);
           }
@@ -630,8 +648,113 @@ export class EventHandler implements IEventHandler {
         auto_setup_verification_channels: globalConfig.getSettings().autoSetupVerificationChannels,
         verification_channel_auto_created: verificationChannelWasCreated,
       });
+
+      await this.maybeSendSetupNudge(guild, config);
     } catch (error) {
       console.error(`Failed to handle new guild ${guild.id}:`, error);
     }
+  }
+
+  private async maybeSendSetupNudge(guild: Guild, config: Server): Promise<void> {
+    if (!this.isSetupIncomplete(config)) {
+      return;
+    }
+
+    if (this.wasSetupNudgeRecentlyAttempted(config.settings.setup_nudge_last_attempt_at)) {
+      return;
+    }
+
+    const recipient = await this.resolveSetupNudgeRecipient(guild);
+    const attemptedAt = new Date().toISOString();
+    let result: SetupNudgeResult = 'no_recipient';
+
+    if (recipient) {
+      try {
+        await recipient.user.send(this.buildSetupNudgeMessage(guild));
+        result = 'sent';
+      } catch (error) {
+        result = 'dm_failed';
+        console.warn(`Failed to DM setup nudge for guild ${guild.id}:`, error);
+      }
+    }
+
+    await this.configService.updateServerSettings(guild.id, {
+      setup_nudge_last_attempt_at: attemptedAt,
+      setup_nudge_last_recipient_id: recipient?.user.id ?? null,
+      setup_nudge_last_result: result,
+      setup_nudge_last_source: recipient?.source ?? null,
+    });
+  }
+
+  private isSetupIncomplete(config: Server): boolean {
+    return (
+      !config.restricted_role_id || !config.admin_channel_id || !config.verification_channel_id
+    );
+  }
+
+  private wasSetupNudgeRecentlyAttempted(lastAttemptAt: string | null | undefined): boolean {
+    if (!lastAttemptAt) {
+      return false;
+    }
+
+    const attemptedAtMs = Date.parse(lastAttemptAt);
+    if (Number.isNaN(attemptedAtMs)) {
+      return false;
+    }
+
+    return Date.now() - attemptedAtMs < SETUP_NUDGE_SUPPRESSION_MS;
+  }
+
+  private async resolveSetupNudgeRecipient(guild: Guild): Promise<SetupNudgeRecipient | null> {
+    const auditLogInstaller = await this.resolveAuditLogInstaller(guild);
+    if (auditLogInstaller) {
+      return auditLogInstaller;
+    }
+
+    return this.resolveOwnerRecipient(guild);
+  }
+
+  private async resolveAuditLogInstaller(guild: Guild): Promise<SetupNudgeRecipient | null> {
+    const botUserId = this.client.user?.id;
+    if (!botUserId) {
+      return null;
+    }
+
+    try {
+      const auditLogs = await guild.fetchAuditLogs({
+        type: AuditLogEvent.BotAdd,
+        limit: 5,
+      });
+      const installEntry = auditLogs.entries.find(
+        (entry) => entry.target?.id === botUserId && entry.executor && !entry.executor.bot
+      );
+
+      return installEntry?.executor
+        ? { user: installEntry.executor, source: 'audit_log_installer' }
+        : null;
+    } catch (error) {
+      console.warn(`Could not read bot install audit log for guild ${guild.id}:`, error);
+      return null;
+    }
+  }
+
+  private async resolveOwnerRecipient(guild: Guild): Promise<SetupNudgeRecipient | null> {
+    try {
+      const owner = await guild.fetchOwner();
+      return { user: owner.user, source: 'owner' };
+    } catch (error) {
+      console.warn(`Could not resolve owner for setup nudge in guild ${guild.id}:`, error);
+      return null;
+    }
+  }
+
+  private buildSetupNudgeMessage(guild: Guild): string {
+    return [
+      `Thanks for installing Drasil in ${guild.name}.`,
+      'Finish setup by running `/config setup admin-channel:<moderator-channel>` in the server.',
+      'Omit `restricted-role` and `verification-channel` if you want Drasil to create safe defaults.',
+      'Add `report-channel:<channel>` if you want Drasil to create or update report instructions.',
+      'Run `/config validate` afterwards to check permissions, channels, and role hierarchy.',
+    ].join('\n');
   }
 }

--- a/src/controllers/EventHandler.ts
+++ b/src/controllers/EventHandler.ts
@@ -744,6 +744,9 @@ export class EventHandler implements IEventHandler {
   private async resolveOwnerRecipient(guild: Guild): Promise<SetupNudgeRecipient | null> {
     try {
       const owner = await guild.fetchOwner();
+      if (owner.user.bot) {
+        return null;
+      }
       return { user: owner.user, source: 'owner' };
     } catch (error) {
       console.warn(`Could not resolve owner for setup nudge in guild ${guild.id}:`, error);

--- a/src/controllers/InteractionHandler.ts
+++ b/src/controllers/InteractionHandler.ts
@@ -466,14 +466,6 @@ export class InteractionHandler implements IInteractionHandler {
   }
 
   private async handleReportUserSelect(interaction: UserSelectMenuInteraction): Promise<void> {
-    if (!interaction.guildId) {
-      await interaction.reply({
-        content: 'This menu can only be used in a server.',
-        flags: MessageFlags.Ephemeral,
-      });
-      return;
-    }
-
     const targetUserId = interaction.values[0];
     if (!targetUserId) {
       await interaction.reply({
@@ -491,7 +483,7 @@ export class InteractionHandler implements IInteractionHandler {
       return;
     }
 
-    const reasonRequired = await this.getUserReportReasonRequired(interaction.guildId);
+    const reasonRequired = await this.getUserReportReasonRequired(interaction.guildId ?? undefined);
     const modal = this.buildReportUserReasonModal(targetUserId, reasonRequired);
     await interaction.showModal(modal);
   }

--- a/src/controllers/InteractionHandler.ts
+++ b/src/controllers/InteractionHandler.ts
@@ -483,8 +483,7 @@ export class InteractionHandler implements IInteractionHandler {
       return;
     }
 
-    const reasonRequired = await this.getUserReportReasonRequired(interaction.guildId ?? undefined);
-    const modal = this.buildReportUserReasonModal(targetUserId, reasonRequired);
+    const modal = this.buildReportUserReasonModal(targetUserId, false);
     await interaction.showModal(modal);
   }
 

--- a/src/controllers/InteractionHandler.ts
+++ b/src/controllers/InteractionHandler.ts
@@ -710,11 +710,12 @@ export class InteractionHandler implements IInteractionHandler {
         return;
       }
 
+      await interaction.deferReply({ flags: MessageFlags.Ephemeral });
+
       const reasonRequired = await this.getUserReportReasonRequired(interaction.guildId);
       if (reasonRequired && !reason) {
-        await interaction.reply({
+        await interaction.editReply({
           content: 'Please include a reason for this report.',
-          flags: MessageFlags.Ephemeral,
         });
         return;
       }
@@ -724,17 +725,15 @@ export class InteractionHandler implements IInteractionHandler {
         targetUserInputString
       );
       if (targetUserResolution.status === 'not_found') {
-        await interaction.reply({
+        await interaction.editReply({
           content: `Could not find a user matching "${targetUserInputString}".`,
-          flags: MessageFlags.Ephemeral,
         });
         return;
       }
 
       if (targetUserResolution.status === 'ambiguous') {
-        await interaction.reply({
+        await interaction.editReply({
           content: 'Multiple users match that name. Please use their ID or @mention instead.',
-          flags: MessageFlags.Ephemeral,
         });
         return;
       }
@@ -742,9 +741,8 @@ export class InteractionHandler implements IInteractionHandler {
       const targetUserId = targetUserResolution.userId;
 
       if (targetUserId === interaction.user.id) {
-        await interaction.reply({
+        await interaction.editReply({
           content: 'You cannot report yourself.',
-          flags: MessageFlags.Ephemeral,
         });
         return;
       }
@@ -752,18 +750,16 @@ export class InteractionHandler implements IInteractionHandler {
       const guild = await this.client.guilds.fetch(interaction.guildId);
       const member = await guild.members.fetch(targetUserId).catch(() => null);
       if (!member) {
-        await interaction.reply({
+        await interaction.editReply({
           content: `Could not find a user matching "${targetUserInputString}" in this server.`,
-          flags: MessageFlags.Ephemeral,
         });
         return;
       }
 
       await this.securityActionService.handleUserReport(member, interaction.user, reason);
 
-      await interaction.reply({
+      await interaction.editReply({
         content: `Thank you for your report regarding <@${targetUserId}>. It has been submitted for review.`,
-        flags: MessageFlags.Ephemeral,
         allowedMentions: { parse: [] },
       });
     } catch (error) {
@@ -772,6 +768,10 @@ export class InteractionHandler implements IInteractionHandler {
         await interaction.reply({
           content: 'An error occurred while submitting your report. Please try again later.',
           flags: MessageFlags.Ephemeral,
+        });
+      } else if (interaction.deferred) {
+        await interaction.editReply({
+          content: 'An error occurred while submitting your report. Please try again later.',
         });
       } else {
         await interaction.followUp({
@@ -805,14 +805,6 @@ export class InteractionHandler implements IInteractionHandler {
     try {
       const reason =
         interaction.fields.getTextInputValue(REPORT_USER_REASON_FIELD_ID).trim() || undefined;
-      const reasonRequired = await this.getUserReportReasonRequired(interaction.guildId);
-      if (reasonRequired && !reason) {
-        await interaction.reply({
-          content: 'Please include a reason for this report.',
-          flags: MessageFlags.Ephemeral,
-        });
-        return;
-      }
 
       if (targetUserId === interaction.user.id) {
         await interaction.reply({
@@ -822,12 +814,21 @@ export class InteractionHandler implements IInteractionHandler {
         return;
       }
 
+      await interaction.deferReply({ flags: MessageFlags.Ephemeral });
+
+      const reasonRequired = await this.getUserReportReasonRequired(interaction.guildId);
+      if (reasonRequired && !reason) {
+        await interaction.editReply({
+          content: 'Please include a reason for this report.',
+        });
+        return;
+      }
+
       const guild = await this.client.guilds.fetch(interaction.guildId);
       const member = await guild.members.fetch(targetUserId).catch(() => null);
       if (!member) {
-        await interaction.reply({
+        await interaction.editReply({
           content: `Could not find <@${targetUserId}> in this server.`,
-          flags: MessageFlags.Ephemeral,
           allowedMentions: { parse: [] },
         });
         return;
@@ -835,9 +836,8 @@ export class InteractionHandler implements IInteractionHandler {
 
       await this.securityActionService.handleUserReport(member, interaction.user, reason);
 
-      await interaction.reply({
+      await interaction.editReply({
         content: `Thank you for your report regarding <@${targetUserId}>. It has been submitted for review.`,
-        flags: MessageFlags.Ephemeral,
         allowedMentions: { parse: [] },
       });
     } catch (error) {
@@ -846,6 +846,10 @@ export class InteractionHandler implements IInteractionHandler {
         await interaction.reply({
           content: 'An error occurred while submitting your report. Please try again later.',
           flags: MessageFlags.Ephemeral,
+        });
+      } else if (interaction.deferred) {
+        await interaction.editReply({
+          content: 'An error occurred while submitting your report. Please try again later.',
         });
       } else {
         await interaction.followUp({

--- a/src/controllers/InteractionHandler.ts
+++ b/src/controllers/InteractionHandler.ts
@@ -6,15 +6,15 @@ import {
   ChannelType,
   GuildMember,
   PermissionFlagsBits,
-  ModalBuilder, // Added
-  TextInputBuilder, // Added
-  TextInputStyle, // Added
-  ActionRowBuilder, // Added
+  ModalBuilder,
+  TextInputBuilder,
+  TextInputStyle,
+  ActionRowBuilder,
   InteractionContextType,
   User,
-  // UserSelectMenuBuilder, // Removed - Cannot be used in Modals
-  ModalSubmitInteraction, // Added
-  // Interaction, // Removed - Unused
+  UserSelectMenuBuilder,
+  UserSelectMenuInteraction,
+  ModalSubmitInteraction,
   ButtonStyle,
 } from 'discord.js';
 import * as dotenv from 'dotenv';
@@ -40,6 +40,7 @@ import {
   REPORT_MESSAGE_MODAL_PREFIX,
   REPORT_MESSAGE_REASON_FIELD_ID,
   USER_REPORT_MESSAGE_CONTENT_MAX_LENGTH,
+  USER_REPORT_REASON_MAX_LENGTH,
 } from '../utils/userReportSettings';
 import {
   parseChannelId,
@@ -57,6 +58,11 @@ const OBSERVED_BAN_DEFAULT_REASON = 'Banned from observed suspicious notificatio
 const VERIFICATION_BAN_MODAL_PREFIX = 'verification:ban_modal';
 const VERIFICATION_BAN_NOTES_FIELD_ID = 'verification_ban_notes';
 const VERIFICATION_BAN_DEFAULT_REASON = 'Banned by moderator during verification';
+const REPORT_USER_SELECT_CUSTOM_ID = 'report_user_select';
+const REPORT_USER_TYPED_MODAL_ID = 'report_user_modal_submit';
+const REPORT_USER_REASON_MODAL_PREFIX = 'report_user_reason_modal';
+const REPORT_USER_TARGET_FIELD_ID = 'report_target_user_input';
+const REPORT_USER_REASON_FIELD_ID = 'report_reason';
 
 type UserResolution =
   | { status: 'found'; userId: string }
@@ -76,6 +82,11 @@ export interface IInteractionHandler {
    * Handle a modal submission interaction
    */
   handleModalSubmit(interaction: ModalSubmitInteraction): Promise<void>; // Added
+
+  /**
+   * Handle a user select menu interaction
+   */
+  handleUserSelectMenuInteraction(interaction: UserSelectMenuInteraction): Promise<void>;
 }
 
 @injectable()
@@ -418,16 +429,92 @@ export class InteractionHandler implements IInteractionHandler {
   }
 
   private async handleReportUserInitiate(interaction: ButtonInteraction): Promise<void> {
+    const userSelect = new UserSelectMenuBuilder()
+      .setCustomId(REPORT_USER_SELECT_CUSTOM_ID)
+      .setPlaceholder('Choose the user to report')
+      .setMinValues(1)
+      .setMaxValues(1);
+    const row = new ActionRowBuilder<UserSelectMenuBuilder>().addComponents(userSelect);
+
     await interaction.reply({
-      content:
-        "Use `/report` and choose the user from Discord's user picker, or right-click the user and choose `Apps` -> `Report User`. Discord buttons cannot collect a typed user argument safely.",
+      content: 'Choose the user you want to report. Only you can see this picker.',
+      components: [row],
       flags: MessageFlags.Ephemeral,
     });
   }
 
+  public async handleUserSelectMenuInteraction(
+    interaction: UserSelectMenuInteraction
+  ): Promise<void> {
+    if (!interaction.guildId) {
+      await interaction.reply({
+        content: 'This menu can only be used in a server.',
+        flags: MessageFlags.Ephemeral,
+      });
+      return;
+    }
+
+    if (interaction.customId !== REPORT_USER_SELECT_CUSTOM_ID) {
+      await interaction.reply({
+        content: 'Unknown menu action',
+        flags: MessageFlags.Ephemeral,
+      });
+      return;
+    }
+
+    await this.handleReportUserSelect(interaction);
+  }
+
+  private async handleReportUserSelect(interaction: UserSelectMenuInteraction): Promise<void> {
+    if (!interaction.guildId) {
+      await interaction.reply({
+        content: 'This menu can only be used in a server.',
+        flags: MessageFlags.Ephemeral,
+      });
+      return;
+    }
+
+    const targetUserId = interaction.values[0];
+    if (!targetUserId) {
+      await interaction.reply({
+        content: 'Please choose a user to report.',
+        flags: MessageFlags.Ephemeral,
+      });
+      return;
+    }
+
+    if (targetUserId === interaction.user.id) {
+      await interaction.reply({
+        content: 'You cannot report yourself.',
+        flags: MessageFlags.Ephemeral,
+      });
+      return;
+    }
+
+    const reasonRequired = await this.getUserReportReasonRequired(interaction.guildId);
+    const modal = this.buildReportUserReasonModal(targetUserId, reasonRequired);
+    await interaction.showModal(modal);
+  }
+
+  private buildReportUserReasonModal(targetUserId: string, reasonRequired: boolean): ModalBuilder {
+    const modal = new ModalBuilder()
+      .setCustomId(`${REPORT_USER_REASON_MODAL_PREFIX}:${targetUserId}`)
+      .setTitle('Report User');
+    const reasonInput = new TextInputBuilder()
+      .setCustomId(REPORT_USER_REASON_FIELD_ID)
+      .setLabel(reasonRequired ? 'Reason' : 'Reason (optional)')
+      .setStyle(TextInputStyle.Paragraph)
+      .setPlaceholder('What happened? Include extra context if useful.')
+      .setMaxLength(USER_REPORT_REASON_MAX_LENGTH)
+      .setRequired(reasonRequired);
+
+    modal.addComponents(new ActionRowBuilder<TextInputBuilder>().addComponents(reasonInput));
+    return modal;
+  }
+
   public async handleModalSubmit(interaction: ModalSubmitInteraction): Promise<void> {
     switch (interaction.customId) {
-      case 'report_user_modal_submit':
+      case REPORT_USER_TYPED_MODAL_ID:
         await this.handleReportUserModalSubmit(interaction);
         return;
       case SETUP_VERIFICATION_MODAL_ID:
@@ -440,6 +527,10 @@ export class InteractionHandler implements IInteractionHandler {
         }
         if (interaction.customId.startsWith(`${REPORT_MESSAGE_MODAL_PREFIX}:`)) {
           await this.handleReportMessageModalSubmit(interaction);
+          return;
+        }
+        if (interaction.customId.startsWith(`${REPORT_USER_REASON_MODAL_PREFIX}:`)) {
+          await this.handleReportUserReasonModalSubmit(interaction);
           return;
         }
         if (interaction.customId.startsWith('observed:ban_modal:')) {
@@ -613,9 +704,10 @@ export class InteractionHandler implements IInteractionHandler {
 
     try {
       const targetUserInputString = interaction.fields.getTextInputValue(
-        'report_target_user_input'
+        REPORT_USER_TARGET_FIELD_ID
       );
-      const reason = interaction.fields.getTextInputValue('report_reason').trim() || undefined;
+      const reason =
+        interaction.fields.getTextInputValue(REPORT_USER_REASON_FIELD_ID).trim() || undefined;
 
       if (!targetUserInputString) {
         await interaction.reply({
@@ -684,6 +776,80 @@ export class InteractionHandler implements IInteractionHandler {
       });
     } catch (error) {
       console.error('[InteractionHandler] Error handling report modal submission:', error);
+      if (!interaction.replied && !interaction.deferred) {
+        await interaction.reply({
+          content: 'An error occurred while submitting your report. Please try again later.',
+          flags: MessageFlags.Ephemeral,
+        });
+      } else {
+        await interaction.followUp({
+          content: 'An error occurred while submitting your report. Please try again later.',
+          flags: MessageFlags.Ephemeral,
+        });
+      }
+    }
+  }
+
+  private async handleReportUserReasonModalSubmit(
+    interaction: ModalSubmitInteraction
+  ): Promise<void> {
+    if (!interaction.guildId) {
+      await interaction.reply({
+        content: 'This action can only be performed in a server.',
+        flags: MessageFlags.Ephemeral,
+      });
+      return;
+    }
+
+    const targetUserId = interaction.customId.slice(`${REPORT_USER_REASON_MODAL_PREFIX}:`.length);
+    if (!/^\d{17,19}$/.test(targetUserId)) {
+      await interaction.reply({
+        content: 'This report form is invalid. Please try reporting the user again.',
+        flags: MessageFlags.Ephemeral,
+      });
+      return;
+    }
+
+    try {
+      const reason =
+        interaction.fields.getTextInputValue(REPORT_USER_REASON_FIELD_ID).trim() || undefined;
+      const reasonRequired = await this.getUserReportReasonRequired(interaction.guildId);
+      if (reasonRequired && !reason) {
+        await interaction.reply({
+          content: 'Please include a reason for this report.',
+          flags: MessageFlags.Ephemeral,
+        });
+        return;
+      }
+
+      if (targetUserId === interaction.user.id) {
+        await interaction.reply({
+          content: 'You cannot report yourself.',
+          flags: MessageFlags.Ephemeral,
+        });
+        return;
+      }
+
+      const guild = await this.client.guilds.fetch(interaction.guildId);
+      const member = await guild.members.fetch(targetUserId).catch(() => null);
+      if (!member) {
+        await interaction.reply({
+          content: `Could not find <@${targetUserId}> in this server.`,
+          flags: MessageFlags.Ephemeral,
+          allowedMentions: { parse: [] },
+        });
+        return;
+      }
+
+      await this.securityActionService.handleUserReport(member, interaction.user, reason);
+
+      await interaction.reply({
+        content: `Thank you for your report regarding <@${targetUserId}>. It has been submitted for review.`,
+        flags: MessageFlags.Ephemeral,
+        allowedMentions: { parse: [] },
+      });
+    } catch (error) {
+      console.error('[InteractionHandler] Error handling report reason modal submission:', error);
       if (!interaction.replied && !interaction.deferred) {
         await interaction.reply({
           content: 'An error occurred while submitting your report. Please try again later.',

--- a/src/di/container.ts
+++ b/src/di/container.ts
@@ -47,6 +47,10 @@ import {
   IProductAnalyticsService,
   ProductAnalyticsService,
 } from '../services/ProductAnalyticsService';
+import {
+  ISetupDiagnosticsService,
+  SetupDiagnosticsService,
+} from '../services/SetupDiagnosticsService';
 // Initialize container
 const container = new Container();
 
@@ -188,6 +192,11 @@ function configureServices(container: Container): void {
   container
     .bind<IProductAnalyticsService>(TYPES.ProductAnalyticsService)
     .to(ProductAnalyticsService)
+    .inSingletonScope();
+
+  container
+    .bind<ISetupDiagnosticsService>(TYPES.SetupDiagnosticsService)
+    .to(SetupDiagnosticsService)
     .inSingletonScope();
 }
 

--- a/src/di/symbols.ts
+++ b/src/di/symbols.ts
@@ -20,6 +20,7 @@ export const TYPES = {
   UserModerationService: Symbol.for('UserModerationService'),
   VerificationThreadAnalysisService: Symbol.for('VerificationThreadAnalysisService'),
   ProductAnalyticsService: Symbol.for('ProductAnalyticsService'),
+  SetupDiagnosticsService: Symbol.for('SetupDiagnosticsService'),
 
   // Repositories
   BaseRepository: Symbol.for('BaseRepository'),

--- a/src/repositories/types.ts
+++ b/src/repositories/types.ts
@@ -60,6 +60,12 @@ export interface ServerSettings {
   report_ai_restrict_threshold?: number;
   report_ai_max_images?: number;
   report_ai_max_image_bytes?: number;
+  report_instructions_channel_id?: string | null;
+  report_instructions_message_id?: string | null;
+  setup_nudge_last_attempt_at?: string | null;
+  setup_nudge_last_recipient_id?: string | null;
+  setup_nudge_last_result?: 'sent' | 'dm_failed' | 'no_recipient' | null;
+  setup_nudge_last_source?: 'audit_log_installer' | 'owner' | null;
 }
 
 /**

--- a/src/services/NotificationManager.ts
+++ b/src/services/NotificationManager.ts
@@ -14,6 +14,7 @@ import {
   PermissionFlagsBits,
   GuildChannelCreateOptions,
   GuildBasedChannel,
+  OverwriteResolvable,
   ButtonInteraction,
   MessageFlags,
   TextChannel,
@@ -1384,8 +1385,17 @@ export class NotificationManager implements INotificationManager {
     }
 
     try {
+      const permissionOverwrites = this.buildVerificationChannelPermissionOverwrites(
+        guild,
+        restrictedRoleId
+      );
       const existingVerificationChannel = await this.findExistingVerificationChannel(guild);
       if (existingVerificationChannel) {
+        await existingVerificationChannel.permissionOverwrites.set(
+          permissionOverwrites,
+          'Sync Drasil verification channel permissions'
+        );
+
         if (persistConfig) {
           await this.configService.updateServerConfig(guild.id, {
             verification_channel_id: existingVerificationChannel.id,
@@ -1394,63 +1404,6 @@ export class NotificationManager implements INotificationManager {
 
         return existingVerificationChannel.id;
       }
-
-      // Create permission overwrites for the channel
-      const permissionOverwrites = [
-        // Default role (everyone) - deny access
-        {
-          id: guild.roles.everyone.id,
-          deny: [
-            PermissionFlagsBits.ViewChannel,
-            PermissionFlagsBits.SendMessages,
-            PermissionFlagsBits.ReadMessageHistory,
-            PermissionFlagsBits.CreatePublicThreads,
-            PermissionFlagsBits.CreatePrivateThreads,
-          ],
-        },
-        // Restricted role - can view and send messages, but not read history
-        {
-          id: restrictedRoleId,
-          allow: [
-            PermissionFlagsBits.ViewChannel,
-            PermissionFlagsBits.SendMessages,
-            PermissionFlagsBits.ReadMessageHistory, // TODO: Check if users need to be granted this to see history of private thread
-            PermissionFlagsBits.SendMessagesInThreads,
-          ],
-        },
-        // Bot - full access
-        {
-          id: this.client.user?.id || '',
-          allow: [
-            PermissionFlagsBits.ViewChannel,
-            PermissionFlagsBits.SendMessages,
-            PermissionFlagsBits.ReadMessageHistory,
-            PermissionFlagsBits.ManageChannels,
-            PermissionFlagsBits.ManageThreads,
-            PermissionFlagsBits.CreatePublicThreads,
-            PermissionFlagsBits.CreatePrivateThreads,
-            PermissionFlagsBits.SendMessagesInThreads,
-            PermissionFlagsBits.ModerateMembers,
-          ],
-        },
-      ];
-
-      // Find admin roles by checking for manage channels permission
-      const adminRoles = guild.roles.cache.filter((role) =>
-        role.permissions.has(PermissionFlagsBits.ManageChannels)
-      );
-
-      // Add admin roles to permission overwrites
-      adminRoles.forEach((role) => {
-        permissionOverwrites.push({
-          id: role.id,
-          allow: [
-            PermissionFlagsBits.ViewChannel,
-            PermissionFlagsBits.SendMessages,
-            PermissionFlagsBits.ReadMessageHistory,
-          ],
-        });
-      });
 
       // Create the verification channel
       const channelOptions: GuildChannelCreateOptions = {
@@ -1474,6 +1427,71 @@ export class NotificationManager implements INotificationManager {
       console.error('Failed to set up verification channel:', error);
       return null;
     }
+  }
+
+  private buildVerificationChannelPermissionOverwrites(
+    guild: Guild,
+    restrictedRoleId: string
+  ): OverwriteResolvable[] {
+    const permissionOverwrites: OverwriteResolvable[] = [
+      // Default role (everyone) - deny access
+      {
+        id: guild.roles.everyone.id,
+        deny: [
+          PermissionFlagsBits.ViewChannel,
+          PermissionFlagsBits.SendMessages,
+          PermissionFlagsBits.ReadMessageHistory,
+          PermissionFlagsBits.CreatePublicThreads,
+          PermissionFlagsBits.CreatePrivateThreads,
+        ],
+      },
+      // Restricted role - can view and send messages, but not read history
+      {
+        id: restrictedRoleId,
+        allow: [
+          PermissionFlagsBits.ViewChannel,
+          PermissionFlagsBits.SendMessages,
+          PermissionFlagsBits.ReadMessageHistory, // TODO: Check if users need to be granted this to see history of private thread
+          PermissionFlagsBits.SendMessagesInThreads,
+        ],
+      },
+    ];
+
+    if (this.client.user?.id) {
+      permissionOverwrites.push({
+        id: this.client.user.id,
+        allow: [
+          PermissionFlagsBits.ViewChannel,
+          PermissionFlagsBits.SendMessages,
+          PermissionFlagsBits.ReadMessageHistory,
+          PermissionFlagsBits.ManageChannels,
+          PermissionFlagsBits.ManageThreads,
+          PermissionFlagsBits.CreatePublicThreads,
+          PermissionFlagsBits.CreatePrivateThreads,
+          PermissionFlagsBits.SendMessagesInThreads,
+          PermissionFlagsBits.ModerateMembers,
+        ],
+      });
+    }
+
+    // Find admin roles by checking for manage channels permission
+    const adminRoles = guild.roles.cache.filter((role) =>
+      role.permissions.has(PermissionFlagsBits.ManageChannels)
+    );
+
+    // Add admin roles to permission overwrites
+    adminRoles.forEach((role) => {
+      permissionOverwrites.push({
+        id: role.id,
+        allow: [
+          PermissionFlagsBits.ViewChannel,
+          PermissionFlagsBits.SendMessages,
+          PermissionFlagsBits.ReadMessageHistory,
+        ],
+      });
+    });
+
+    return permissionOverwrites;
   }
 
   private async findExistingVerificationChannel(guild: Guild): Promise<TextChannel | null> {

--- a/src/services/NotificationManager.ts
+++ b/src/services/NotificationManager.ts
@@ -1389,20 +1389,20 @@ export class NotificationManager implements INotificationManager {
         guild,
         restrictedRoleId
       );
-      const existingVerificationChannel = await this.findExistingVerificationChannel(guild);
-      if (existingVerificationChannel) {
-        await existingVerificationChannel.permissionOverwrites.set(
+      const configuredVerificationChannel = await this.findConfiguredVerificationChannel(guild);
+      if (configuredVerificationChannel) {
+        await configuredVerificationChannel.permissionOverwrites.set(
           permissionOverwrites,
           'Sync Drasil verification channel permissions'
         );
 
         if (persistConfig) {
           await this.configService.updateServerConfig(guild.id, {
-            verification_channel_id: existingVerificationChannel.id,
+            verification_channel_id: configuredVerificationChannel.id,
           });
         }
 
-        return existingVerificationChannel.id;
+        return configuredVerificationChannel.id;
       }
 
       // Create the verification channel
@@ -1494,27 +1494,39 @@ export class NotificationManager implements INotificationManager {
     return permissionOverwrites;
   }
 
-  private async findExistingVerificationChannel(guild: Guild): Promise<TextChannel | null> {
-    const cachedChannel = guild.channels.cache.find((channel) =>
-      this.isVerificationTextChannel(channel)
+  private async findConfiguredVerificationChannel(guild: Guild): Promise<TextChannel | null> {
+    const serverConfig = await this.configService.getServerConfig(guild.id).catch((error) => {
+      console.warn(
+        'Failed to load server config while checking for an existing verification channel:',
+        error
+      );
+      return null;
+    });
+    const verificationChannelId = serverConfig?.verification_channel_id;
+    if (!verificationChannelId) {
+      return null;
+    }
+
+    const cachedChannel = guild.channels.cache.find(
+      (channel) => channel.id === verificationChannelId
     );
-    if (cachedChannel) {
+    if (this.isTextChannel(cachedChannel)) {
       return cachedChannel;
     }
 
-    const fetchedChannels = await guild.channels.fetch().catch((error) => {
+    const fetchedChannel = await guild.channels.fetch(verificationChannelId).catch((error) => {
       console.warn(
-        'Failed to fetch channels while checking for existing verification channel:',
+        'Failed to fetch configured verification channel while setting up permissions:',
         error
       );
       return null;
     });
 
-    return fetchedChannels?.find((channel) => this.isVerificationTextChannel(channel)) ?? null;
+    return this.isTextChannel(fetchedChannel) ? fetchedChannel : null;
   }
 
-  private isVerificationTextChannel(channel: GuildBasedChannel | null): channel is TextChannel {
-    return channel?.type === ChannelType.GuildText && channel.name === VERIFICATION_CHANNEL_NAME;
+  private isTextChannel(channel: GuildBasedChannel | null | undefined): channel is TextChannel {
+    return channel?.type === ChannelType.GuildText;
   }
 
   /**

--- a/src/services/NotificationManager.ts
+++ b/src/services/NotificationManager.ts
@@ -90,7 +90,8 @@ export interface INotificationManager {
     guild: Guild,
     restrictedRoleId: string,
     persistConfig?: boolean,
-    onChannelCreated?: (channelId: string) => void
+    onChannelCreated?: (channelId: string) => void,
+    configuredVerificationChannelId?: string
   ): Promise<string | null>;
 
   /**
@@ -1379,7 +1380,8 @@ export class NotificationManager implements INotificationManager {
     guild: Guild,
     restrictedRoleId: string,
     persistConfig = true,
-    onChannelCreated?: (channelId: string) => void
+    onChannelCreated?: (channelId: string) => void,
+    configuredVerificationChannelId?: string
   ): Promise<string | null> {
     if (!restrictedRoleId) {
       console.error('Restricted role ID is required to set up verification channel');
@@ -1391,7 +1393,10 @@ export class NotificationManager implements INotificationManager {
         guild,
         restrictedRoleId
       );
-      const configuredVerificationChannel = await this.findConfiguredVerificationChannel(guild);
+      const configuredVerificationChannel = await this.findConfiguredVerificationChannel(
+        guild,
+        configuredVerificationChannelId
+      );
       if (configuredVerificationChannel) {
         await configuredVerificationChannel.permissionOverwrites.set(
           permissionOverwrites,
@@ -1497,15 +1502,22 @@ export class NotificationManager implements INotificationManager {
     return permissionOverwrites;
   }
 
-  private async findConfiguredVerificationChannel(guild: Guild): Promise<TextChannel | null> {
-    const serverConfig = await this.configService.getServerConfig(guild.id).catch((error) => {
-      console.warn(
-        'Failed to load server config while checking for an existing verification channel:',
-        error
-      );
-      return null;
-    });
-    const verificationChannelId = serverConfig?.verification_channel_id;
+  private async findConfiguredVerificationChannel(
+    guild: Guild,
+    resolvedVerificationChannelId?: string
+  ): Promise<TextChannel | null> {
+    let verificationChannelId = resolvedVerificationChannelId ?? null;
+    if (!verificationChannelId) {
+      const serverConfig = await this.configService.getServerConfig(guild.id).catch((error) => {
+        console.warn(
+          'Failed to load server config while checking for an existing verification channel:',
+          error
+        );
+        return null;
+      });
+      verificationChannelId = serverConfig?.verification_channel_id ?? null;
+    }
+
     if (!verificationChannelId) {
       return null;
     }

--- a/src/services/NotificationManager.ts
+++ b/src/services/NotificationManager.ts
@@ -89,7 +89,8 @@ export interface INotificationManager {
   setupVerificationChannel(
     guild: Guild,
     restrictedRoleId: string,
-    persistConfig?: boolean
+    persistConfig?: boolean,
+    onChannelCreated?: (channelId: string) => void
   ): Promise<string | null>;
 
   /**
@@ -1377,7 +1378,8 @@ export class NotificationManager implements INotificationManager {
   public async setupVerificationChannel(
     guild: Guild,
     restrictedRoleId: string,
-    persistConfig = true
+    persistConfig = true,
+    onChannelCreated?: (channelId: string) => void
   ): Promise<string | null> {
     if (!restrictedRoleId) {
       console.error('Restricted role ID is required to set up verification channel');
@@ -1415,6 +1417,7 @@ export class NotificationManager implements INotificationManager {
       };
 
       const verificationChannel = await guild.channels.create(channelOptions);
+      onChannelCreated?.(verificationChannel.id);
 
       if (persistConfig) {
         await this.configService.updateServerConfig(guild.id, {

--- a/src/services/NotificationManager.ts
+++ b/src/services/NotificationManager.ts
@@ -13,6 +13,7 @@ import {
   ChannelType,
   PermissionFlagsBits,
   GuildChannelCreateOptions,
+  GuildBasedChannel,
   ButtonInteraction,
   MessageFlags,
   TextChannel,
@@ -36,6 +37,8 @@ import { getVerificationActionFailures } from '../utils/verificationActionFailur
 import { getCaseResponderSettings } from '../utils/caseResponderSettings';
 import { CASE_STAFF_ROUTING_METADATA_KEY } from './ThreadManager';
 import { isDetectionEventExcludedFromAccounting } from '../utils/detectionEventAccounting';
+
+const VERIFICATION_CHANNEL_NAME = 'verification';
 
 export interface NotificationButton {
   id: string;
@@ -1381,6 +1384,17 @@ export class NotificationManager implements INotificationManager {
     }
 
     try {
+      const existingVerificationChannel = await this.findExistingVerificationChannel(guild);
+      if (existingVerificationChannel) {
+        if (persistConfig) {
+          await this.configService.updateServerConfig(guild.id, {
+            verification_channel_id: existingVerificationChannel.id,
+          });
+        }
+
+        return existingVerificationChannel.id;
+      }
+
       // Create permission overwrites for the channel
       const permissionOverwrites = [
         // Default role (everyone) - deny access
@@ -1440,7 +1454,7 @@ export class NotificationManager implements INotificationManager {
 
       // Create the verification channel
       const channelOptions: GuildChannelCreateOptions = {
-        name: 'verification',
+        name: VERIFICATION_CHANNEL_NAME,
         type: ChannelType.GuildText,
         permissionOverwrites: permissionOverwrites,
         topic:
@@ -1460,6 +1474,29 @@ export class NotificationManager implements INotificationManager {
       console.error('Failed to set up verification channel:', error);
       return null;
     }
+  }
+
+  private async findExistingVerificationChannel(guild: Guild): Promise<TextChannel | null> {
+    const cachedChannel = guild.channels.cache.find((channel) =>
+      this.isVerificationTextChannel(channel)
+    );
+    if (cachedChannel) {
+      return cachedChannel;
+    }
+
+    const fetchedChannels = await guild.channels.fetch().catch((error) => {
+      console.warn(
+        'Failed to fetch channels while checking for existing verification channel:',
+        error
+      );
+      return null;
+    });
+
+    return fetchedChannels?.find((channel) => this.isVerificationTextChannel(channel)) ?? null;
+  }
+
+  private isVerificationTextChannel(channel: GuildBasedChannel | null): channel is TextChannel {
+    return channel?.type === ChannelType.GuildText && channel.name === VERIFICATION_CHANNEL_NAME;
   }
 
   /**

--- a/src/services/SetupDiagnosticsService.ts
+++ b/src/services/SetupDiagnosticsService.ts
@@ -1,0 +1,406 @@
+import { ChannelType, Guild, GuildMember, PermissionFlagsBits, TextChannel } from 'discord.js';
+import { inject, injectable } from 'inversify';
+import { IConfigService } from '../config/ConfigService';
+import { Server } from '../repositories/types';
+import { TYPES } from '../di/symbols';
+import { getDetectionResponseSettings } from '../utils/detectionResponseSettings';
+
+export type SetupDiagnosticSeverity = 'error' | 'warning';
+
+export interface SetupDiagnosticIssue {
+  readonly severity: SetupDiagnosticSeverity;
+  readonly code: string;
+  readonly message: string;
+}
+
+export interface SetupDiagnosticReport {
+  readonly guildId: string;
+  readonly checkedAt: Date;
+  readonly issues: readonly SetupDiagnosticIssue[];
+  readonly errorCount: number;
+  readonly warningCount: number;
+}
+
+export interface SetupCandidate {
+  readonly restrictedRoleId?: string | null;
+  readonly willCreateRestrictedRole?: boolean;
+  readonly adminChannelId: string | null;
+  readonly verificationChannelId?: string | null;
+  readonly willCreateVerificationChannel?: boolean;
+  readonly reportInstructionsChannelId?: string | null;
+}
+
+export interface ISetupDiagnosticsService {
+  validateGuildSetup(guild: Guild): Promise<SetupDiagnosticReport>;
+  validateSetupCandidate(guild: Guild, candidate: SetupCandidate): Promise<SetupDiagnosticReport>;
+}
+
+interface PermissionRequirement {
+  readonly permission: bigint;
+  readonly label: string;
+  readonly severity: SetupDiagnosticSeverity;
+  readonly codeSuffix: string;
+}
+
+const ADMIN_CHANNEL_PERMISSIONS: readonly PermissionRequirement[] = [
+  {
+    permission: PermissionFlagsBits.ViewChannel,
+    label: 'View Channel',
+    severity: 'error',
+    codeSuffix: 'view',
+  },
+  {
+    permission: PermissionFlagsBits.SendMessages,
+    label: 'Send Messages',
+    severity: 'error',
+    codeSuffix: 'send',
+  },
+];
+
+const VERIFICATION_CHANNEL_PERMISSIONS: readonly PermissionRequirement[] = [
+  ...ADMIN_CHANNEL_PERMISSIONS,
+  {
+    permission: PermissionFlagsBits.CreatePrivateThreads,
+    label: 'Create Private Threads',
+    severity: 'error',
+    codeSuffix: 'create-private-threads',
+  },
+  {
+    permission: PermissionFlagsBits.ManageThreads,
+    label: 'Manage Threads',
+    severity: 'warning',
+    codeSuffix: 'manage-threads',
+  },
+];
+
+@injectable()
+export class SetupDiagnosticsService implements ISetupDiagnosticsService {
+  constructor(@inject(TYPES.ConfigService) private readonly configService: IConfigService) {}
+
+  public async validateGuildSetup(guild: Guild): Promise<SetupDiagnosticReport> {
+    const issues: SetupDiagnosticIssue[] = [];
+    const serverConfig = await this.configService.getServerConfig(guild.id);
+    const botMember = await this.getBotMember(guild);
+
+    if (!botMember) {
+      issues.push({
+        severity: 'error',
+        code: 'bot-member-missing',
+        message: 'Could not load Drasil as a server member, so permissions cannot be checked.',
+      });
+      return this.toReport(guild.id, issues);
+    }
+
+    this.checkGuildPermissions(botMember, issues);
+    await this.checkRestrictedRole(guild, botMember, serverConfig, issues);
+    await this.checkConfiguredTextChannel(
+      guild,
+      botMember,
+      serverConfig.admin_channel_id,
+      'admin-channel',
+      'Admin notification channel',
+      ADMIN_CHANNEL_PERMISSIONS,
+      issues
+    );
+    await this.checkConfiguredTextChannel(
+      guild,
+      botMember,
+      serverConfig.verification_channel_id,
+      'verification-channel',
+      'Verification channel',
+      VERIFICATION_CHANNEL_PERMISSIONS,
+      issues
+    );
+
+    const detectionSettings = getDetectionResponseSettings(serverConfig.settings);
+    if (detectionSettings.observedNotificationChannelId) {
+      await this.checkConfiguredTextChannel(
+        guild,
+        botMember,
+        detectionSettings.observedNotificationChannelId,
+        'observed-notification-channel',
+        'Observed detection notification channel',
+        ADMIN_CHANNEL_PERMISSIONS,
+        issues
+      );
+    }
+
+    if (serverConfig.settings.report_instructions_channel_id) {
+      await this.checkConfiguredTextChannel(
+        guild,
+        botMember,
+        serverConfig.settings.report_instructions_channel_id,
+        'report-instructions-channel',
+        'Report instructions channel',
+        ADMIN_CHANNEL_PERMISSIONS,
+        issues
+      );
+    }
+
+    return this.toReport(guild.id, issues);
+  }
+
+  public async validateSetupCandidate(
+    guild: Guild,
+    candidate: SetupCandidate
+  ): Promise<SetupDiagnosticReport> {
+    const issues: SetupDiagnosticIssue[] = [];
+    const botMember = await this.getBotMember(guild);
+
+    if (!botMember) {
+      issues.push({
+        severity: 'error',
+        code: 'bot-member-missing',
+        message: 'Could not load Drasil as a server member, so permissions cannot be checked.',
+      });
+      return this.toReport(guild.id, issues);
+    }
+
+    this.checkGuildPermissions(botMember, issues);
+    await this.checkRestrictedRoleCandidate(guild, botMember, candidate, issues);
+    await this.checkConfiguredTextChannel(
+      guild,
+      botMember,
+      candidate.adminChannelId,
+      'admin-channel',
+      'Admin notification channel',
+      ADMIN_CHANNEL_PERMISSIONS,
+      issues
+    );
+    await this.checkVerificationChannelCandidate(guild, botMember, candidate, issues);
+
+    if (candidate.reportInstructionsChannelId) {
+      await this.checkConfiguredTextChannel(
+        guild,
+        botMember,
+        candidate.reportInstructionsChannelId,
+        'report-instructions-channel',
+        'Report instructions channel',
+        ADMIN_CHANNEL_PERMISSIONS,
+        issues
+      );
+    }
+
+    return this.toReport(guild.id, issues);
+  }
+
+  private async getBotMember(guild: Guild): Promise<GuildMember | null> {
+    if (guild.members.me) {
+      return guild.members.me;
+    }
+
+    return guild.members.fetchMe().catch(() => null);
+  }
+
+  private checkGuildPermissions(botMember: GuildMember, issues: SetupDiagnosticIssue[]): void {
+    if (!botMember.permissions.has(PermissionFlagsBits.ManageRoles)) {
+      issues.push({
+        severity: 'error',
+        code: 'guild-manage-roles',
+        message: 'Drasil is missing Manage Roles, so it cannot apply the restricted role.',
+      });
+    }
+
+    if (!botMember.permissions.has(PermissionFlagsBits.BanMembers)) {
+      issues.push({
+        severity: 'warning',
+        code: 'guild-ban-members',
+        message: 'Drasil is missing Ban Members, so moderator ban actions will fail.',
+      });
+    }
+
+    if (!botMember.permissions.has(PermissionFlagsBits.ViewAuditLog)) {
+      issues.push({
+        severity: 'warning',
+        code: 'guild-view-audit-log',
+        message:
+          'Drasil is missing View Audit Log, so installer attribution and setup nudges are best-effort only.',
+      });
+    }
+
+    if (botMember.permissions.has(PermissionFlagsBits.Administrator)) {
+      issues.push({
+        severity: 'warning',
+        code: 'guild-administrator',
+        message:
+          'Drasil has Administrator. Prefer the documented specific permissions once setup is complete.',
+      });
+    }
+  }
+
+  private async checkRestrictedRole(
+    guild: Guild,
+    botMember: GuildMember,
+    serverConfig: Server,
+    issues: SetupDiagnosticIssue[]
+  ): Promise<void> {
+    await this.checkRestrictedRoleId(guild, botMember, serverConfig.restricted_role_id, issues);
+  }
+
+  private async checkRestrictedRoleCandidate(
+    guild: Guild,
+    botMember: GuildMember,
+    candidate: SetupCandidate,
+    issues: SetupDiagnosticIssue[]
+  ): Promise<void> {
+    if (candidate.restrictedRoleId) {
+      await this.checkRestrictedRoleId(guild, botMember, candidate.restrictedRoleId, issues);
+      return;
+    }
+
+    if (candidate.willCreateRestrictedRole) {
+      return;
+    }
+
+    issues.push({
+      severity: 'error',
+      code: 'restricted-role-missing',
+      message: 'Restricted role is not configured.',
+    });
+  }
+
+  private async checkRestrictedRoleId(
+    guild: Guild,
+    botMember: GuildMember,
+    restrictedRoleId: string | null | undefined,
+    issues: SetupDiagnosticIssue[]
+  ): Promise<void> {
+    if (!restrictedRoleId) {
+      issues.push({
+        severity: 'error',
+        code: 'restricted-role-missing',
+        message: 'Restricted role is not configured.',
+      });
+      return;
+    }
+
+    const restrictedRole = await guild.roles.fetch(restrictedRoleId).catch(() => null);
+    if (!restrictedRole) {
+      issues.push({
+        severity: 'error',
+        code: 'restricted-role-not-found',
+        message: `Restricted role ${restrictedRoleId} no longer exists.`,
+      });
+      return;
+    }
+
+    if (restrictedRole.id === guild.id) {
+      issues.push({
+        severity: 'error',
+        code: 'restricted-role-everyone',
+        message: 'Restricted role cannot be @everyone.',
+      });
+    }
+
+    if (restrictedRole.managed) {
+      issues.push({
+        severity: 'error',
+        code: 'restricted-role-managed',
+        message: `Restricted role <@&${restrictedRole.id}> is managed by an integration and cannot be assigned by Drasil.`,
+      });
+    }
+
+    if (botMember.roles.highest.comparePositionTo(restrictedRole) <= 0) {
+      issues.push({
+        severity: 'error',
+        code: 'restricted-role-hierarchy',
+        message: `Drasil's highest role must be above restricted role <@&${restrictedRole.id}>.`,
+      });
+    }
+  }
+
+  private async checkVerificationChannelCandidate(
+    guild: Guild,
+    botMember: GuildMember,
+    candidate: SetupCandidate,
+    issues: SetupDiagnosticIssue[]
+  ): Promise<void> {
+    if (candidate.verificationChannelId) {
+      await this.checkConfiguredTextChannel(
+        guild,
+        botMember,
+        candidate.verificationChannelId,
+        'verification-channel',
+        'Verification channel',
+        VERIFICATION_CHANNEL_PERMISSIONS,
+        issues
+      );
+      return;
+    }
+
+    if (!candidate.willCreateVerificationChannel) {
+      issues.push({
+        severity: 'error',
+        code: 'verification-channel-missing',
+        message: 'Verification channel is not configured.',
+      });
+      return;
+    }
+
+    if (!botMember.permissions.has(PermissionFlagsBits.ManageChannels)) {
+      issues.push({
+        severity: 'error',
+        code: 'verification-channel-create-manage-channels',
+        message:
+          'Drasil is missing Manage Channels, so it cannot create the verification channel automatically.',
+      });
+    }
+  }
+
+  private async checkConfiguredTextChannel(
+    guild: Guild,
+    botMember: GuildMember,
+    channelId: string | null | undefined,
+    codePrefix: string,
+    label: string,
+    requirements: readonly PermissionRequirement[],
+    issues: SetupDiagnosticIssue[]
+  ): Promise<void> {
+    if (!channelId) {
+      issues.push({
+        severity: 'error',
+        code: `${codePrefix}-missing`,
+        message: `${label} is not configured.`,
+      });
+      return;
+    }
+
+    const channel = await guild.channels.fetch(channelId).catch(() => null);
+    if (!channel || channel.type !== ChannelType.GuildText) {
+      issues.push({
+        severity: 'error',
+        code: `${codePrefix}-not-found`,
+        message: `${label} ${channelId} no longer exists or is not a text channel.`,
+      });
+      return;
+    }
+
+    const textChannel = channel as TextChannel;
+    const permissions = textChannel.permissionsFor(botMember);
+
+    for (const requirement of requirements) {
+      if (!permissions.has(requirement.permission)) {
+        issues.push({
+          severity: requirement.severity,
+          code: `${codePrefix}-${requirement.codeSuffix}`,
+          message: `Drasil is missing ${requirement.label} in ${label} <#${textChannel.id}>.`,
+        });
+      }
+    }
+  }
+
+  private toReport(
+    guildId: string,
+    issues: readonly SetupDiagnosticIssue[]
+  ): SetupDiagnosticReport {
+    const errorCount = issues.filter((issue) => issue.severity === 'error').length;
+    const warningCount = issues.filter((issue) => issue.severity === 'warning').length;
+    return {
+      guildId,
+      checkedAt: new Date(),
+      issues,
+      errorCount,
+      warningCount,
+    };
+  }
+}

--- a/src/services/SetupDiagnosticsService.ts
+++ b/src/services/SetupDiagnosticsService.ts
@@ -66,6 +66,12 @@ const VERIFICATION_CHANNEL_PERMISSIONS: readonly PermissionRequirement[] = [
     codeSuffix: 'create-private-threads',
   },
   {
+    permission: PermissionFlagsBits.SendMessagesInThreads,
+    label: 'Send Messages in Threads',
+    severity: 'error',
+    codeSuffix: 'send-messages-in-threads',
+  },
+  {
     permission: PermissionFlagsBits.ManageThreads,
     label: 'Manage Threads',
     severity: 'warning',

--- a/src/services/SetupDiagnosticsService.ts
+++ b/src/services/SetupDiagnosticsService.ts
@@ -86,6 +86,15 @@ const VERIFICATION_CHANNEL_PERMISSIONS: readonly PermissionRequirement[] = [
   },
 ];
 
+const VERIFICATION_CHANNEL_SYNC_PERMISSIONS: readonly PermissionRequirement[] = [
+  {
+    permission: PermissionFlagsBits.ManageChannels,
+    label: 'Manage Channels',
+    severity: 'error',
+    codeSuffix: 'sync-manage-channels',
+  },
+];
+
 @injectable()
 export class SetupDiagnosticsService implements ISetupDiagnosticsService {
   constructor(@inject(TYPES.ConfigService) private readonly configService: IConfigService) {}
@@ -335,20 +344,11 @@ export class SetupDiagnosticsService implements ISetupDiagnosticsService {
         candidate.verificationChannelId,
         'verification-channel',
         'Verification channel',
-        candidate.willSyncVerificationChannelPermissions ? [] : VERIFICATION_CHANNEL_PERMISSIONS,
+        candidate.willSyncVerificationChannelPermissions
+          ? VERIFICATION_CHANNEL_SYNC_PERMISSIONS
+          : VERIFICATION_CHANNEL_PERMISSIONS,
         issues
       );
-      if (
-        candidate.willSyncVerificationChannelPermissions &&
-        !botMember.permissions.has(PermissionFlagsBits.ManageChannels)
-      ) {
-        issues.push({
-          severity: 'error',
-          code: 'verification-channel-sync-manage-channels',
-          message:
-            'Drasil is missing Manage Channels, so it cannot sync the configured verification channel permissions.',
-        });
-      }
       return;
     }
 

--- a/src/services/SetupDiagnosticsService.ts
+++ b/src/services/SetupDiagnosticsService.ts
@@ -55,6 +55,12 @@ const ADMIN_CHANNEL_PERMISSIONS: readonly PermissionRequirement[] = [
     severity: 'error',
     codeSuffix: 'send',
   },
+  {
+    permission: PermissionFlagsBits.EmbedLinks,
+    label: 'Embed Links',
+    severity: 'error',
+    codeSuffix: 'embed-links',
+  },
 ];
 
 const VERIFICATION_CHANNEL_PERMISSIONS: readonly PermissionRequirement[] = [

--- a/src/services/SetupDiagnosticsService.ts
+++ b/src/services/SetupDiagnosticsService.ts
@@ -27,6 +27,7 @@ export interface SetupCandidate {
   readonly adminChannelId: string | null;
   readonly verificationChannelId?: string | null;
   readonly willCreateVerificationChannel?: boolean;
+  readonly willSyncVerificationChannelPermissions?: boolean;
   readonly reportInstructionsChannelId?: string | null;
 }
 
@@ -334,7 +335,7 @@ export class SetupDiagnosticsService implements ISetupDiagnosticsService {
         candidate.verificationChannelId,
         'verification-channel',
         'Verification channel',
-        VERIFICATION_CHANNEL_PERMISSIONS,
+        candidate.willSyncVerificationChannelPermissions ? [] : VERIFICATION_CHANNEL_PERMISSIONS,
         issues
       );
       return;

--- a/src/services/SetupDiagnosticsService.ts
+++ b/src/services/SetupDiagnosticsService.ts
@@ -338,6 +338,17 @@ export class SetupDiagnosticsService implements ISetupDiagnosticsService {
         candidate.willSyncVerificationChannelPermissions ? [] : VERIFICATION_CHANNEL_PERMISSIONS,
         issues
       );
+      if (
+        candidate.willSyncVerificationChannelPermissions &&
+        !botMember.permissions.has(PermissionFlagsBits.ManageChannels)
+      ) {
+        issues.push({
+          severity: 'error',
+          code: 'verification-channel-sync-manage-channels',
+          message:
+            'Drasil is missing Manage Channels, so it cannot sync the configured verification channel permissions.',
+        });
+      }
       return;
     }
 


### PR DESCRIPTION
## Summary
- Add unified /config setup and /config validate flows with setup diagnostics and hard-error gating.
- Make verification/report setup idempotent and add install setup nudges using audit-log installer attribution with owner fallback.
- Update docs and focused unit coverage for setup diagnostics, setup commands, install nudges, and startup ordering.

## Testing
- npm run format:check
- npm run lint
- npm run build
- npm test
- git diff --check

## Risk Notes
- Draft PR for review before paid/external review triggers.
- Setup nudges are best-effort DMs and rate-limited through server settings.
- /setupverification remains available but now shares diagnostics hard-error gating.