### PR TITLE
Continue lockdown apply after confirmed unsync

### DIFF
--- a/src/__tests__/unit/RestrictedRoleLockdownService.unit.test.ts
+++ b/src/__tests__/unit/RestrictedRoleLockdownService.unit.test.ts
@@ -43,6 +43,7 @@ describe('RestrictedRoleLockdownService (unit)', () => {
     restrictedOverwrite?: ReturnType<typeof createOverwrite>;
     extraOverwrites?: readonly ReturnType<typeof createOverwrite>[];
     keepPermissionsLockedAfterSet?: boolean;
+    overwriteSetError?: Error;
   }) => {
     const restrictedOverwrite = options.restrictedOverwrite ?? createOverwrite();
     const cache = new Map([
@@ -66,6 +67,9 @@ describe('RestrictedRoleLockdownService (unit)', () => {
           return Promise.resolve(undefined);
         }),
         set: jest.fn().mockImplementation(() => {
+          if (options.overwriteSetError) {
+            return Promise.reject(options.overwriteSetError);
+          }
           if (!options.keepPermissionsLockedAfterSet) {
             channel.permissionsLocked = false;
           }
@@ -264,6 +268,52 @@ describe('RestrictedRoleLockdownService (unit)', () => {
       'verification-channel-1',
     ]);
     expect(report.appliedActions.map((action) => action.channelId)).toEqual(['category-1']);
+    expect(configService.updateServerSettings).toHaveBeenCalledWith('guild-1', {
+      restricted_lockdown_enabled: true,
+    });
+  });
+
+  it('does not report successfully unsynced channels as synced when another unsync fails', async () => {
+    const category = createChannel({
+      id: 'category-1',
+      name: 'public',
+      type: ChannelType.GuildCategory,
+    });
+    const successfulAllowedChannel = createChannel({
+      id: 'verification-channel-1',
+      name: 'verification',
+      type: ChannelType.GuildText,
+      parentId: 'category-1',
+      permissionsLocked: true,
+      keepPermissionsLockedAfterSet: true,
+    });
+    const failedAllowedChannel = createChannel({
+      id: 'report-channel-1',
+      name: 'reports',
+      type: ChannelType.GuildText,
+      parentId: 'category-1',
+      permissionsLocked: true,
+      overwriteSetError: new Error('Missing Permissions'),
+    });
+    const guild = createGuild([category, successfulAllowedChannel, failedAllowedChannel]);
+    const configService = createConfigService({
+      report_instructions_channel_id: 'report-channel-1',
+    });
+    const service = new RestrictedRoleLockdownService(configService as any);
+
+    const report = await service.applyGuild(guild, 'admin-1', { unsyncAllowedChannels: true });
+
+    expect(successfulAllowedChannel.permissionOverwrites.set).toHaveBeenCalled();
+    expect(failedAllowedChannel.permissionOverwrites.set).toHaveBeenCalled();
+    expect(report.unsyncedAllowedChannels.map((action) => action.channelId)).toEqual([
+      'verification-channel-1',
+    ]);
+    expect(report.syncedAllowedChannels.map((action) => action.channelId)).toEqual([
+      'report-channel-1',
+    ]);
+    expect(report.failedActions.map((action) => action.channelId)).toEqual(['report-channel-1']);
+    expect(category.permissionOverwrites.edit).not.toHaveBeenCalled();
+    expect(configService.updateServerSettings).not.toHaveBeenCalled();
   });
 
   it('applies missing lockdown denies and marks lockdown enabled', async () => {

--- a/src/__tests__/unit/RestrictedRoleLockdownService.unit.test.ts
+++ b/src/__tests__/unit/RestrictedRoleLockdownService.unit.test.ts
@@ -42,6 +42,7 @@ describe('RestrictedRoleLockdownService (unit)', () => {
     permissionsLocked?: boolean | null;
     restrictedOverwrite?: ReturnType<typeof createOverwrite>;
     extraOverwrites?: readonly ReturnType<typeof createOverwrite>[];
+    keepPermissionsLockedAfterSet?: boolean;
   }) => {
     const restrictedOverwrite = options.restrictedOverwrite ?? createOverwrite();
     const cache = new Map([
@@ -65,7 +66,9 @@ describe('RestrictedRoleLockdownService (unit)', () => {
           return Promise.resolve(undefined);
         }),
         set: jest.fn().mockImplementation(() => {
-          channel.permissionsLocked = false;
+          if (!options.keepPermissionsLockedAfterSet) {
+            channel.permissionsLocked = false;
+          }
           return Promise.resolve(undefined);
         }),
       },
@@ -227,6 +230,40 @@ describe('RestrictedRoleLockdownService (unit)', () => {
     expect(configService.updateServerSettings).toHaveBeenCalledWith('guild-1', {
       restricted_lockdown_enabled: true,
     });
+  });
+
+  it('continues apply when the immediate re-audit still marks a just-unsynced channel locked', async () => {
+    const category = createChannel({
+      id: 'category-1',
+      name: 'public',
+      type: ChannelType.GuildCategory,
+    });
+    const verificationChannel = createChannel({
+      id: 'verification-channel-1',
+      name: 'verification',
+      type: ChannelType.GuildText,
+      parentId: 'category-1',
+      permissionsLocked: true,
+      keepPermissionsLockedAfterSet: true,
+    });
+    const guild = createGuild([category, verificationChannel]);
+    const configService = createConfigService();
+    const service = new RestrictedRoleLockdownService(configService as any);
+
+    const report = await service.applyGuild(guild, 'admin-1', { unsyncAllowedChannels: true });
+
+    expect(verificationChannel.permissionOverwrites.set).toHaveBeenCalled();
+    expect(category.permissionOverwrites.edit).toHaveBeenCalledWith(
+      restrictedRoleId,
+      expect.objectContaining({ ViewChannel: false, SendMessages: false }),
+      expect.any(Object)
+    );
+    expect(report.errorCount).toBe(0);
+    expect(report.syncedAllowedChannels).toEqual([]);
+    expect(report.unsyncedAllowedChannels.map((action) => action.channelId)).toEqual([
+      'verification-channel-1',
+    ]);
+    expect(report.appliedActions.map((action) => action.channelId)).toEqual(['category-1']);
   });
 
   it('applies missing lockdown denies and marks lockdown enabled', async () => {

--- a/src/services/RestrictedRoleLockdownService.ts
+++ b/src/services/RestrictedRoleLockdownService.ts
@@ -149,27 +149,28 @@ export class RestrictedRoleLockdownService implements IRestrictedRoleLockdownSer
         actorId
       );
       unsyncedAllowedChannels = unsyncResult.unsyncedActions;
+      const recentlyUnsyncedAllowedChannelIds = new Set(
+        unsyncedAllowedChannels.map((action) => action.channelId)
+      );
 
       if (unsyncResult.failedActions.length > 0) {
+        const refreshed = await this.buildReport(guild, false, recentlyUnsyncedAllowedChannelIds);
         return this.toReport({
-          guildId: report.guildId,
-          checkedAt: new Date(),
-          enabled: report.enabled,
-          allowedChannelIds: report.allowedChannelIds,
-          allowedCategoryIds: report.allowedCategoryIds,
-          autoAllowedChannelIds: report.autoAllowedChannelIds,
-          issues: [...report.issues, ...this.applyFailuresToIssues(unsyncResult.failedActions)],
-          plannedActions: report.plannedActions,
+          guildId: refreshed.guildId,
+          checkedAt: refreshed.checkedAt,
+          enabled: refreshed.enabled,
+          allowedChannelIds: refreshed.allowedChannelIds,
+          allowedCategoryIds: refreshed.allowedCategoryIds,
+          autoAllowedChannelIds: refreshed.autoAllowedChannelIds,
+          issues: [...refreshed.issues, ...this.applyFailuresToIssues(unsyncResult.failedActions)],
+          plannedActions: refreshed.plannedActions,
           appliedActions: [],
           failedActions: unsyncResult.failedActions,
-          syncedAllowedChannels: report.syncedAllowedChannels,
+          syncedAllowedChannels: refreshed.syncedAllowedChannels,
           unsyncedAllowedChannels,
         });
       }
 
-      const recentlyUnsyncedAllowedChannelIds = new Set(
-        unsyncedAllowedChannels.map((action) => action.channelId)
-      );
       report = await this.buildReport(guild, false, recentlyUnsyncedAllowedChannelIds);
       if (report.errorCount > 0) {
         return { ...report, unsyncedAllowedChannels };

--- a/src/services/RestrictedRoleLockdownService.ts
+++ b/src/services/RestrictedRoleLockdownService.ts
@@ -167,7 +167,10 @@ export class RestrictedRoleLockdownService implements IRestrictedRoleLockdownSer
         });
       }
 
-      report = await this.buildReport(guild, false);
+      const recentlyUnsyncedAllowedChannelIds = new Set(
+        unsyncedAllowedChannels.map((action) => action.channelId)
+      );
+      report = await this.buildReport(guild, false, recentlyUnsyncedAllowedChannelIds);
       if (report.errorCount > 0) {
         return { ...report, unsyncedAllowedChannels };
       }
@@ -239,7 +242,11 @@ export class RestrictedRoleLockdownService implements IRestrictedRoleLockdownSer
       });
     }
 
-    const refreshed = await this.buildReport(guild, true);
+    const refreshed = await this.buildReport(
+      guild,
+      true,
+      new Set(unsyncedAllowedChannels.map((action) => action.channelId))
+    );
     return this.toReport({
       guildId: guild.id,
       checkedAt: refreshed.checkedAt,
@@ -258,7 +265,8 @@ export class RestrictedRoleLockdownService implements IRestrictedRoleLockdownSer
 
   private async buildReport(
     guild: Guild,
-    skipSetupChecks: boolean
+    skipSetupChecks: boolean,
+    recentlyUnsyncedAllowedChannelIds: ReadonlySet<string> = new Set()
   ): Promise<RestrictedLockdownReport> {
     const serverConfig = await this.configService.getServerConfig(guild.id);
     const settings = getRestrictedLockdownSettings(serverConfig.settings);
@@ -326,7 +334,12 @@ export class RestrictedRoleLockdownService implements IRestrictedRoleLockdownSer
 
       const parentId = channel.parentId ?? null;
       if (allowedChannelIds.has(channel.id)) {
-        if (parentId && deniedCategoryIds.has(parentId) && channel.permissionsLocked === true) {
+        if (
+          parentId &&
+          deniedCategoryIds.has(parentId) &&
+          channel.permissionsLocked === true &&
+          !recentlyUnsyncedAllowedChannelIds.has(channel.id)
+        ) {
           syncedAllowedChannels.push(this.toPlannedAction(channel, 'channel'));
           issues.push({
             severity: 'error',


### PR DESCRIPTION
## Summary
- continue lockdown apply after confirmed unsync-allowed:true writes even if the immediate re-audit still reports those channels as permissionsLocked`n- keep the successfully unsynced channel IDs out of same-run synced-channel blockers in both the pre-apply and final reports
- add a regression test for stale Discord.js permissionsLocked state after permissionOverwrites.set`n
## Why
Production showed Unsynced allowed channels: 2 for #reports-and-tickets and #welcome-center, but the same channels still appeared as synced allowed-channel blockers in the immediate re-audit. That left Applied deny writes: 0 even though the unsync writes succeeded.

## Tests
- npm test -- --runTestsByPath src/__tests__/unit/RestrictedRoleLockdownService.unit.test.ts
- npm run build
- npm run lint
- npm run format:check
- git diff --check
- npm test