### PR TITLE
Add verification case repair flow

### DIFF
--- a/src/__tests__/integration/SecurityActionService.integration.test.ts
+++ b/src/__tests__/integration/SecurityActionService.integration.test.ts
@@ -88,6 +88,13 @@ describeIntegration('SecurityActionService (integration)', () => {
       activateReportIntakeThread: jest.fn().mockResolvedValue(true),
       resolveVerificationThread: jest.fn().mockResolvedValue(true),
       reopenVerificationThread: jest.fn().mockResolvedValue(true),
+      repairVerificationThread: jest.fn().mockResolvedValue({
+        threadId: 'thread-1',
+        threadCreated: false,
+        userAdded: true,
+        promptSent: true,
+        promptAlreadyPresent: false,
+      }),
     };
     userModerationService = {
       restrictUser: jest.fn().mockResolvedValue(true),

--- a/src/__tests__/integration/UserModerationService.integration.test.ts
+++ b/src/__tests__/integration/UserModerationService.integration.test.ts
@@ -80,6 +80,13 @@ describeIntegration('UserModerationService (integration)', () => {
       activateReportIntakeThread: jest.fn().mockResolvedValue(true),
       resolveVerificationThread: jest.fn().mockResolvedValue(true),
       reopenVerificationThread: jest.fn().mockResolvedValue(true),
+      repairVerificationThread: jest.fn().mockResolvedValue({
+        threadId: 'thread-1',
+        threadCreated: false,
+        userAdded: true,
+        promptSent: true,
+        promptAlreadyPresent: false,
+      }),
     };
   });
 

--- a/src/__tests__/unit/CommandHandler.unit.test.ts
+++ b/src/__tests__/unit/CommandHandler.unit.test.ts
@@ -38,6 +38,7 @@ describe('CommandHandler (unit)', () => {
     handleUserReport: jest.Mock;
     handleMessageReport: jest.Mock;
     openAdminCase: jest.Mock;
+    repairActiveCase: jest.Mock;
     intakeRoleMembers: jest.Mock;
     setupVerificationChannel: jest.Mock;
     setupDiagnosticsService: any | null;
@@ -45,6 +46,7 @@ describe('CommandHandler (unit)', () => {
     validateSetupCandidate: jest.Mock;
     excludeDetectionFromAccounting: jest.Mock;
     restoreDetectionAccounting: jest.Mock;
+    restrictedRoleLockdownService: any;
   }>;
 
   const originalUserInstallReportingEnabled = process.env.DRASIL_USER_INSTALL_REPORTING_ENABLED;
@@ -103,6 +105,18 @@ describe('CommandHandler (unit)', () => {
           opened: true,
           restrictionAttempted: false,
           restricted: false,
+        }),
+      repairActiveCase:
+        overrides.repairActiveCase ??
+        jest.fn().mockResolvedValue({
+          repaired: true,
+          message: 'Repaired active verification case for test-user#0001.',
+          verificationEventId: 'ver-1',
+          threadId: 'thread-1',
+          threadCreated: false,
+          userAdded: true,
+          promptSent: true,
+          promptAlreadyPresent: false,
         }),
       intakeRoleMembers:
         overrides.intakeRoleMembers ??
@@ -169,7 +183,8 @@ describe('CommandHandler (unit)', () => {
         userModerationService,
         securityActionService,
         undefined,
-        setupDiagnosticsService
+        setupDiagnosticsService,
+        overrides.restrictedRoleLockdownService
       ),
       client,
       userModerationService,
@@ -242,6 +257,8 @@ describe('CommandHandler (unit)', () => {
       const channelOption = subcommand.options.find((option: any) => option.name === 'channel');
       expect(channelOption.channel_types).toContain(ChannelType.GuildMedia);
     }
+    const applySubcommand = lockdownGroup.options.find((option: any) => option.name === 'apply');
+    expect(applySubcommand.options.map((option: any) => option.name)).toContain('unsync-allowed');
   });
 
   it('denies legacy test commands for non-admin members', async () => {
@@ -467,8 +484,12 @@ describe('CommandHandler (unit)', () => {
     expect(caseCommand.options.map((option: any) => option.name)).toEqual([
       'open',
       'restrict',
+      'repair',
       'intake-role',
     ]);
+
+    const repair = caseCommand.options.find((option: any) => option.name === 'repair');
+    expect(repair.options.map((option: any) => option.name)).toEqual(['user']);
 
     const intakeRole = caseCommand.options.find((option: any) => option.name === 'intake-role');
     expect(intakeRole.options.map((option: any) => option.name)).toEqual([
@@ -806,6 +827,59 @@ describe('CommandHandler (unit)', () => {
         'Opened a case for target#0001, but I could not apply the restricted role. Check bot permissions and role hierarchy.',
       allowedMentions: { parse: [] },
     });
+  });
+
+  it('repairs an active verification case via /case repair', async () => {
+    const repairActiveCase = jest.fn().mockResolvedValue({
+      repaired: true,
+      message: 'Repaired active verification case for target#0001.',
+      verificationEventId: 'ver-1',
+      threadId: 'thread-1',
+      threadCreated: false,
+      userAdded: true,
+      promptSent: true,
+      promptAlreadyPresent: false,
+    });
+    const { handler, securityActionService } = buildHandler({ repairActiveCase });
+    const invoker = { id: 'admin-1' } as any;
+    const targetUser = { id: 'user-2', tag: 'target#0001' } as any;
+    const targetMember = { id: targetUser.id } as any;
+    const guild = {
+      id: 'guild-1',
+      members: {
+        fetch: jest
+          .fn()
+          .mockImplementation(async (id: string) =>
+            id === invoker.id
+              ? { permissions: { has: jest.fn().mockReturnValue(true) } }
+              : targetMember
+          ),
+      },
+    } as any;
+    const interaction = {
+      commandName: 'case',
+      user: invoker,
+      guild,
+      options: {
+        getSubcommand: jest.fn().mockReturnValue('repair'),
+        getUser: jest.fn().mockReturnValue(targetUser),
+      },
+      deferReply: jest.fn().mockResolvedValue(undefined),
+      editReply: jest.fn().mockResolvedValue(undefined),
+      reply: jest.fn().mockResolvedValue(undefined),
+    } as any;
+
+    await handler.handleSlashCommand(interaction);
+
+    expect(securityActionService.repairActiveCase).toHaveBeenCalledWith(targetMember);
+    expect(interaction.deferReply).toHaveBeenCalledWith({ flags: MessageFlags.Ephemeral });
+    expect(interaction.editReply).toHaveBeenCalledWith({
+      content: expect.stringContaining('Prompt sent: `yes`'),
+      allowedMentions: { parse: [] },
+    });
+    expect(interaction.editReply.mock.calls[0][0].content).toContain(
+      'https://discord.com/channels/guild-1/thread-1'
+    );
   });
 
   it('dry-runs restricted role intake via /case intake-role', async () => {
@@ -3195,6 +3269,76 @@ describe('CommandHandler (unit)', () => {
       content: expect.stringContaining('Channel <#media-channel-1> added to'),
       allowedMentions: { parse: [] },
     });
+  });
+
+  it('passes confirmed unsync option and lists lockdown errors before warnings', async () => {
+    const lockdownService = {
+      auditGuild: jest.fn(),
+      applyGuild: jest.fn().mockResolvedValue({
+        guildId: 'guild-1',
+        checkedAt: new Date('2026-01-01T00:00:00.000Z'),
+        enabled: false,
+        allowedChannelIds: ['allowed-channel-1'],
+        allowedCategoryIds: [],
+        autoAllowedChannelIds: ['verification-channel-1'],
+        issues: [
+          {
+            severity: 'warning',
+            code: 'lockdown-warning',
+            message: 'Warning should be listed after blockers.',
+          },
+          {
+            severity: 'error',
+            code: 'lockdown-error',
+            message: 'Allowed channel is synced under a denied category.',
+          },
+        ],
+        plannedActions: [],
+        appliedActions: [],
+        failedActions: [],
+        syncedAllowedChannels: [
+          { scope: 'channel', channelId: 'allowed-channel-1', channelName: 'welcome-center' },
+        ],
+        unsyncedAllowedChannels: [
+          { scope: 'channel', channelId: 'allowed-channel-1', channelName: 'welcome-center' },
+        ],
+        errorCount: 1,
+        warningCount: 1,
+      }),
+    };
+    const { handler } = buildHandler({ restrictedRoleLockdownService: lockdownService });
+    const guild = {
+      id: 'guild-1',
+      members: {
+        fetch: jest.fn().mockResolvedValue({
+          permissions: {
+            has: jest.fn().mockReturnValue(true),
+          },
+        }),
+      },
+    } as any;
+    const interaction = {
+      commandName: 'config',
+      user: { id: 'admin-1' },
+      guild,
+      options: {
+        getSubcommandGroup: jest.fn().mockReturnValue('lockdown'),
+        getSubcommand: jest.fn().mockReturnValue('apply'),
+        getBoolean: jest.fn().mockReturnValue(true),
+      },
+      reply: jest.fn().mockResolvedValue(undefined),
+      deferReply: jest.fn().mockResolvedValue(undefined),
+      editReply: jest.fn().mockResolvedValue(undefined),
+    } as any;
+
+    await handler.handleSlashCommand(interaction);
+
+    expect(lockdownService.applyGuild).toHaveBeenCalledWith(guild, 'admin-1', {
+      unsyncAllowedChannels: true,
+    });
+    const content = interaction.editReply.mock.calls[0][0].content as string;
+    expect(content).toContain('Unsynced allowed channels: `1`');
+    expect(content.indexOf('[ERROR]')).toBeLessThan(content.indexOf('[WARNING]'));
   });
 
   it('handles /config detection set-mode', async () => {

--- a/src/__tests__/unit/DetectionOrchestrator.unit.test.ts
+++ b/src/__tests__/unit/DetectionOrchestrator.unit.test.ts
@@ -626,6 +626,38 @@ describe('DetectionOrchestrator (unit)', () => {
     });
   });
 
+  it('clamps suspicious new-join confidence to 100%', async () => {
+    gptService.analyzeProfile.mockResolvedValue(
+      makeGptAnalysis({
+        result: 'SUSPICIOUS',
+        confidence: 0.9,
+        reasons: ['AI analysis flagged user/message context as suspicious'],
+      })
+    );
+
+    const orchestrator = new DetectionOrchestrator(
+      heuristicService,
+      gptService,
+      detectionEventsRepository,
+      userRepository,
+      serverRepository
+    );
+
+    const profile: UserProfileData = {
+      username: 'new-user',
+      accountCreatedAt: new Date(),
+      joinedServerAt: new Date(),
+      recentMessages: [],
+    };
+
+    const result = await orchestrator.detectNewJoin(serverId, userId, profile);
+    const events = await detectionEventsRepository.findByServerAndUser(serverId, userId);
+
+    expect(result.label).toBe('SUSPICIOUS');
+    expect(result.confidence).toBe(1);
+    expect(events[0].confidence).toBe(1);
+  });
+
   it('excludes suspicious new joins from accounting in detection test mode', async () => {
     const originalTestMode = process.env.DRASIL_DETECTION_TEST_MODE;
     const originalTestRunId = process.env.DRASIL_DETECTION_TEST_RUN_ID;

--- a/src/__tests__/unit/EventHandler.unit.test.ts
+++ b/src/__tests__/unit/EventHandler.unit.test.ts
@@ -1,4 +1,11 @@
-import { Events, GuildMember, Message, PermissionFlagsBits, PermissionsBitField } from 'discord.js';
+import {
+  Events,
+  GuildMember,
+  Message,
+  MessageType,
+  PermissionFlagsBits,
+  PermissionsBitField,
+} from 'discord.js';
 import { EventHandler } from '../../controllers/EventHandler';
 import { DetectionType } from '../../repositories/types';
 
@@ -89,6 +96,8 @@ describe('EventHandler (unit)', () => {
     return {
       author: { bot: false, id: 'user-1' },
       content: 'free nitro',
+      system: false,
+      type: MessageType.Default,
       guild: { id: 'guild-1' },
       member,
       channel: { isThread: jest.fn().mockReturnValue(false) },
@@ -232,6 +241,21 @@ describe('EventHandler (unit)', () => {
         username: 'test-user',
       })
     );
+  });
+
+  it('skips automatic detection for Discord system messages', async () => {
+    const detectionOrchestrator = {
+      detectMessage: jest.fn(),
+      detectNewJoin: jest.fn(),
+    };
+    const handler = buildHandler({ detectionOrchestrator });
+    const message = buildMessage(new PermissionsBitField()) as any;
+    message.system = true;
+    message.type = MessageType.UserJoin;
+
+    await (handler as any).handleMessage(message);
+
+    expect(detectionOrchestrator.detectMessage).not.toHaveBeenCalled();
   });
 
   it('records report intake thread messages before automatic detection', async () => {

--- a/src/__tests__/unit/EventHandler.unit.test.ts
+++ b/src/__tests__/unit/EventHandler.unit.test.ts
@@ -258,6 +258,34 @@ describe('EventHandler (unit)', () => {
     expect(detectionOrchestrator.detectMessage).not.toHaveBeenCalled();
   });
 
+  it('runs automatic message detection for Discord reply messages', async () => {
+    const detectionOrchestrator = {
+      detectMessage: jest.fn().mockResolvedValue({
+        label: 'OK',
+        confidence: 0,
+        reasons: [],
+        triggerSource: DetectionType.SUSPICIOUS_CONTENT,
+        triggerContent: 'free nitro',
+      }),
+      detectNewJoin: jest.fn(),
+    };
+    const handler = buildHandler({ detectionOrchestrator });
+    const message = buildMessage(new PermissionsBitField()) as any;
+    message.type = MessageType.Reply;
+
+    await (handler as any).handleMessage(message);
+
+    expect(detectionOrchestrator.detectMessage).toHaveBeenCalledWith(
+      'guild-1',
+      'user-1',
+      'free nitro',
+      expect.objectContaining({
+        serverId: 'guild-1',
+        userId: 'user-1',
+      })
+    );
+  });
+
   it('records report intake thread messages before automatic detection', async () => {
     const detectionOrchestrator = {
       detectMessage: jest.fn(),

--- a/src/__tests__/unit/InteractionHandler.unit.test.ts
+++ b/src/__tests__/unit/InteractionHandler.unit.test.ts
@@ -122,6 +122,15 @@ describe('InteractionHandler (unit)', () => {
         restrictionAttempted: false,
         restricted: false,
       }),
+      repairActiveCase: jest.fn().mockResolvedValue({
+        repaired: true,
+        message: 'Repaired active verification case for test-user#0001.',
+        threadId: 'thread-1',
+        threadCreated: false,
+        userAdded: true,
+        promptSent: true,
+        promptAlreadyPresent: false,
+      }),
       intakeRoleMembers: jest.fn().mockResolvedValue({} as any),
       handleUserReport: jest.fn().mockResolvedValue(true),
       handleMessageReport: jest.fn().mockResolvedValue(true),
@@ -184,6 +193,13 @@ describe('InteractionHandler (unit)', () => {
       activateReportIntakeThread: jest.fn().mockResolvedValue(true),
       resolveVerificationThread: jest.fn(),
       reopenVerificationThread: jest.fn(),
+      repairVerificationThread: jest.fn().mockResolvedValue({
+        threadId: 'thread-1',
+        threadCreated: false,
+        userAdded: true,
+        promptSent: true,
+        promptAlreadyPresent: false,
+      }),
     };
     adminActionRepository = {
       findByUserAndServer: jest.fn(),

--- a/src/__tests__/unit/RestrictedRoleLockdownService.unit.test.ts
+++ b/src/__tests__/unit/RestrictedRoleLockdownService.unit.test.ts
@@ -14,14 +14,20 @@ describe('RestrictedRoleLockdownService (unit)', () => {
   ];
 
   const createOverwrite = (
-    options: { allow?: readonly bigint[]; deny?: readonly bigint[] } = {}
+    options: {
+      id?: string;
+      type?: OverwriteType;
+      allow?: readonly bigint[];
+      deny?: readonly bigint[];
+    } = {}
   ) => {
     const allowFlags = new Set(options.allow ?? []);
     const denyFlags = new Set(options.deny ?? []);
     return {
-      id: restrictedRoleId,
-      allow: { has: jest.fn((permission: bigint) => allowFlags.has(permission)) },
-      deny: { has: jest.fn((permission: bigint) => denyFlags.has(permission)) },
+      id: options.id ?? restrictedRoleId,
+      type: options.type ?? OverwriteType.Role,
+      allow: { has: jest.fn((permission: bigint) => allowFlags.has(permission)), bitfield: 0n },
+      deny: { has: jest.fn((permission: bigint) => denyFlags.has(permission)), bitfield: 0n },
       setDeny(permission: bigint): void {
         denyFlags.add(permission);
       },
@@ -42,7 +48,7 @@ describe('RestrictedRoleLockdownService (unit)', () => {
       [restrictedRoleId, restrictedOverwrite],
       ...(options.extraOverwrites ?? []).map((overwrite) => [overwrite.id, overwrite] as const),
     ]);
-    return {
+    const channel = {
       id: options.id,
       name: options.name,
       type: options.type,
@@ -58,9 +64,15 @@ describe('RestrictedRoleLockdownService (unit)', () => {
           cache.set(targetRoleId, overwrite);
           return Promise.resolve(undefined);
         }),
+        set: jest.fn().mockImplementation(() => {
+          channel.permissionsLocked = false;
+          return Promise.resolve(undefined);
+        }),
       },
       permissionsFor: jest.fn().mockReturnValue({ has: jest.fn().mockReturnValue(true) }),
     };
+
+    return channel;
   };
 
   const createGuild = (channels: readonly ReturnType<typeof createChannel>[]) => {
@@ -89,6 +101,7 @@ describe('RestrictedRoleLockdownService (unit)', () => {
       },
       roles: {
         everyone: { id: 'everyone-role' },
+        cache: new Map(),
         fetch: jest.fn().mockResolvedValue(restrictedRole),
       },
       channels: {
@@ -174,6 +187,46 @@ describe('RestrictedRoleLockdownService (unit)', () => {
     );
     expect(category.permissionOverwrites.edit).not.toHaveBeenCalled();
     expect(configService.updateServerSettings).not.toHaveBeenCalled();
+  });
+
+  it('unsyncs allowed channels only when explicitly confirmed', async () => {
+    const category = createChannel({
+      id: 'category-1',
+      name: 'public',
+      type: ChannelType.GuildCategory,
+    });
+    const verificationChannel = createChannel({
+      id: 'verification-channel-1',
+      name: 'verification',
+      type: ChannelType.GuildText,
+      parentId: 'category-1',
+      permissionsLocked: true,
+    });
+    const guild = createGuild([category, verificationChannel]);
+    const configService = createConfigService();
+    const service = new RestrictedRoleLockdownService(configService as any);
+
+    const report = await service.applyGuild(guild, 'admin-1', { unsyncAllowedChannels: true });
+
+    expect(verificationChannel.permissionOverwrites.set).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        expect.objectContaining({ id: restrictedRoleId, ViewChannel: true, SendMessages: true }),
+      ]),
+      expect.stringContaining('admin-1')
+    );
+    expect(category.permissionOverwrites.edit).toHaveBeenCalledWith(
+      restrictedRoleId,
+      expect.objectContaining({ ViewChannel: false, SendMessages: false }),
+      expect.any(Object)
+    );
+    expect(report.errorCount).toBe(0);
+    expect(report.unsyncedAllowedChannels.map((action) => action.channelId)).toEqual([
+      'verification-channel-1',
+    ]);
+    expect(report.appliedActions.map((action) => action.channelId)).toEqual(['category-1']);
+    expect(configService.updateServerSettings).toHaveBeenCalledWith('guild-1', {
+      restricted_lockdown_enabled: true,
+    });
   });
 
   it('applies missing lockdown denies and marks lockdown enabled', async () => {
@@ -271,6 +324,56 @@ describe('RestrictedRoleLockdownService (unit)', () => {
       expect.arrayContaining([
         expect.stringContaining(
           'explicit View Channel allow for <@user-1>. That user may still see it'
+        ),
+      ])
+    );
+  });
+
+  it('suppresses noisy allow warnings for everyone and managed bot roles', async () => {
+    const everyoneOverwrite = createOverwrite({
+      id: 'everyone-role',
+      type: OverwriteType.Role,
+      allow: [PermissionFlagsBits.ViewChannel],
+    });
+    const managedBotOverwrite = createOverwrite({
+      id: 'bot-role-1',
+      type: OverwriteType.Role,
+      allow: [PermissionFlagsBits.ViewChannel],
+    });
+    const humanRoleOverwrite = createOverwrite({
+      id: 'human-role-1',
+      type: OverwriteType.Role,
+      allow: [PermissionFlagsBits.ViewChannel],
+    });
+    const category = createChannel({
+      id: 'category-1',
+      name: 'public',
+      type: ChannelType.GuildCategory,
+      extraOverwrites: [everyoneOverwrite, managedBotOverwrite, humanRoleOverwrite],
+    });
+    const verificationChannel = createChannel({
+      id: 'verification-channel-1',
+      name: 'verification',
+      type: ChannelType.GuildText,
+    });
+    const guild = createGuild([category, verificationChannel]);
+    guild.roles.cache = new Map([
+      ['bot-role-1', { id: 'bot-role-1', managed: true }],
+      ['human-role-1', { id: 'human-role-1', managed: false }],
+    ]);
+    const service = new RestrictedRoleLockdownService(createConfigService() as any);
+
+    const report = await service.auditGuild(guild);
+
+    const messages = report.issues.map((issue) => issue.message);
+    expect(messages).not.toEqual(
+      expect.arrayContaining([expect.stringContaining('@&everyone-role')])
+    );
+    expect(messages).not.toEqual(expect.arrayContaining([expect.stringContaining('@&bot-role-1')]));
+    expect(messages).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining(
+          'explicit View Channel allow for <@&human-role-1>. Users with that role may still see it'
         ),
       ])
     );

--- a/src/__tests__/unit/SecurityActionService.unit.test.ts
+++ b/src/__tests__/unit/SecurityActionService.unit.test.ts
@@ -528,6 +528,51 @@ describe('SecurityActionService (unit)', () => {
     });
   });
 
+  it('reports thread repair success when notification button update fails', async () => {
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+    const guildId = 'guild-case-repair-notification-fails';
+    const userId = 'user-case-repair-notification-fails';
+    const member = buildMember(guildId, userId);
+    const verificationEvent = await verificationEventRepository.createFromDetection(
+      null,
+      guildId,
+      userId,
+      VerificationStatus.PENDING
+    );
+    verificationEvent.thread_id = 'thread-1';
+    await verificationEventRepository.update(verificationEvent.id, verificationEvent);
+    notificationManager.updateNotificationButtons.mockRejectedValueOnce(
+      new Error('Missing Message')
+    );
+
+    try {
+      const result = await buildService().repairActiveCase(member);
+
+      expect(threadManager.repairVerificationThread).toHaveBeenCalledWith(
+        member,
+        expect.objectContaining({ id: verificationEvent.id, thread_id: 'thread-1' })
+      );
+      expect(notificationManager.updateNotificationButtons).toHaveBeenCalledWith(
+        expect.objectContaining({ id: verificationEvent.id }),
+        VerificationStatus.PENDING
+      );
+      expect(result).toMatchObject({
+        repaired: true,
+        verificationEventId: verificationEvent.id,
+        threadId: 'thread-1',
+        userAdded: true,
+        promptSent: true,
+      });
+      expect(result.message).toContain('Notification buttons could not be updated automatically');
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Failed to update notification buttons for repaired case'),
+        expect.any(Error)
+      );
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+
   it('does not repair moderator-only report review threads as user-facing threads', async () => {
     const guildId = 'guild-case-repair-report-review';
     const userId = 'user-case-repair-report-review';

--- a/src/__tests__/unit/SecurityActionService.unit.test.ts
+++ b/src/__tests__/unit/SecurityActionService.unit.test.ts
@@ -86,6 +86,13 @@ describe('SecurityActionService (unit)', () => {
       activateReportIntakeThread: jest.fn().mockResolvedValue(true),
       resolveVerificationThread: jest.fn().mockResolvedValue(true),
       reopenVerificationThread: jest.fn().mockResolvedValue(true),
+      repairVerificationThread: jest.fn().mockResolvedValue({
+        threadId: 'thread-1',
+        threadCreated: false,
+        userAdded: true,
+        promptSent: true,
+        promptAlreadyPresent: false,
+      }),
     };
     userModerationService = {
       restrictUser: jest.fn().mockImplementation(async (member: GuildMember) => {
@@ -482,6 +489,66 @@ describe('SecurityActionService (unit)', () => {
     expect(userModerationService.restrictUser).toHaveBeenCalledWith(member);
     expect(threadManager.createVerificationThread).not.toHaveBeenCalled();
     expect(notificationManager.upsertSuspiciousUserNotification).toHaveBeenCalledTimes(1);
+  });
+
+  it('repairs an active restricted case thread and reapplies the restricted role', async () => {
+    const guildId = 'guild-case-repair';
+    const userId = 'user-case-repair';
+    const member = buildMember(guildId, userId);
+    const verificationEvent = await verificationEventRepository.createFromDetection(
+      null,
+      guildId,
+      userId,
+      VerificationStatus.PENDING
+    );
+    verificationEvent.thread_id = 'thread-1';
+    await verificationEventRepository.update(verificationEvent.id, verificationEvent);
+    await serverMemberRepository.upsertMember(guildId, userId, {
+      is_restricted: true,
+      verification_status: VerificationStatus.PENDING,
+    });
+
+    const result = await buildService().repairActiveCase(member);
+
+    expect(userModerationService.restrictUser).toHaveBeenCalledWith(member);
+    expect(threadManager.repairVerificationThread).toHaveBeenCalledWith(
+      member,
+      expect.objectContaining({ id: verificationEvent.id, thread_id: 'thread-1' })
+    );
+    expect(notificationManager.updateNotificationButtons).toHaveBeenCalledWith(
+      expect.objectContaining({ id: verificationEvent.id }),
+      VerificationStatus.PENDING
+    );
+    expect(result).toMatchObject({
+      repaired: true,
+      verificationEventId: verificationEvent.id,
+      threadId: 'thread-1',
+      userAdded: true,
+      promptSent: true,
+    });
+  });
+
+  it('does not repair moderator-only report review threads as user-facing threads', async () => {
+    const guildId = 'guild-case-repair-report-review';
+    const userId = 'user-case-repair-report-review';
+    const member = buildMember(guildId, userId);
+    const verificationEvent = await verificationEventRepository.createFromDetection(
+      null,
+      guildId,
+      userId,
+      VerificationStatus.PENDING
+    );
+    verificationEvent.thread_id = 'thread-1';
+    verificationEvent.metadata = {
+      [VERIFICATION_THREAD_TYPE_METADATA_KEY]: REPORT_REVIEW_THREAD_TYPE,
+    };
+    await verificationEventRepository.update(verificationEvent.id, verificationEvent);
+
+    const result = await buildService().repairActiveCase(member);
+
+    expect(threadManager.repairVerificationThread).not.toHaveBeenCalled();
+    expect(result.repaired).toBe(false);
+    expect(result.message).toContain('moderator-only report review thread');
   });
 
   it('normalizes blank admin case reasons', async () => {

--- a/src/__tests__/unit/ThreadManager.unit.test.ts
+++ b/src/__tests__/unit/ThreadManager.unit.test.ts
@@ -291,6 +291,39 @@ describe('ThreadManager (unit)', () => {
     expect(result.promptSent).toBe(false);
   });
 
+  it('sends a missing prompt when repair finds unrelated bot messages', async () => {
+    (thread.messages.fetch as jest.Mock).mockResolvedValueOnce(
+      new Map([
+        [
+          'message-1',
+          {
+            author: { id: 'bot-1', bot: true },
+            content: 'Case responder routing updated.',
+          },
+        ],
+      ])
+    );
+    const manager = new ThreadManager(
+      { user: { id: 'bot-1' } } as any,
+      configService,
+      verificationEventRepository,
+      userRepository,
+      serverRepository,
+      serverMemberRepository
+    );
+    const member = buildMember('guild-1', 'user-1');
+    const event = buildVerificationEvent({ thread_id: 'thread-1' });
+
+    const result = await manager.repairVerificationThread(member, event);
+
+    expect(thread.members.add).toHaveBeenCalledWith(member.id);
+    expect(thread.send).toHaveBeenCalledWith(
+      expect.objectContaining({ content: expect.stringContaining(`<@${member.id}>`) })
+    );
+    expect(result.promptAlreadyPresent).toBe(false);
+    expect(result.promptSent).toBe(true);
+  });
+
   it('uses custom verification prompt template when configured', async () => {
     (configService.getServerConfig as jest.Mock).mockResolvedValue({
       settings: {

--- a/src/__tests__/unit/ThreadManager.unit.test.ts
+++ b/src/__tests__/unit/ThreadManager.unit.test.ts
@@ -76,6 +76,9 @@ describe('ThreadManager (unit)', () => {
       setArchived: jest.fn().mockResolvedValue(undefined),
       setLocked: jest.fn().mockResolvedValue(undefined),
       setInvitable: jest.fn().mockResolvedValue(undefined),
+      messages: {
+        fetch: jest.fn().mockResolvedValue(new Map()),
+      },
       isThread: jest.fn().mockReturnValue(true),
     } as unknown as jest.Mocked<ThreadChannel>;
 
@@ -145,6 +148,45 @@ describe('ThreadManager (unit)', () => {
     });
   });
 
+  it('retries adding the flagged user before sending the verification prompt', async () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+    (thread.members.add as jest.Mock)
+      .mockRejectedValueOnce(new Error('Missing Access'))
+      .mockResolvedValueOnce(undefined);
+    const manager = new ThreadManager(
+      {} as any,
+      configService,
+      verificationEventRepository,
+      userRepository,
+      serverRepository,
+      serverMemberRepository
+    );
+    (manager as any).wait = jest.fn().mockResolvedValue(undefined);
+    const member = buildMember('guild-1', 'user-1');
+    const fetch = jest.fn().mockResolvedValue(member);
+    (member as any).fetch = fetch;
+    const event = await verificationEventRepository.createFromDetection(
+      null,
+      'guild-1',
+      'user-1',
+      VerificationStatus.PENDING
+    );
+
+    try {
+      const createdThread = await manager.createVerificationThread(member, event);
+
+      expect(createdThread?.id).toBe('thread-1');
+      expect(thread.members.add).toHaveBeenCalledTimes(2);
+      expect((manager as any).wait).toHaveBeenCalledWith(750);
+      expect(fetch).toHaveBeenCalledWith(true);
+      expect(thread.send).toHaveBeenCalledWith(
+        expect.objectContaining({ content: expect.stringContaining(`<@${member.id}>`) })
+      );
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
   it('keeps a created verification thread linked when prompt send fails', async () => {
     const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
     thread.send.mockRejectedValueOnce(new Error('Missing Send Messages permission'));
@@ -165,10 +207,11 @@ describe('ThreadManager (unit)', () => {
     );
 
     try {
-      const createdThread = await manager.createVerificationThread(member, event);
+      await expect(manager.createVerificationThread(member, event)).rejects.toThrow(
+        'Failed to send initial verification prompt'
+      );
       const storedEvent = await verificationEventRepository.findById(event.id);
 
-      expect(createdThread).toBeNull();
       expect(channel.threads.create).toHaveBeenCalled();
       expect(storedEvent?.thread_id).toBe('thread-1');
       expect(storedEvent?.metadata).toMatchObject({
@@ -177,6 +220,75 @@ describe('ThreadManager (unit)', () => {
     } finally {
       errorSpy.mockRestore();
     }
+  });
+
+  it('repairs an existing verification thread by adding the user and sending a missing prompt', async () => {
+    const manager = new ThreadManager(
+      { user: { id: 'bot-1' } } as any,
+      configService,
+      verificationEventRepository,
+      userRepository,
+      serverRepository,
+      serverMemberRepository
+    );
+    const member = buildMember('guild-1', 'user-1');
+    const event = buildVerificationEvent({ thread_id: 'thread-1' });
+
+    const result = await manager.repairVerificationThread(member, event);
+
+    expect(channel.threads.fetch).toHaveBeenCalledWith('thread-1');
+    expect(thread.members.add).toHaveBeenCalledWith(member.id);
+    expect(thread.messages.fetch).toHaveBeenCalledWith({ limit: 25 });
+    expect(thread.send).toHaveBeenCalledWith({
+      content: renderVerificationPromptTemplate(DEFAULT_VERIFICATION_PROMPT_TEMPLATE, {
+        userMention: `<@${member.id}>`,
+        serverName: member.guild.name,
+      }),
+      allowedMentions: {
+        parse: [],
+        users: [member.id],
+        roles: [],
+        repliedUser: false,
+      },
+    });
+    expect(result).toEqual({
+      threadId: 'thread-1',
+      threadCreated: false,
+      userAdded: true,
+      promptSent: true,
+      promptAlreadyPresent: false,
+    });
+  });
+
+  it('does not duplicate the verification prompt during repair', async () => {
+    (thread.messages.fetch as jest.Mock).mockResolvedValueOnce(
+      new Map([
+        [
+          'message-1',
+          {
+            author: { id: 'bot-1', bot: true },
+            content: '<@user-1> already asked for verification.',
+          },
+        ],
+      ])
+    );
+    const manager = new ThreadManager(
+      { user: { id: 'bot-1' } } as any,
+      configService,
+      verificationEventRepository,
+      userRepository,
+      serverRepository,
+      serverMemberRepository
+    );
+    const member = buildMember('guild-1', 'user-1');
+    const event = buildVerificationEvent({ thread_id: 'thread-1' });
+
+    const result = await manager.repairVerificationThread(member, event);
+
+    expect(thread.members.add).toHaveBeenCalledWith(member.id);
+    expect(thread.send).not.toHaveBeenCalled();
+    expect(result.promptAlreadyPresent).toBe(true);
+    expect(result.promptSent).toBe(false);
   });
 
   it('uses custom verification prompt template when configured', async () => {
@@ -288,16 +400,17 @@ describe('ThreadManager (unit)', () => {
     );
 
     try {
-      const createdThread = await manager.createReportReviewThread(member, event, {
-        label: 'SUSPICIOUS',
-        confidence: 1.0,
-        reasons: ['Reported by user reporter-1. Reason: suspicious DM'],
-        triggerSource: DetectionType.USER_REPORT,
-        triggerContent: 'suspicious DM',
-      });
+      await expect(
+        manager.createReportReviewThread(member, event, {
+          label: 'SUSPICIOUS',
+          confidence: 1.0,
+          reasons: ['Reported by user reporter-1. Reason: suspicious DM'],
+          triggerSource: DetectionType.USER_REPORT,
+          triggerContent: 'suspicious DM',
+        })
+      ).rejects.toThrow('Failed to send report review thread prompt');
       const storedEvent = await verificationEventRepository.findById(event.id);
 
-      expect(createdThread).toBeNull();
       expect(channel.threads.create).toHaveBeenCalled();
       expect(storedEvent?.thread_id).toBe('thread-1');
       expect(storedEvent?.metadata).toMatchObject({

--- a/src/__tests__/unit/ThreadManager.unit.test.ts
+++ b/src/__tests__/unit/ThreadManager.unit.test.ts
@@ -238,7 +238,7 @@ describe('ThreadManager (unit)', () => {
 
     expect(channel.threads.fetch).toHaveBeenCalledWith('thread-1');
     expect(thread.members.add).toHaveBeenCalledWith(member.id);
-    expect(thread.messages.fetch).toHaveBeenCalledWith({ limit: 25 });
+    expect(thread.messages.fetch).toHaveBeenCalledWith({ limit: 100 });
     expect(thread.send).toHaveBeenCalledWith({
       content: renderVerificationPromptTemplate(DEFAULT_VERIFICATION_PROMPT_TEMPLATE, {
         userMention: `<@${member.id}>`,

--- a/src/__tests__/unit/UserModerationService.unit.test.ts
+++ b/src/__tests__/unit/UserModerationService.unit.test.ts
@@ -76,6 +76,13 @@ describe('UserModerationService (unit)', () => {
       activateReportIntakeThread: jest.fn().mockResolvedValue(true),
       resolveVerificationThread: jest.fn().mockResolvedValue(true),
       reopenVerificationThread: jest.fn().mockResolvedValue(true),
+      repairVerificationThread: jest.fn().mockResolvedValue({
+        threadId: 'thread-1',
+        threadCreated: false,
+        userAdded: true,
+        promptSent: true,
+        promptAlreadyPresent: false,
+      }),
     };
   });
 

--- a/src/controllers/CommandHandler.ts
+++ b/src/controllers/CommandHandler.ts
@@ -364,6 +364,14 @@ export class CommandHandler implements ICommandHandler {
               subcommand
                 .setName('apply')
                 .setDescription('Apply missing restricted-role lockdown denies')
+                .addBooleanOption((option) =>
+                  option
+                    .setName('unsync-allowed')
+                    .setDescription(
+                      'Unsync allowed channels that are synced under denied categories'
+                    )
+                    .setRequired(false)
+                )
             )
             .addSubcommand((subcommand) =>
               subcommand
@@ -1014,6 +1022,17 @@ export class CommandHandler implements ICommandHandler {
                 .setDescription('Why moderators should review this user')
                 .setRequired(false)
                 .setMaxLength(500)
+            )
+        )
+        .addSubcommand((subcommand) =>
+          subcommand
+            .setName('repair')
+            .setDescription('Repair an active user-facing verification case thread')
+            .addUserOption((option) =>
+              option
+                .setName('user')
+                .setDescription('The user whose active case to repair')
+                .setRequired(true)
             )
         )
         .addSubcommand((subcommand) =>
@@ -1929,7 +1948,9 @@ export class CommandHandler implements ICommandHandler {
     try {
       const report =
         subcommand === 'apply'
-          ? await this.restrictedRoleLockdownService.applyGuild(guild, interaction.user.id)
+          ? await this.restrictedRoleLockdownService.applyGuild(guild, interaction.user.id, {
+              unsyncAllowedChannels: interaction.options.getBoolean('unsync-allowed') ?? false,
+            })
           : await this.restrictedRoleLockdownService.auditGuild(guild);
 
       await interaction.editReply({
@@ -2015,18 +2036,48 @@ export class CommandHandler implements ICommandHandler {
       `Mode: \`${report.enabled ? 'enabled' : 'disabled'}\``,
       `Planned deny writes: \`${report.plannedActions.length}\``,
       `Applied deny writes: \`${report.appliedActions.length}\``,
+      `Unsynced allowed channels: \`${report.unsyncedAllowedChannels.length}\``,
       `Allowed channels: ${this.formatChannelIdList(report.allowedChannelIds)}`,
       `Allowed categories: ${this.formatChannelIdList(report.allowedCategoryIds)}`,
       `Auto-allowed channels: ${this.formatChannelIdList(report.autoAllowedChannelIds)}`,
     ];
 
+    if (report.syncedAllowedChannels.length > 0) {
+      lines.push(
+        '',
+        'Synced allowed-channel blockers:',
+        ...report.syncedAllowedChannels
+          .slice(0, 8)
+          .map((action) => `- #${action.channelName} (${action.channelId})`)
+      );
+      if (report.syncedAllowedChannels.length > 8) {
+        lines.push(`- ... +${report.syncedAllowedChannels.length - 8} more blocker(s)`);
+      }
+    }
+
+    if (report.unsyncedAllowedChannels.length > 0) {
+      lines.push(
+        '',
+        'Allowed channels unsynced before apply:',
+        ...report.unsyncedAllowedChannels
+          .slice(0, 8)
+          .map((action) => `- #${action.channelName} (${action.channelId})`)
+      );
+      if (report.unsyncedAllowedChannels.length > 8) {
+        lines.push(`- ... +${report.unsyncedAllowedChannels.length - 8} more unsynced channel(s)`);
+      }
+    }
+
     if (report.issues.length > 0) {
+      const sortedIssues = [...report.issues].sort((left, right) =>
+        left.severity === right.severity ? 0 : left.severity === 'error' ? -1 : 1
+      );
       lines.push('', 'Issues:');
-      for (const issue of report.issues.slice(0, 12)) {
+      for (const issue of sortedIssues.slice(0, 12)) {
         lines.push(`- [${issue.severity.toUpperCase()}] ${issue.message}`);
       }
-      if (report.issues.length > 12) {
-        lines.push(`- ... +${report.issues.length - 12} more issue(s)`);
+      if (sortedIssues.length > 12) {
+        lines.push(`- ... +${sortedIssues.length - 12} more issue(s)`);
       }
     }
 
@@ -3990,6 +4041,11 @@ export class CommandHandler implements ICommandHandler {
       return;
     }
 
+    if (subcommand === 'repair') {
+      await this.handleCaseRepairCommand(interaction, guild);
+      return;
+    }
+
     if (subcommand === 'intake-role') {
       await this.handleCaseRoleIntakeCommand(interaction, guild);
       return;
@@ -4045,6 +4101,50 @@ export class CommandHandler implements ICommandHandler {
       console.error('Failed to open admin case:', error);
       await interaction.editReply({
         content: `Failed to open a case for ${targetUser.tag}. Please try again later.`,
+      });
+    }
+  }
+
+  private async handleCaseRepairCommand(
+    interaction: ChatInputCommandInteraction,
+    guild: Guild
+  ): Promise<void> {
+    const targetUser = interaction.options.getUser('user', true);
+    const targetMember = await guild.members.fetch(targetUser.id).catch(() => null);
+    if (!targetMember) {
+      await interaction.reply({
+        content: `Could not find user ${targetUser.tag} in this server.`,
+        flags: MessageFlags.Ephemeral,
+      });
+      return;
+    }
+
+    await interaction.deferReply({ flags: MessageFlags.Ephemeral });
+
+    try {
+      const result = await this.securityActionService.repairActiveCase(targetMember);
+      const lines = [result.message];
+
+      if (result.threadId) {
+        lines.push(`Thread: https://discord.com/channels/${guild.id}/${result.threadId}`);
+      }
+      lines.push(
+        `Thread created: \`${result.threadCreated ? 'yes' : 'no'}\``,
+        `User added: \`${result.userAdded ? 'yes' : 'no'}\``,
+        `Prompt sent: \`${result.promptSent ? 'yes' : 'no'}\``,
+        `Prompt already present: \`${result.promptAlreadyPresent ? 'yes' : 'no'}\``
+      );
+
+      await interaction.editReply({
+        content: lines.join('\n'),
+        allowedMentions: { parse: [] },
+      });
+    } catch (error) {
+      console.error('Failed to repair active case:', error);
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      await interaction.editReply({
+        content: `Failed to repair the active case for ${targetUser.tag}: ${message}`,
+        allowedMentions: { parse: [] },
       });
     }
   }

--- a/src/controllers/EventHandler.ts
+++ b/src/controllers/EventHandler.ts
@@ -7,7 +7,6 @@ import {
   Guild,
   Events,
   MessageFlags,
-  MessageType,
   PermissionFlagsBits,
 } from 'discord.js';
 import * as dotenv from 'dotenv';
@@ -219,7 +218,7 @@ export class EventHandler implements IEventHandler {
       return;
     }
 
-    if (message.system || message.type !== MessageType.Default) {
+    if (message.system) {
       return;
     }
 

--- a/src/controllers/EventHandler.ts
+++ b/src/controllers/EventHandler.ts
@@ -7,6 +7,7 @@ import {
   Guild,
   Events,
   MessageFlags,
+  MessageType,
   PermissionFlagsBits,
 } from 'discord.js';
 import * as dotenv from 'dotenv';
@@ -215,6 +216,10 @@ export class EventHandler implements IEventHandler {
     // Handle debug/test commands
     if (message.content.startsWith('!test')) {
       await this.commandHandler.handleTestCommands(message);
+      return;
+    }
+
+    if (message.system || message.type !== MessageType.Default) {
       return;
     }
 

--- a/src/services/DetectionOrchestrator.ts
+++ b/src/services/DetectionOrchestrator.ts
@@ -269,7 +269,7 @@ export class DetectionOrchestrator implements IDetectionOrchestrator {
 
         result = {
           label: suspicionScore >= 0.5 ? 'SUSPICIOUS' : 'OK',
-          confidence: Math.abs(suspicionScore - 0.5) * 2,
+          confidence: this.toConfidence(suspicionScore),
           reasons: reasons,
           triggerSource: DetectionType.SUSPICIOUS_CONTENT,
           triggerContent: content,
@@ -279,7 +279,7 @@ export class DetectionOrchestrator implements IDetectionOrchestrator {
       } else {
         result = {
           label: suspicionScore >= 0.5 ? 'SUSPICIOUS' : 'OK',
-          confidence: Math.abs(suspicionScore - 0.5) * 2,
+          confidence: this.toConfidence(suspicionScore),
           reasons: reasons,
           triggerSource: DetectionType.SUSPICIOUS_CONTENT,
           triggerContent: content,
@@ -375,7 +375,7 @@ export class DetectionOrchestrator implements IDetectionOrchestrator {
       // Assign initial result to a variable
       const initialResult: DetectionResult = {
         label: suspicionScore >= 0.5 ? 'SUSPICIOUS' : 'OK',
-        confidence: Math.abs(suspicionScore - 0.5) * 2,
+        confidence: this.toConfidence(suspicionScore),
         reasons: reasons,
         triggerSource: DetectionType.NEW_ACCOUNT,
         triggerContent: 'Server Join',
@@ -429,6 +429,10 @@ export class DetectionOrchestrator implements IDetectionOrchestrator {
       (now.getTime() - accountCreatedAt.getTime()) / (1000 * 60 * 60 * 24)
     );
     return diffInDays <= this.NEW_ACCOUNT_THRESHOLD_DAYS;
+  }
+
+  private toConfidence(suspicionScore: number): number {
+    return Math.min(1, Math.max(0, Math.abs(suspicionScore - 0.5) * 2));
   }
 
   /**

--- a/src/services/RestrictedRoleLockdownService.ts
+++ b/src/services/RestrictedRoleLockdownService.ts
@@ -3,6 +3,7 @@ import {
   Guild,
   GuildMember,
   NonThreadGuildBasedChannel,
+  OverwriteResolvable,
   PermissionFlagsBits,
   PermissionOverwriteManager,
   PermissionOverwriteOptions,
@@ -38,6 +39,10 @@ export interface RestrictedLockdownApplyFailure extends RestrictedLockdownPlanne
   readonly message: string;
 }
 
+export interface RestrictedLockdownApplyOptions {
+  readonly unsyncAllowedChannels?: boolean;
+}
+
 export interface RestrictedLockdownReport {
   readonly guildId: string;
   readonly checkedAt: Date;
@@ -49,13 +54,19 @@ export interface RestrictedLockdownReport {
   readonly plannedActions: readonly RestrictedLockdownPlannedAction[];
   readonly appliedActions: readonly RestrictedLockdownPlannedAction[];
   readonly failedActions: readonly RestrictedLockdownApplyFailure[];
+  readonly syncedAllowedChannels: readonly RestrictedLockdownPlannedAction[];
+  readonly unsyncedAllowedChannels: readonly RestrictedLockdownPlannedAction[];
   readonly errorCount: number;
   readonly warningCount: number;
 }
 
 export interface IRestrictedRoleLockdownService {
   auditGuild(guild: Guild): Promise<RestrictedLockdownReport>;
-  applyGuild(guild: Guild, actorId: string): Promise<RestrictedLockdownReport>;
+  applyGuild(
+    guild: Guild,
+    actorId: string,
+    options?: RestrictedLockdownApplyOptions
+  ): Promise<RestrictedLockdownReport>;
 }
 
 interface LockdownPermission {
@@ -116,10 +127,50 @@ export class RestrictedRoleLockdownService implements IRestrictedRoleLockdownSer
     return this.buildReport(guild, false);
   }
 
-  public async applyGuild(guild: Guild, actorId: string): Promise<RestrictedLockdownReport> {
-    const report = await this.buildReport(guild, false);
+  public async applyGuild(
+    guild: Guild,
+    actorId: string,
+    options: RestrictedLockdownApplyOptions = {}
+  ): Promise<RestrictedLockdownReport> {
+    let report = await this.buildReport(guild, false);
+    let unsyncedAllowedChannels: RestrictedLockdownPlannedAction[] = [];
+
     if (report.errorCount > 0) {
-      return report;
+      const onlySyncedAllowedChannelErrors =
+        report.syncedAllowedChannels.length > 0 &&
+        report.errorCount === report.syncedAllowedChannels.length;
+      if (!options.unsyncAllowedChannels || !onlySyncedAllowedChannelErrors) {
+        return report;
+      }
+
+      const unsyncResult = await this.unsyncAllowedChannelsUnderDeniedCategories(
+        guild,
+        report.syncedAllowedChannels,
+        actorId
+      );
+      unsyncedAllowedChannels = unsyncResult.unsyncedActions;
+
+      if (unsyncResult.failedActions.length > 0) {
+        return this.toReport({
+          guildId: report.guildId,
+          checkedAt: new Date(),
+          enabled: report.enabled,
+          allowedChannelIds: report.allowedChannelIds,
+          allowedCategoryIds: report.allowedCategoryIds,
+          autoAllowedChannelIds: report.autoAllowedChannelIds,
+          issues: [...report.issues, ...this.applyFailuresToIssues(unsyncResult.failedActions)],
+          plannedActions: report.plannedActions,
+          appliedActions: [],
+          failedActions: unsyncResult.failedActions,
+          syncedAllowedChannels: report.syncedAllowedChannels,
+          unsyncedAllowedChannels,
+        });
+      }
+
+      report = await this.buildReport(guild, false);
+      if (report.errorCount > 0) {
+        return { ...report, unsyncedAllowedChannels };
+      }
     }
 
     if (report.plannedActions.length === 0) {
@@ -128,7 +179,7 @@ export class RestrictedRoleLockdownService implements IRestrictedRoleLockdownSer
           [RESTRICTED_LOCKDOWN_ENABLED_SETTING_KEY]: true,
         });
       }
-      return { ...report, enabled: true };
+      return { ...report, enabled: true, unsyncedAllowedChannels };
     }
 
     const serverConfig = await this.configService.getServerConfig(guild.id);
@@ -148,6 +199,8 @@ export class RestrictedRoleLockdownService implements IRestrictedRoleLockdownSer
         plannedActions: report.plannedActions,
         appliedActions: [],
         failedActions,
+        syncedAllowedChannels: report.syncedAllowedChannels,
+        unsyncedAllowedChannels,
       });
     }
 
@@ -198,6 +251,8 @@ export class RestrictedRoleLockdownService implements IRestrictedRoleLockdownSer
       plannedActions: refreshed.plannedActions,
       appliedActions,
       failedActions,
+      syncedAllowedChannels: refreshed.syncedAllowedChannels,
+      unsyncedAllowedChannels,
     });
   }
 
@@ -212,6 +267,7 @@ export class RestrictedRoleLockdownService implements IRestrictedRoleLockdownSer
     ]);
     const issues: RestrictedLockdownIssue[] = [];
     const plannedActions: RestrictedLockdownPlannedAction[] = [];
+    const syncedAllowedChannels: RestrictedLockdownPlannedAction[] = [];
     const botMember = await this.getBotMember(guild);
     const restrictedRole = await this.getRestrictedRole(guild, serverConfig.restricted_role_id);
 
@@ -232,6 +288,8 @@ export class RestrictedRoleLockdownService implements IRestrictedRoleLockdownSer
         plannedActions,
         appliedActions: [],
         failedActions: [],
+        syncedAllowedChannels,
+        unsyncedAllowedChannels: [],
       });
     }
 
@@ -250,7 +308,7 @@ export class RestrictedRoleLockdownService implements IRestrictedRoleLockdownSer
       }
 
       deniedCategoryIds.add(category.id);
-      this.checkConflictingRoleAllows(category, restrictedRole.id, issues);
+      this.checkConflictingRoleAllows(guild, botMember, category, restrictedRole.id, issues);
       if (!this.hasRestrictedLockdownDeny(category, restrictedRole.id)) {
         issues.push({
           severity: 'warning',
@@ -269,10 +327,11 @@ export class RestrictedRoleLockdownService implements IRestrictedRoleLockdownSer
       const parentId = channel.parentId ?? null;
       if (allowedChannelIds.has(channel.id)) {
         if (parentId && deniedCategoryIds.has(parentId) && channel.permissionsLocked === true) {
+          syncedAllowedChannels.push(this.toPlannedAction(channel, 'channel'));
           issues.push({
             severity: 'error',
             code: 'lockdown-allowed-channel-synced-under-denied-category',
-            message: `Allowed channel ${this.formatChannel(channel)} is synced under a denied category. Move it, allow the category, or manually unsync it before applying lockdown.`,
+            message: `Allowed channel ${this.formatChannel(channel)} is synced under a denied category. Move it, allow the category, or rerun apply with \`unsync-allowed:true\` to copy current parent permissions before applying lockdown.`,
           });
         }
         continue;
@@ -286,7 +345,7 @@ export class RestrictedRoleLockdownService implements IRestrictedRoleLockdownSer
         continue;
       }
 
-      this.checkConflictingRoleAllows(channel, restrictedRole.id, issues);
+      this.checkConflictingRoleAllows(guild, botMember, channel, restrictedRole.id, issues);
       if (!this.hasRestrictedLockdownDeny(channel, restrictedRole.id)) {
         issues.push({
           severity: 'warning',
@@ -308,6 +367,8 @@ export class RestrictedRoleLockdownService implements IRestrictedRoleLockdownSer
       plannedActions,
       appliedActions: [],
       failedActions: [],
+      syncedAllowedChannels,
+      unsyncedAllowedChannels: [],
     });
   }
 
@@ -441,6 +502,8 @@ export class RestrictedRoleLockdownService implements IRestrictedRoleLockdownSer
   }
 
   private checkConflictingRoleAllows(
+    guild: Guild,
+    botMember: GuildMember | null,
     channel: LockdownChannel,
     restrictedRoleId: string,
     issues: RestrictedLockdownIssue[]
@@ -454,6 +517,10 @@ export class RestrictedRoleLockdownService implements IRestrictedRoleLockdownSer
       }
 
       const isMemberOverwrite = overwrite.type === OverwriteType.Member;
+      if (!isMemberOverwrite && this.shouldSkipRoleAllowWarning(guild, botMember, overwrite.id)) {
+        continue;
+      }
+
       const mentionPrefix = isMemberOverwrite ? '@' : '@&';
       const affectedSubject = isMemberOverwrite ? 'That user' : 'Users with that role';
       issues.push({
@@ -462,6 +529,29 @@ export class RestrictedRoleLockdownService implements IRestrictedRoleLockdownSer
         message: `${this.formatChannel(channel)} has an explicit View Channel allow for <${mentionPrefix}${overwrite.id}>. ${affectedSubject} may still see it despite the restricted-role deny.`,
       });
     }
+  }
+
+  private shouldSkipRoleAllowWarning(
+    guild: Guild,
+    botMember: GuildMember | null,
+    roleId: string
+  ): boolean {
+    if (roleId === guild.roles.everyone.id) {
+      return true;
+    }
+
+    const botRoleCache = botMember
+      ? (botMember.roles as { cache?: { has(roleId: string): boolean } }).cache
+      : undefined;
+    if (botRoleCache?.has(roleId)) {
+      return true;
+    }
+
+    const role = (guild.roles as { cache?: { get(roleId: string): Role | undefined } }).cache?.get(
+      roleId
+    );
+    const botRoleId = (role as { tags?: { botId?: string | null } } | undefined)?.tags?.botId;
+    return role?.managed === true || typeof botRoleId === 'string';
   }
 
   private hasRestrictedLockdownDeny(channel: LockdownChannel, restrictedRoleId: string): boolean {
@@ -474,6 +564,92 @@ export class RestrictedRoleLockdownService implements IRestrictedRoleLockdownSer
     return [...fetchedChannels.values()].filter((channel): channel is LockdownChannel =>
       this.isLockdownChannel(channel)
     );
+  }
+
+  private async unsyncAllowedChannelsUnderDeniedCategories(
+    guild: Guild,
+    syncedAllowedChannels: readonly RestrictedLockdownPlannedAction[],
+    actorId: string
+  ): Promise<{
+    unsyncedActions: RestrictedLockdownPlannedAction[];
+    failedActions: RestrictedLockdownApplyFailure[];
+  }> {
+    const serverConfig = await this.configService.getServerConfig(guild.id);
+    const restrictedRole = await this.getRestrictedRole(guild, serverConfig.restricted_role_id);
+    if (!restrictedRole) {
+      return {
+        unsyncedActions: [],
+        failedActions: syncedAllowedChannels.map((action) => ({
+          ...action,
+          message: 'Restricted role is no longer configured.',
+        })),
+      };
+    }
+
+    const channels = await this.fetchLockdownChannels(guild);
+    const channelById = new Map(channels.map((channel) => [channel.id, channel]));
+    const unsyncedActions: RestrictedLockdownPlannedAction[] = [];
+    const failedActions: RestrictedLockdownApplyFailure[] = [];
+
+    for (const action of syncedAllowedChannels) {
+      const channel = channelById.get(action.channelId);
+      const parent = channel?.parentId ? channelById.get(channel.parentId) : undefined;
+      if (!channel || !parent || parent.type !== ChannelType.GuildCategory) {
+        failedActions.push({
+          ...action,
+          message: 'Allowed channel or parent category was not found.',
+        });
+        continue;
+      }
+
+      try {
+        await channel.permissionOverwrites.set(
+          this.buildUnsyncedAllowedChannelOverwrites(parent, restrictedRole.id),
+          `Drasil restricted-role lockdown unsynced allowed channel by ${actorId}`
+        );
+        unsyncedActions.push(action);
+      } catch (error) {
+        failedActions.push({
+          ...action,
+          message: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
+
+    return { unsyncedActions, failedActions };
+  }
+
+  private buildUnsyncedAllowedChannelOverwrites(
+    parent: LockdownChannel,
+    restrictedRoleId: string
+  ): OverwriteResolvable[] {
+    const copiedParentOverwrites: OverwriteResolvable[] = [
+      ...parent.permissionOverwrites.cache.values(),
+    ]
+      .filter((overwrite) => overwrite.id !== restrictedRoleId)
+      .map((overwrite) => ({
+        id: overwrite.id,
+        type: overwrite.type,
+        allow: overwrite.allow.bitfield,
+        deny: overwrite.deny.bitfield,
+      }));
+
+    const restrictedRoleOptions = LOCKDOWN_PERMISSIONS.reduce<PermissionOverwriteOptions>(
+      (options, permission) => {
+        options[permission.option] = true;
+        return options;
+      },
+      {}
+    );
+
+    return [
+      ...copiedParentOverwrites,
+      {
+        id: restrictedRoleId,
+        type: OverwriteType.Role,
+        ...restrictedRoleOptions,
+      },
+    ];
   }
 
   private isLockdownChannel(
@@ -546,6 +722,8 @@ export class RestrictedRoleLockdownService implements IRestrictedRoleLockdownSer
     readonly plannedActions: readonly RestrictedLockdownPlannedAction[];
     readonly appliedActions: readonly RestrictedLockdownPlannedAction[];
     readonly failedActions: readonly RestrictedLockdownApplyFailure[];
+    readonly syncedAllowedChannels: readonly RestrictedLockdownPlannedAction[];
+    readonly unsyncedAllowedChannels: readonly RestrictedLockdownPlannedAction[];
   }): RestrictedLockdownReport {
     return {
       ...input,

--- a/src/services/SecurityActionService.ts
+++ b/src/services/SecurityActionService.ts
@@ -1279,15 +1279,24 @@ export class SecurityActionService implements ISecurityActionService {
       };
     }
 
-    await this.notificationManager.updateNotificationButtons(
-      repairCase,
-      VerificationStatus.PENDING
-    );
+    let notificationUpdateMessage = '';
+    try {
+      await this.notificationManager.updateNotificationButtons(
+        repairCase,
+        VerificationStatus.PENDING
+      );
+    } catch (error) {
+      notificationUpdateMessage = ' Notification buttons could not be updated automatically.';
+      console.error(
+        `Failed to update notification buttons for repaired case ${repairCase.id}; continuing repair flow:`,
+        error
+      );
+    }
 
     return {
       ...threadRepair,
       repaired: true,
-      message: `Repaired active verification case for ${member.user.tag}.`,
+      message: `Repaired active verification case for ${member.user.tag}.${notificationUpdateMessage}`,
       verificationEventId: repairCase.id,
     };
   }

--- a/src/services/SecurityActionService.ts
+++ b/src/services/SecurityActionService.ts
@@ -26,6 +26,7 @@ import { IUserRepository } from '../repositories/UserRepository';
 import {
   IThreadManager,
   REPORT_REVIEW_THREAD_TYPE,
+  VerificationThreadRepairResult,
   VERIFICATION_THREAD_TYPE_METADATA_KEY,
 } from './ThreadManager';
 import { IUserModerationService } from './UserModerationService';
@@ -100,6 +101,8 @@ export interface ISecurityActionService {
     moderator: User,
     options: AdminCaseOptions
   ): Promise<AdminCaseResult>;
+
+  repairActiveCase(member: GuildMember): Promise<ActiveCaseRepairResult>;
 
   intakeRoleMembers(options: RoleIntakeOptions): Promise<RoleIntakeResult>;
 
@@ -194,6 +197,12 @@ export interface AdminCaseResult {
   opened: boolean;
   restrictionAttempted: boolean;
   restricted: boolean;
+}
+
+export interface ActiveCaseRepairResult extends VerificationThreadRepairResult {
+  repaired: boolean;
+  message: string;
+  verificationEventId?: string;
 }
 
 export interface RoleIntakeOptions {
@@ -1218,6 +1227,69 @@ export class SecurityActionService implements ISecurityActionService {
       console.error(`Failed to open admin case for ${member.user.tag}:`, error);
       throw error;
     }
+  }
+
+  public async repairActiveCase(member: GuildMember): Promise<ActiveCaseRepairResult> {
+    const activeCase = await this.verificationEventRepository.findActiveByUserAndServer(
+      member.id,
+      member.guild.id
+    );
+    if (!activeCase) {
+      return {
+        repaired: false,
+        message: `No active verification case found for ${member.user.tag}.`,
+        threadId: null,
+        threadCreated: false,
+        userAdded: false,
+        promptSent: false,
+        promptAlreadyPresent: false,
+      };
+    }
+
+    if (this.hasReportReviewThread(activeCase)) {
+      return {
+        repaired: false,
+        message:
+          'Active case uses a moderator-only report review thread; no user-facing verification thread repair was attempted.',
+        verificationEventId: activeCase.id,
+        threadId: activeCase.thread_id,
+        threadCreated: false,
+        userAdded: false,
+        promptSent: false,
+        promptAlreadyPresent: false,
+      };
+    }
+
+    let repairCase = activeCase;
+    const serverMember = await this.serverMemberRepository.findByServerAndUser(
+      member.guild.id,
+      member.id
+    );
+    if (serverMember?.is_restricted === true) {
+      repairCase = await this.tryRestrictUser(member, activeCase);
+    }
+
+    const threadRepair = await this.threadManager.repairVerificationThread(member, repairCase);
+    if (!threadRepair.threadId) {
+      return {
+        ...threadRepair,
+        repaired: false,
+        message: `Could not create or repair the verification thread for ${member.user.tag}.`,
+        verificationEventId: repairCase.id,
+      };
+    }
+
+    await this.notificationManager.updateNotificationButtons(
+      repairCase,
+      VerificationStatus.PENDING
+    );
+
+    return {
+      ...threadRepair,
+      repaired: true,
+      message: `Repaired active verification case for ${member.user.tag}.`,
+      verificationEventId: repairCase.id,
+    };
   }
 
   public async intakeRoleMembers(options: RoleIntakeOptions): Promise<RoleIntakeResult> {

--- a/src/services/ThreadManager.ts
+++ b/src/services/ThreadManager.ts
@@ -30,6 +30,15 @@ export const VERIFICATION_THREAD_TYPE = 'verification';
 export const REPORT_REVIEW_THREAD_TYPE = 'report_review';
 export const REPORT_INTAKE_THREAD_NAME_PREFIX = 'Report intake:';
 export const CASE_STAFF_ROUTING_METADATA_KEY = 'case_staff_routing';
+const FLAGGED_USER_THREAD_ADD_RETRY_DELAYS_MS = [750, 1500, 3000] as const;
+
+export interface VerificationThreadRepairResult {
+  threadId: string | null;
+  threadCreated: boolean;
+  userAdded: boolean;
+  promptSent: boolean;
+  promptAlreadyPresent: boolean;
+}
 
 /**
  * Interface for NotificationManager service
@@ -44,6 +53,11 @@ export interface IThreadManager {
     member: GuildMember,
     verificationEvent: VerificationEvent
   ): Promise<ThreadChannel | null>;
+
+  repairVerificationThread(
+    member: GuildMember,
+    verificationEvent: VerificationEvent
+  ): Promise<VerificationThreadRepairResult>;
 
   createReportReviewThread(
     member: GuildMember,
@@ -287,6 +301,140 @@ export class ThreadManager implements IThreadManager {
     };
   }
 
+  private buildThreadSetupError(stage: string, error: unknown): Error {
+    const message = error instanceof Error && error.message ? error.message : String(error);
+    return new Error(`Failed to ${stage}: ${message || 'Unknown error'}`);
+  }
+
+  private async wait(delayMs: number): Promise<void> {
+    await new Promise<void>((resolve) => setTimeout(resolve, delayMs));
+  }
+
+  private async refreshMember(member: GuildMember): Promise<void> {
+    const fetchMember = (member as { fetch?: (force?: boolean) => Promise<GuildMember> }).fetch;
+    if (!fetchMember) {
+      return;
+    }
+
+    await fetchMember.call(member, true).catch((error) => {
+      console.warn(`Failed to refresh member ${member.id} before thread add retry:`, error);
+    });
+  }
+
+  private async addFlaggedUserToVerificationThread(
+    member: GuildMember,
+    thread: ThreadChannel
+  ): Promise<void> {
+    let lastError: unknown;
+
+    try {
+      await thread.members.add(member.id);
+      return;
+    } catch (error) {
+      lastError = error;
+    }
+
+    for (const retryDelay of FLAGGED_USER_THREAD_ADD_RETRY_DELAYS_MS) {
+      console.warn(
+        `Failed to add ${member.id} to verification thread ${thread.id}; retrying in ${retryDelay}ms:`,
+        lastError
+      );
+      await this.wait(retryDelay);
+      await this.refreshMember(member);
+
+      try {
+        await thread.members.add(member.id);
+        return;
+      } catch (error) {
+        lastError = error;
+      }
+    }
+
+    throw lastError;
+  }
+
+  private async fetchStoredThread(
+    verificationEvent: VerificationEvent
+  ): Promise<ThreadChannel | null> {
+    if (!verificationEvent.thread_id) {
+      return null;
+    }
+
+    const parentChannels: TextChannel[] = [];
+    const verificationChannel = await this.configService.getVerificationChannel(
+      verificationEvent.server_id
+    );
+    if (verificationChannel) {
+      parentChannels.push(verificationChannel);
+    }
+
+    const adminChannel = await this.configService.getAdminChannel(verificationEvent.server_id);
+    if (adminChannel && !parentChannels.some((channel) => channel.id === adminChannel.id)) {
+      parentChannels.push(adminChannel);
+    }
+
+    for (const parentChannel of parentChannels) {
+      const thread = await parentChannel.threads
+        .fetch(verificationEvent.thread_id)
+        .catch(() => null);
+      if (thread?.isThread()) {
+        return thread;
+      }
+    }
+
+    const fetchChannel = (
+      this.client.channels as { fetch?: (id: string) => Promise<unknown> } | undefined
+    )?.fetch;
+    const fetchedChannel = fetchChannel
+      ? await fetchChannel.call(this.client.channels, verificationEvent.thread_id).catch(() => null)
+      : null;
+    if (!fetchedChannel) {
+      return null;
+    }
+
+    const maybeThread = fetchedChannel as ThreadChannel;
+    return maybeThread.isThread() ? maybeThread : null;
+  }
+
+  private async sendInitialVerificationPrompt(
+    member: GuildMember,
+    thread: ThreadChannel
+  ): Promise<void> {
+    const rawInitialPrompt = await this.getInitialVerificationPrompt(member);
+    const initialPrompt = enforceDiscordMessageLimit(rawInitialPrompt);
+    if (initialPrompt.length < rawInitialPrompt.length) {
+      console.warn(
+        `Verification prompt exceeded Discord content limit for guild ${member.guild.id}; truncated before sending.`
+      );
+    }
+
+    await thread.send({
+      content: initialPrompt,
+      allowedMentions: {
+        parse: [],
+        users: [member.id],
+        roles: [],
+        repliedUser: false,
+      },
+    });
+  }
+
+  private async hasInitialVerificationPrompt(
+    member: GuildMember,
+    thread: ThreadChannel
+  ): Promise<boolean> {
+    const messages = await thread.messages.fetch({ limit: 25 });
+    const botUserId = this.client.user?.id;
+
+    return [...messages.values()].some((message) => {
+      if (botUserId && message.author.id === botUserId) {
+        return true;
+      }
+
+      return message.author.bot && message.content.includes(`<@${member.id}>`);
+    });
+  }
+
   /**
    * Creates a thread for a suspicious user in the verification channel
    * @param member The suspicious guild member
@@ -306,6 +454,9 @@ export class ThreadManager implements IThreadManager {
       return null;
     }
 
+    let setupStage = 'prepare verification thread records';
+    let threadWasCreated = false;
+
     try {
       // Ensure the server exists
       await this.serverRepository.getOrCreateServer(member.guild.id);
@@ -321,6 +472,7 @@ export class ThreadManager implements IThreadManager {
       );
 
       // Create a thread for verification
+      setupStage = 'create verification thread';
       const threadName = `Verification: ${member.user.username}`;
       const thread = await channel.threads.create({
         name: threadName,
@@ -328,13 +480,16 @@ export class ThreadManager implements IThreadManager {
         reason: `Verification thread for suspicious user: ${member.user.tag}`,
         type: ChannelType.PrivateThread,
       });
+      threadWasCreated = true;
 
       // Persist the Discord thread before follow-up operations so partial setup
       // failures do not orphan a thread that was already created.
+      setupStage = 'store verification thread id';
       await this.storeThreadId(verificationEvent, thread.id, VERIFICATION_THREAD_TYPE);
 
       // Add the member to the private thread so they can see it
-      await thread.members.add(member.id);
+      setupStage = 'add flagged user to verification thread';
+      await this.addFlaggedUserToVerificationThread(member, thread);
 
       // Lock invites after the flagged user has been added.
       // Some server permission setups allow creating private threads but not managing them;
@@ -348,28 +503,9 @@ export class ThreadManager implements IThreadManager {
         );
       }
 
+      setupStage = 'route case responders to verification thread';
       const routingResult = await this.addCaseResponderMembers(member.guild, thread, [member.id]);
 
-      const rawInitialPrompt = await this.getInitialVerificationPrompt(member);
-      const initialPrompt = enforceDiscordMessageLimit(rawInitialPrompt);
-      if (initialPrompt.length < rawInitialPrompt.length) {
-        console.warn(
-          `Verification prompt exceeded Discord content limit for guild ${member.guild.id}; truncated before sending.`
-        );
-      }
-
-      // Send an initial message to the thread
-      await thread.send({
-        content: initialPrompt,
-        allowedMentions: {
-          parse: [],
-          users: [member.id],
-          roles: [],
-          repliedUser: false,
-        },
-      });
-
-      // Store thread in the database
       await this.storeThreadId(
         verificationEvent,
         thread.id,
@@ -377,11 +513,60 @@ export class ThreadManager implements IThreadManager {
         this.buildCaseStaffRoutingMetadata(routingResult)
       );
 
+      // Send an initial message to the thread
+      setupStage = 'send initial verification prompt';
+      await this.sendInitialVerificationPrompt(member, thread);
+
       return thread;
     } catch (error) {
       console.error('Failed to create verification thread:', error);
+      if (threadWasCreated) {
+        throw this.buildThreadSetupError(setupStage, error);
+      }
       return null;
     }
+  }
+
+  public async repairVerificationThread(
+    member: GuildMember,
+    verificationEvent: VerificationEvent
+  ): Promise<VerificationThreadRepairResult> {
+    if (!verificationEvent.thread_id) {
+      const createdThread = await this.createVerificationThread(member, verificationEvent);
+      return {
+        threadId: createdThread?.id ?? null,
+        threadCreated: Boolean(createdThread),
+        userAdded: Boolean(createdThread),
+        promptSent: Boolean(createdThread),
+        promptAlreadyPresent: false,
+      };
+    }
+
+    const thread = await this.fetchStoredThread(verificationEvent);
+    if (!thread) {
+      throw new Error(`Stored verification thread ${verificationEvent.thread_id} was not found.`);
+    }
+
+    if (thread.archived) {
+      await thread.setArchived(false, 'Repair active verification case');
+    }
+    if (thread.locked) {
+      await thread.setLocked(false, 'Repair active verification case');
+    }
+
+    await this.addFlaggedUserToVerificationThread(member, thread);
+    const promptAlreadyPresent = await this.hasInitialVerificationPrompt(member, thread);
+    if (!promptAlreadyPresent) {
+      await this.sendInitialVerificationPrompt(member, thread);
+    }
+
+    return {
+      threadId: thread.id,
+      threadCreated: false,
+      userAdded: true,
+      promptSent: !promptAlreadyPresent,
+      promptAlreadyPresent,
+    };
   }
 
   public async createReportReviewThread(
@@ -399,6 +584,9 @@ export class ThreadManager implements IThreadManager {
       return null;
     }
 
+    let setupStage = 'prepare report review thread records';
+    let threadWasCreated = false;
+
     try {
       await this.serverRepository.getOrCreateServer(member.guild.id);
       await this.userRepository.getOrCreateUser(member.id, member.user.username);
@@ -408,15 +596,18 @@ export class ThreadManager implements IThreadManager {
         member.joinedAt ?? undefined
       );
 
+      setupStage = 'create report review thread';
       const thread = await channel.threads.create({
         name: `Report review: ${member.user.username}`,
         autoArchiveDuration: ThreadAutoArchiveDuration.OneWeek,
         reason: `Review-only report thread for user: ${member.user.tag}`,
         type: ChannelType.PrivateThread,
       });
+      threadWasCreated = true;
 
       // Persist the Discord thread before follow-up operations so partial setup
       // failures do not orphan a thread that was already created.
+      setupStage = 'store report review thread id';
       await this.storeThreadId(verificationEvent, thread.id, REPORT_REVIEW_THREAD_TYPE);
 
       try {
@@ -428,8 +619,17 @@ export class ThreadManager implements IThreadManager {
         );
       }
 
+      setupStage = 'route case responders to report review thread';
       const routingResult = await this.addCaseResponderMembers(member.guild, thread, [member.id]);
 
+      await this.storeThreadId(
+        verificationEvent,
+        thread.id,
+        REPORT_REVIEW_THREAD_TYPE,
+        this.buildCaseStaffRoutingMetadata(routingResult)
+      );
+
+      setupStage = 'send report review thread prompt';
       await thread.send({
         content: this.buildReportReviewThreadMessage(member, detectionResult, sourceMessage),
         allowedMentions: {
@@ -440,16 +640,12 @@ export class ThreadManager implements IThreadManager {
         },
       });
 
-      await this.storeThreadId(
-        verificationEvent,
-        thread.id,
-        REPORT_REVIEW_THREAD_TYPE,
-        this.buildCaseStaffRoutingMetadata(routingResult)
-      );
-
       return thread;
     } catch (error) {
       console.error('Failed to create report review thread:', error);
+      if (threadWasCreated) {
+        throw this.buildThreadSetupError(setupStage, error);
+      }
       return null;
     }
   }

--- a/src/services/ThreadManager.ts
+++ b/src/services/ThreadManager.ts
@@ -31,6 +31,7 @@ export const REPORT_REVIEW_THREAD_TYPE = 'report_review';
 export const REPORT_INTAKE_THREAD_NAME_PREFIX = 'Report intake:';
 export const CASE_STAFF_ROUTING_METADATA_KEY = 'case_staff_routing';
 const FLAGGED_USER_THREAD_ADD_RETRY_DELAYS_MS = [750, 1500, 3000] as const;
+const INITIAL_VERIFICATION_PROMPT_SCAN_LIMIT = 100;
 
 export interface VerificationThreadRepairResult {
   threadId: string | null;
@@ -423,7 +424,7 @@ export class ThreadManager implements IThreadManager {
     member: GuildMember,
     thread: ThreadChannel
   ): Promise<boolean> {
-    const messages = await thread.messages.fetch({ limit: 25 });
+    const messages = await thread.messages.fetch({ limit: INITIAL_VERIFICATION_PROMPT_SCAN_LIMIT });
     const botUserId = this.client.user?.id;
 
     return [...messages.values()].some((message) => {

--- a/src/services/ThreadManager.ts
+++ b/src/services/ThreadManager.ts
@@ -428,11 +428,9 @@ export class ThreadManager implements IThreadManager {
     const botUserId = this.client.user?.id;
 
     return [...messages.values()].some((message) => {
-      if (botUserId && message.author.id === botUserId) {
-        return true;
-      }
-
-      return message.author.bot && message.content.includes(`<@${member.id}>`);
+      const isFromBot =
+        (botUserId && message.author.id === botUserId) || (!botUserId && message.author.bot);
+      return isFromBot && message.content.includes(`<@${member.id}>`);
     });
   }
 


### PR DESCRIPTION
## Summary
- Adds explicit restricted-role lockdown unsync controls and richer report output for synced allowed-channel blockers.
- Hardens automatic detection by ignoring Discord system/non-default messages and clamping heuristic confidence to 0..1.
- Preserves created verification/report thread IDs on partial setup failure and reports the failed setup stage.
- Adds retry-backed user membership repair plus /case repair user:<user> for active user-facing verification cases.

## Why
Aaron's active verification thread existed, but the flagged user was not added and no prompt was sent. Steady-state permissions looked valid, so the likely failure mode is a Discord role/channel propagation race immediately after restriction. This PR makes thread creation failures recoverable, retries the user add path, and provides a focused repair command for already-active cases.

## Behavior Notes
- Normal lockdown apply remains conservative and will not unsync allowed channels automatically.
- Operators must pass unsync-allowed:true to copy parent overwrites onto synced allowed channels before applying lockdown denies.
- /case repair refuses moderator-only report-review threads and does not duplicate an existing bot prompt.
- Message deletion is still outside lockdown V1.

## Rollout
- Deploy the bot update.
- Run /case repair user:Aaron Alison for the affected active case.
- Separately fix Drasil permissions in #reports-and-tickets so report intake threads can be created and posted.

## Tests
- npm run build
- npm run lint
- npm run format:check
- git diff --check
- npm test