### PR TITLE
[AGENT] Harden workflow token permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
       - main
   pull_request:
 
+permissions:
+  contents: read
+
 env:
   GIT_CONFIG_COUNT: 1
   GIT_CONFIG_KEY_0: init.defaultBranch

--- a/.github/workflows/iac.yml
+++ b/.github/workflows/iac.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 env:
   GIT_CONFIG_COUNT: 1
   GIT_CONFIG_KEY_0: init.defaultBranch


### PR DESCRIPTION
[AGENT]

## What / Why

Adds explicit read-only GitHub Actions token permissions to CI and IaC workflows to resolve open CodeQL actions/missing-workflow-permissions findings.

No package bumps were needed: Dependabot alerts are empty and npm audit reports 0 vulnerabilities.

## Linked issues

- N/A - GitHub code scanning alerts 2, 5, 6, and 7

## How to test

- npm ci
- npm run format:check
- npm run check
- actionlint
- npm audit --json

## Risk / rollout

Low. These workflows only need repository contents read access for checkout and validation jobs.

## AI Review Packet (fresh-context friendly)

- Primary goal: Resolve the open CodeQL workflow permission findings with least-privilege GitHub Actions permissions.
- Non-goals: Dependency upgrades, runtime code changes, deployment behavior changes.
- Key files changed: .github/workflows/ci.yml, .github/workflows/iac.yml.
- Invariants this PR must preserve: CI and IaC checks continue to run on pull requests and pushes to main.
- Manual test notes: Local npm gates and actionlint pass.
- Questions for reviewers: Are any workflow jobs missing a legitimate write permission requirement?

## Merge checklist

- [ ] All PR review threads resolved (or explicitly addressed)