### PR TITLE
Clean up repository warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,11 @@ on:
       - main
   pull_request:
 
+env:
+  GIT_CONFIG_COUNT: 1
+  GIT_CONFIG_KEY_0: init.defaultBranch
+  GIT_CONFIG_VALUE_0: main
+
 jobs:
   build-test:
     runs-on: ubuntu-latest
@@ -16,6 +21,7 @@ jobs:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
           POSTGRES_DB: drasil_test
+          POSTGRES_INITDB_ARGS: --auth-local=scram-sha-256 --auth-host=scram-sha-256
         ports:
           - 5432:5432
         options: >-

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -15,6 +15,11 @@ concurrency:
   group: deploy-prod
   cancel-in-progress: false
 
+env:
+  GIT_CONFIG_COUNT: 1
+  GIT_CONFIG_KEY_0: init.defaultBranch
+  GIT_CONFIG_VALUE_0: main
+
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/iac.yml
+++ b/.github/workflows/iac.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@v4.0.1
         with:
           terraform_version: 1.6.6
 

--- a/.github/workflows/iac.yml
+++ b/.github/workflows/iac.yml
@@ -6,6 +6,11 @@ on:
     branches:
       - main
 
+env:
+  GIT_CONFIG_COUNT: 1
+  GIT_CONFIG_KEY_0: init.defaultBranch
+  GIT_CONFIG_VALUE_0: main
+
 jobs:
   terraform:
     runs-on: ubuntu-latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,10 @@
 # syntax=docker/dockerfile:1.7
 
-FROM node:20.19-bookworm-slim AS base
+FROM node:24-bookworm-slim AS base
 
 WORKDIR /app
+
+ENV NPM_CONFIG_UPDATE_NOTIFIER=false
 
 # Prisma engine generation during npm postinstall needs OpenSSL available.
 RUN apt-get update \

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ The bot currently implements the following heuristic checks:
 This project uses npm scripts for common development tasks:
 
 - `npm start`: Runs the bot using `ts-node` (for development).
-- `npm run dev`: Runs the bot using `ts-node-dev` which automatically restarts on file changes.
+- `npm run dev`: Runs the bot with Node's watch mode and automatically restarts on file changes.
 - `npm test`: Runs the Jest test suite.
 - `npm run test:watch`: Runs Jest in watch mode.
 - `npm run build`: Compiles TypeScript code to JavaScript in the `dist/` directory.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,6 @@
       "version": "1.0.0",
       "hasInstallScript": true,
       "license": "ISC",
-      "engines": {
-        "node": ">=22.22.0"
-      },
       "dependencies": {
         "@arizeai/openinference-instrumentation-openai": "^2.1.0",
         "@arizeai/phoenix-otel": "^0.3.4",
@@ -49,9 +46,11 @@
         "prettier": "^3.5.3",
         "ts-jest": "^29.3.0",
         "ts-node": "^10.9.1",
-        "ts-node-dev": "^2.0.0",
         "typescript": "^5.0.0",
         "typescript-eslint": "^8.28.0"
+      },
+      "engines": {
+        "node": ">=22.22.0"
       }
     },
     "node_modules/@arizeai/openinference-core": {
@@ -4035,20 +4034,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/strip-bom": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@types/strip-bom/-/strip-bom-3.0.0.tgz",
-      "integrity": "sha512-xevGOReSYGM7g/kUBZzPqCrR/KYAo+F0yiPc85WFTJa0MSLtyFTVTU6cJu/aV4mid7IffDIWqo69THF2o4JiEQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/strip-json-comments": {
-      "version": "0.0.30",
-      "resolved": "https://registry.npmjs.org/@types/strip-json-comments/-/strip-json-comments-0.0.30.tgz",
-      "integrity": "sha512-7NQmHra/JILCd1QqpSzl8+mJRc8ZHz3uDm8YV1Ks9IhK0epEiTw8aIErbvH9PI+6XbqhyIQy3462nEsn7UVzjQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/ws": {
       "version": "8.18.1",
       "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
@@ -4701,19 +4686,6 @@
       "integrity": "sha512-WIFoBPCdnTOdk9inkE1ZRvCZ4P0CpSkAiLlchC65N7n9DcjZ3NhqkBOlafzpOVnO8ixyi37kicmSJ3ENhPZl7Q==",
       "license": "MIT"
     },
-    "node_modules/binary-extensions": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
-      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/brace-expansion": {
       "version": "1.1.14",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
@@ -5299,16 +5271,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/dynamic-dedupe": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/dynamic-dedupe/-/dynamic-dedupe-0.3.0.tgz",
-      "integrity": "sha512-ssuANeD+z97meYOqd50e04Ze5qp4bPqo8cCkI4TRjZkzAUgIDTrXV1R8QCdINpiI+hw14+rYazvTRdQrz0/rFQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "xtend": "^4.0.0"
       }
     },
     "node_modules/effect": {
@@ -6464,19 +6426,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/is-binary-path": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
-      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "binary-extensions": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/is-core-module": {
       "version": "2.16.1",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
@@ -7600,19 +7549,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/mkdirp": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/module-details-from-path": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.4.tgz",
@@ -8588,20 +8524,6 @@
         "node": ">= 4"
       }
     },
-    "node_modules/rimraf": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-      "deprecated": "Rimraf versions prior to v4 are no longer supported",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      }
-    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -8960,16 +8882,6 @@
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
       "license": "MIT"
     },
-    "node_modules/tree-kill": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
-      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "tree-kill": "cli.js"
-      }
-    },
     "node_modules/ts-api-utils": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.4.0.tgz",
@@ -9125,125 +9037,6 @@
         "@swc/wasm": {
           "optional": true
         }
-      }
-    },
-    "node_modules/ts-node-dev": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ts-node-dev/-/ts-node-dev-2.0.0.tgz",
-      "integrity": "sha512-ywMrhCfH6M75yftYvrvNarLEY+SUXtUvU8/0Z6llrHQVBx12GiFk5sStF8UdfE/yfzk9IAq7O5EEbTQsxlBI8w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "chokidar": "^3.5.1",
-        "dynamic-dedupe": "^0.3.0",
-        "minimist": "^1.2.6",
-        "mkdirp": "^1.0.4",
-        "resolve": "^1.0.0",
-        "rimraf": "^2.6.1",
-        "source-map-support": "^0.5.12",
-        "tree-kill": "^1.2.2",
-        "ts-node": "^10.4.0",
-        "tsconfig": "^7.0.0"
-      },
-      "bin": {
-        "ts-node-dev": "lib/bin.js",
-        "tsnd": "lib/bin.js"
-      },
-      "engines": {
-        "node": ">=0.8.0"
-      },
-      "peerDependencies": {
-        "node-notifier": "*",
-        "typescript": "*"
-      },
-      "peerDependenciesMeta": {
-        "node-notifier": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/ts-node-dev/node_modules/chokidar": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
-      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "anymatch": "~3.1.2",
-        "braces": "~3.0.2",
-        "glob-parent": "~5.1.2",
-        "is-binary-path": "~2.1.0",
-        "is-glob": "~4.0.1",
-        "normalize-path": "~3.0.0",
-        "readdirp": "~3.6.0"
-      },
-      "engines": {
-        "node": ">= 8.10.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.2"
-      }
-    },
-    "node_modules/ts-node-dev/node_modules/glob-parent": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "is-glob": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/ts-node-dev/node_modules/readdirp": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
-      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "picomatch": "^2.2.1"
-      },
-      "engines": {
-        "node": ">=8.10.0"
-      }
-    },
-    "node_modules/tsconfig": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/tsconfig/-/tsconfig-7.0.0.tgz",
-      "integrity": "sha512-vZXmzPrL+EmC4T/4rVlT2jNVMWCi/O4DIiSj3UHg1OE5kCKbk4mfrXc6dZksLgRM/TZlKnousKH9bbTazUWRRw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/strip-bom": "^3.0.0",
-        "@types/strip-json-comments": "0.0.30",
-        "strip-bom": "^3.0.0",
-        "strip-json-comments": "^2.0.0"
-      }
-    },
-    "node_modules/tsconfig/node_modules/strip-bom": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/tsconfig/node_modules/strip-json-comments": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/tslib": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,9 @@
       "version": "1.0.0",
       "hasInstallScript": true,
       "license": "ISC",
+      "engines": {
+        "node": ">=22.22.0"
+      },
       "dependencies": {
         "@arizeai/openinference-instrumentation-openai": "^2.1.0",
         "@arizeai/phoenix-otel": "^0.3.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "@eslint/js": "^9.23.0",
         "@jest/globals": "^29.7.0",
         "@types/jest": "^29.5.14",
-        "@types/node": "^20.17.24",
+        "@types/node": "^22.0.0",
         "@types/pg": "^8.16.0",
         "babel-jest": "^29.7.0",
         "eslint": "^9.23.0",
@@ -3976,9 +3976,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.19.33",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.33.tgz",
-      "integrity": "sha512-Rs1bVAIdBs5gbTIKza/tgpMuG1k3U/UMJLWecIMxNdJFDMzcM5LOiLVRYh3PilWEYDIeUDv7bpiHPLPsbydGcw==",
+      "version": "22.19.19",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.19.tgz",
+      "integrity": "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@eslint/js": "^9.23.0",
     "@jest/globals": "^29.7.0",
     "@types/jest": "^29.5.14",
-    "@types/node": "^20.17.24",
+    "@types/node": "^22.0.0",
     "@types/pg": "^8.16.0",
     "babel-jest": "^29.7.0",
     "eslint": "^9.23.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "start": "ts-node src/index.ts",
-    "dev": "ts-node-dev --respawn src/index.ts",
+    "dev": "node --watch -r ts-node/register src/index.ts",
     "test": "jest --testPathPattern=src/__tests__/unit",
     "test:watch": "jest --watch --testPathPattern=src/__tests__/unit",
     "test:coverage": "jest --testPathPattern=src/__tests__/unit --coverage",
@@ -67,7 +67,6 @@
     "prettier": "^3.5.3",
     "ts-jest": "^29.3.0",
     "ts-node": "^10.9.1",
-    "ts-node-dev": "^2.0.0",
     "typescript": "^5.0.0",
     "typescript-eslint": "^8.28.0"
   },

--- a/package.json
+++ b/package.json
@@ -44,6 +44,9 @@
   ],
   "author": "",
   "license": "ISC",
+  "engines": {
+    "node": ">=22.22.0"
+  },
   "devDependencies": {
     "@babel/core": "^7.26.10",
     "@babel/preset-env": "^7.26.9",

--- a/scripts/check-public-rls.js
+++ b/scripts/check-public-rls.js
@@ -4,7 +4,7 @@ const { Client } = require('pg');
 
 const CLIENT_ROLES = ['anon', 'authenticated'];
 const DEFAULT_DEFAULT_ACL_OWNERS = ['postgres', 'prisma'];
-const TABLE_PRIVILEGE_CANDIDATES = [
+const BASE_TABLE_PRIVILEGES = [
   'SELECT',
   'INSERT',
   'UPDATE',
@@ -12,8 +12,8 @@ const TABLE_PRIVILEGE_CANDIDATES = [
   'TRUNCATE',
   'REFERENCES',
   'TRIGGER',
-  'MAINTAIN',
 ];
+const OPTIONAL_TABLE_PRIVILEGES = ['MAINTAIN'];
 
 function createConnectionConfig() {
   const databaseUrl = process.env.TEST_DATABASE_URL || process.env.DATABASE_URL;
@@ -52,22 +52,21 @@ function configuredDefaultAclOwners(currentUser) {
 }
 
 async function supportedTablePrivileges(client) {
-  const privileges = [];
+  const optionalPrivilegeResult = await client.query(
+    `
+      SELECT DISTINCT privilege_type
+      FROM information_schema.table_privileges
+      WHERE table_schema = 'public'
+        AND privilege_type = ANY($1::text[])
+      ORDER BY privilege_type;
+    `,
+    [OPTIONAL_TABLE_PRIVILEGES]
+  );
 
-  for (const privilege of TABLE_PRIVILEGE_CANDIDATES) {
-    try {
-      await client.query("SELECT has_table_privilege(current_user, 'pg_class'::regclass, $1)", [
-        privilege,
-      ]);
-      privileges.push(privilege);
-    } catch (error) {
-      if (!error.message.includes('unrecognized privilege type')) {
-        throw error;
-      }
-    }
-  }
-
-  return privileges;
+  return [
+    ...BASE_TABLE_PRIVILEGES,
+    ...optionalPrivilegeResult.rows.map((row) => row.privilege_type),
+  ];
 }
 
 async function main() {

--- a/scripts/check-public-rls.js
+++ b/scripts/check-public-rls.js
@@ -52,21 +52,25 @@ function configuredDefaultAclOwners(currentUser) {
 }
 
 async function supportedTablePrivileges(client) {
-  const optionalPrivilegeResult = await client.query(
-    `
-      SELECT DISTINCT privilege_type
-      FROM information_schema.table_privileges
-      WHERE table_schema = 'public'
-        AND privilege_type = ANY($1::text[])
-      ORDER BY privilege_type;
-    `,
-    [OPTIONAL_TABLE_PRIVILEGES]
-  );
+  const supportedOptionalPrivileges = [];
 
-  return [
-    ...BASE_TABLE_PRIVILEGES,
-    ...optionalPrivilegeResult.rows.map((row) => row.privilege_type),
-  ];
+  for (const privilege of OPTIONAL_TABLE_PRIVILEGES) {
+    try {
+      // Probe privilege support directly instead of inferring it from grants visible to this role.
+      await client.query(`SELECT has_table_privilege('pg_catalog.pg_class'::regclass, $1::text);`, [
+        privilege,
+      ]);
+      supportedOptionalPrivileges.push(privilege);
+    } catch (error) {
+      if (error instanceof Error && error.message.includes('unrecognized privilege type')) {
+        continue;
+      }
+
+      throw error;
+    }
+  }
+
+  return [...BASE_TABLE_PRIVILEGES, ...supportedOptionalPrivileges];
 }
 
 async function main() {

--- a/scripts/create-prisma-user.js
+++ b/scripts/create-prisma-user.js
@@ -1,4 +1,3 @@
-/* eslint-env node, commonjs */
 const { Client } = require('pg');
 const dotenv = require('dotenv');
 

--- a/src/__tests__/unit/EventHandler.unit.test.ts
+++ b/src/__tests__/unit/EventHandler.unit.test.ts
@@ -1,4 +1,4 @@
-import { GuildMember, Message, PermissionFlagsBits, PermissionsBitField } from 'discord.js';
+import { Events, GuildMember, Message, PermissionFlagsBits, PermissionsBitField } from 'discord.js';
 import { EventHandler } from '../../controllers/EventHandler';
 import { DetectionType } from '../../repositories/types';
 
@@ -93,6 +93,20 @@ describe('EventHandler (unit)', () => {
       reply: jest.fn().mockResolvedValue(undefined),
     } as unknown as Message;
   }
+
+  it('registers Discord event handlers with current event names', async () => {
+    const client = { on: jest.fn(), user: { id: 'bot-1' } };
+    const handler = buildHandler({ client });
+
+    await handler.setupEventHandlers();
+
+    expect(client.on).toHaveBeenCalledWith(Events.ClientReady, expect.any(Function));
+    expect(client.on).toHaveBeenCalledWith(Events.MessageCreate, expect.any(Function));
+    expect(client.on).toHaveBeenCalledWith(Events.GuildMemberAdd, expect.any(Function));
+    expect(client.on).toHaveBeenCalledWith(Events.InteractionCreate, expect.any(Function));
+    expect(client.on).toHaveBeenCalledWith(Events.GuildCreate, expect.any(Function));
+    expect(client.on).not.toHaveBeenCalledWith('ready', expect.any(Function));
+  });
 
   it('delegates legacy test commands to CommandHandler', async () => {
     const commandHandler = {

--- a/src/__tests__/unit/ThreadManager.unit.test.ts
+++ b/src/__tests__/unit/ThreadManager.unit.test.ts
@@ -335,6 +335,7 @@ describe('ThreadManager (unit)', () => {
   });
 
   it('truncates rendered prompt to Discord content limit', async () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
     const repeatedPlaceholder = '{user_mention}'.repeat(250);
     (configService.getServerConfig as jest.Mock).mockResolvedValue({
       settings: {
@@ -368,6 +369,10 @@ describe('ThreadManager (unit)', () => {
     expect(sendPayload.content).toContain(
       '[Verification prompt truncated to fit Discord message limits.]'
     );
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Verification prompt exceeded Discord content limit')
+    );
+    warnSpy.mockRestore();
   });
 
   it('falls back to admin channel when verification channel is missing', async () => {

--- a/src/__tests__/unit/ThreadManager.unit.test.ts
+++ b/src/__tests__/unit/ThreadManager.unit.test.ts
@@ -299,80 +299,87 @@ describe('ThreadManager (unit)', () => {
     (configService.getServerConfig as jest.Mock).mockRejectedValue(new Error('config failure'));
     const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
 
-    const manager = new ThreadManager(
-      {} as any,
-      configService,
-      verificationEventRepository,
-      userRepository,
-      serverRepository,
-      serverMemberRepository
-    );
+    try {
+      const manager = new ThreadManager(
+        {} as any,
+        configService,
+        verificationEventRepository,
+        userRepository,
+        serverRepository,
+        serverMemberRepository
+      );
 
-    const member = buildMember('guild-1', 'user-1');
-    const event = await verificationEventRepository.createFromDetection(
-      null,
-      'guild-1',
-      'user-1',
-      VerificationStatus.PENDING
-    );
+      const member = buildMember('guild-1', 'user-1');
+      const event = await verificationEventRepository.createFromDetection(
+        null,
+        'guild-1',
+        'user-1',
+        VerificationStatus.PENDING
+      );
 
-    await manager.createVerificationThread(member, event);
+      await manager.createVerificationThread(member, event);
 
-    expect(thread.send).toHaveBeenCalledWith({
-      content: renderVerificationPromptTemplate(DEFAULT_VERIFICATION_PROMPT_TEMPLATE, {
-        userMention: `<@${member.id}>`,
-        serverName: member.guild.name,
-      }),
-      allowedMentions: {
-        parse: [],
-        users: [member.id],
-        roles: [],
-        repliedUser: false,
-      },
-    });
-    expect(warnSpy).toHaveBeenCalled();
-    warnSpy.mockRestore();
+      expect(thread.send).toHaveBeenCalledWith({
+        content: renderVerificationPromptTemplate(DEFAULT_VERIFICATION_PROMPT_TEMPLATE, {
+          userMention: `<@${member.id}>`,
+          serverName: member.guild.name,
+        }),
+        allowedMentions: {
+          parse: [],
+          users: [member.id],
+          roles: [],
+          repliedUser: false,
+        },
+      });
+      expect(warnSpy).toHaveBeenCalled();
+    } finally {
+      warnSpy.mockRestore();
+    }
   });
 
   it('truncates rendered prompt to Discord content limit', async () => {
     const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
-    const repeatedPlaceholder = '{user_mention}'.repeat(250);
-    (configService.getServerConfig as jest.Mock).mockResolvedValue({
-      settings: {
-        verification_prompt_template: repeatedPlaceholder,
-      },
-    });
 
-    const manager = new ThreadManager(
-      {} as any,
-      configService,
-      verificationEventRepository,
-      userRepository,
-      serverRepository,
-      serverMemberRepository
-    );
+    try {
+      const repeatedPlaceholder = '{user_mention}'.repeat(250);
+      (configService.getServerConfig as jest.Mock).mockResolvedValue({
+        settings: {
+          verification_prompt_template: repeatedPlaceholder,
+        },
+      });
 
-    const member = buildMember('guild-1', 'user-1');
-    const event = await verificationEventRepository.createFromDetection(
-      null,
-      'guild-1',
-      'user-1',
-      VerificationStatus.PENDING
-    );
+      const manager = new ThreadManager(
+        {} as any,
+        configService,
+        verificationEventRepository,
+        userRepository,
+        serverRepository,
+        serverMemberRepository
+      );
 
-    await manager.createVerificationThread(member, event);
+      const member = buildMember('guild-1', 'user-1');
+      const event = await verificationEventRepository.createFromDetection(
+        null,
+        'guild-1',
+        'user-1',
+        VerificationStatus.PENDING
+      );
 
-    const sendPayload = (thread.send as jest.Mock).mock.calls[0][0] as {
-      content: string;
-    };
-    expect(sendPayload.content.length).toBeLessThanOrEqual(DISCORD_MESSAGE_CONTENT_MAX_LENGTH);
-    expect(sendPayload.content).toContain(
-      '[Verification prompt truncated to fit Discord message limits.]'
-    );
-    expect(warnSpy).toHaveBeenCalledWith(
-      expect.stringContaining('Verification prompt exceeded Discord content limit')
-    );
-    warnSpy.mockRestore();
+      await manager.createVerificationThread(member, event);
+
+      const sendPayload = (thread.send as jest.Mock).mock.calls[0][0] as {
+        content: string;
+      };
+      expect(sendPayload.content.length).toBeLessThanOrEqual(DISCORD_MESSAGE_CONTENT_MAX_LENGTH);
+      expect(sendPayload.content).toContain(
+        '[Verification prompt truncated to fit Discord message limits.]'
+      );
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Verification prompt exceeded Discord content limit')
+      );
+    } finally {
+      warnSpy.mockRestore();
+    }
   });
 
   it('falls back to admin channel when verification channel is missing', async () => {

--- a/src/controllers/EventHandler.ts
+++ b/src/controllers/EventHandler.ts
@@ -5,6 +5,7 @@ import {
   GuildMember,
   Interaction,
   Guild,
+  Events,
   MessageFlags,
   PermissionFlagsBits,
 } from 'discord.js';
@@ -129,11 +130,11 @@ export class EventHandler implements IEventHandler {
   }
 
   public async setupEventHandlers(): Promise<void> {
-    this.client.on('ready', this.handleReady.bind(this));
-    this.client.on('messageCreate', this.handleMessage.bind(this));
-    this.client.on('guildMemberAdd', this.handleGuildMemberAdd.bind(this));
-    this.client.on('interactionCreate', this.handleInteraction.bind(this));
-    this.client.on('guildCreate', this.handleGuildCreate.bind(this));
+    this.client.on(Events.ClientReady, this.handleReady.bind(this));
+    this.client.on(Events.MessageCreate, this.handleMessage.bind(this));
+    this.client.on(Events.GuildMemberAdd, this.handleGuildMemberAdd.bind(this));
+    this.client.on(Events.InteractionCreate, this.handleInteraction.bind(this));
+    this.client.on(Events.GuildCreate, this.handleGuildCreate.bind(this));
   }
 
   private async handleReady(): Promise<void> {


### PR DESCRIPTION
## Summary
- Replace deprecated Discord ready event usage with current discord.js event constants.
- Remove stale lint/test warning noise from ESLint, Jest, and the RLS checker.
- Align Docker/runtime cleanup with dependency Node engine requirements and update Terraform setup action.
- Reduce CI/install warning noise by removing ts-node-dev, using Node watch mode, suppressing Git checkout default-branch hints, and configuring Postgres test auth explicitly.
- Address AI review feedback by probing optional table privilege support directly, restoring console spies with `finally`, and aligning `@types/node` with the Node engine floor.

## Testing
- npm run build
- npm run lint
- npm run format:check
- npm test
- git diff --check
- npm run db:check:rls (local DB failed on existing local grants/_prisma_migrations state, but no longer emits the prior MAINTAIN privilege error)
- node --watch -r ts-node/register src/Bot.ts (verified watch-mode TypeScript entrypoint starts and waits for changes; stopped by timeout)
- docker build --target deps --progress=plain -t drasil-cleanup-deps .
- docker build --progress=plain -t drasil-cleanup .
- GitHub PR checks passed for head 6f2d6e68382b5417058105a724fb78e43e454bcc

## Notes
- Docker/CI npm install still reports upstream deprecation warnings from current dependency chains: Jest/glob/inflight, OpenAI/formdata-node, and OTel/acorn-import-assertions. Removing ts-node-dev eliminates the rimraf warning and one source of glob/inflight, but fully removing the rest needs a Jest/OpenAI/OTel dependency-upgrade pass.