### PR TITLE
Add Admin Actions, evidence threads, and stale case reminders

### DIFF
--- a/prisma/migrations/20260603090000_add_private_evidence_threads/migration.sql
+++ b/prisma/migrations/20260603090000_add_private_evidence_threads/migration.sql
@@ -1,0 +1,5 @@
+ALTER TABLE public.verification_events
+  ADD COLUMN IF NOT EXISTS private_evidence_thread_id text;
+
+CREATE INDEX IF NOT EXISTS idx_verification_events_private_evidence_thread
+  ON public.verification_events(private_evidence_thread_id);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -181,6 +181,7 @@ model verification_events {
   user_id                                                                             String?
   detection_event_id                                                                  String?             @db.Uuid
   thread_id                                                                           String?
+  private_evidence_thread_id                                                          String?
   notification_message_id                                                             String?
   status                                                                              verification_status @default(pending)
   created_at                                                                          DateTime?           @default(now()) @db.Timestamptz(6)
@@ -197,6 +198,7 @@ model verification_events {
 
   @@index([created_at], map: "idx_verification_events_created_at_range", type: Brin)
   @@index([detection_event_id], map: "idx_verification_events_detection")
+  @@index([private_evidence_thread_id], map: "idx_verification_events_private_evidence_thread")
   @@index([server_id], map: "idx_verification_events_server")
   @@index([status], map: "idx_verification_events_status")
   @@index([thread_id], map: "idx_verification_events_thread")

--- a/src/__tests__/fakes/inMemoryRepositories.ts
+++ b/src/__tests__/fakes/inMemoryRepositories.ts
@@ -495,7 +495,11 @@ export class InMemoryVerificationEventRepository implements IVerificationEventRe
     return { ...matchingEvents[0] };
   }
 
-  async update(id: string, data: Partial<VerificationEvent>): Promise<VerificationEvent | null> {
+  async update(
+    id: string,
+    data: Partial<VerificationEvent>,
+    options: { touchUpdatedAt?: boolean } = {}
+  ): Promise<VerificationEvent | null> {
     const eventIndex = this.events.findIndex((item) => item.id === id);
     if (eventIndex === -1) {
       return null;
@@ -529,7 +533,8 @@ export class InMemoryVerificationEventRepository implements IVerificationEventRe
       }
     }
 
-    updated.updated_at = new Date();
+    updated.updated_at =
+      options.touchUpdatedAt === false ? (data.updated_at ?? updated.updated_at) : new Date();
     this.events[eventIndex] = updated;
     return { ...updated };
   }

--- a/src/__tests__/fakes/inMemoryRepositories.ts
+++ b/src/__tests__/fakes/inMemoryRepositories.ts
@@ -437,6 +437,15 @@ export class InMemoryVerificationEventRepository implements IVerificationEventRe
       .map((event) => ({ ...event }));
   }
 
+  async findPendingByServer(serverId: string): Promise<VerificationEvent[]> {
+    return this.events
+      .filter(
+        (event) => event.server_id === serverId && event.status === VerificationStatus.PENDING
+      )
+      .sort((a, b) => a.updated_at.getTime() - b.updated_at.getTime())
+      .map((event) => ({ ...event }));
+  }
+
   async createFromDetection(
     detectionEventId: string | null,
     serverId: string,
@@ -450,6 +459,7 @@ export class InMemoryVerificationEventRepository implements IVerificationEventRe
       user_id: userId,
       detection_event_id: detectionEventId,
       thread_id: null,
+      private_evidence_thread_id: null,
       notification_message_id: null,
       status,
       created_at: now,
@@ -495,6 +505,8 @@ export class InMemoryVerificationEventRepository implements IVerificationEventRe
     const updated: VerificationEvent = { ...existing };
 
     if (data.thread_id !== undefined) updated.thread_id = data.thread_id;
+    if (data.private_evidence_thread_id !== undefined)
+      updated.private_evidence_thread_id = data.private_evidence_thread_id;
     if (data.notification_message_id !== undefined)
       updated.notification_message_id = data.notification_message_id;
     if (data.notes !== undefined) updated.notes = data.notes;

--- a/src/__tests__/integration/SecurityActionService.integration.test.ts
+++ b/src/__tests__/integration/SecurityActionService.integration.test.ts
@@ -84,6 +84,10 @@ describeIntegration('SecurityActionService (integration)', () => {
       createReportReviewThread: jest
         .fn()
         .mockResolvedValue({ id: 'thread-1', url: 'https://discord.com/channels/thread-1' } as any),
+      createPrivateEvidenceThread: jest.fn().mockResolvedValue({
+        id: 'evidence-1',
+        url: 'https://discord.com/channels/evidence-1',
+      } as any),
       createReportIntakeThread: jest.fn().mockResolvedValue({} as any),
       activateReportIntakeThread: jest.fn().mockResolvedValue(true),
       resolveVerificationThread: jest.fn().mockResolvedValue(true),
@@ -100,6 +104,7 @@ describeIntegration('SecurityActionService (integration)', () => {
       restrictUser: jest.fn().mockResolvedValue(true),
       verifyUser: jest.fn().mockResolvedValue(true),
       banUser: jest.fn().mockResolvedValue(true),
+      syncAlreadyBannedUser: jest.fn().mockResolvedValue(1),
     };
   });
 

--- a/src/__tests__/integration/UserModerationService.integration.test.ts
+++ b/src/__tests__/integration/UserModerationService.integration.test.ts
@@ -76,6 +76,7 @@ describeIntegration('UserModerationService (integration)', () => {
     threadManager = {
       createVerificationThread: jest.fn().mockResolvedValue({} as any),
       createReportReviewThread: jest.fn().mockResolvedValue({} as any),
+      createPrivateEvidenceThread: jest.fn().mockResolvedValue({} as any),
       createReportIntakeThread: jest.fn().mockResolvedValue({} as any),
       activateReportIntakeThread: jest.fn().mockResolvedValue(true),
       resolveVerificationThread: jest.fn().mockResolvedValue(true),

--- a/src/__tests__/unit/CaseReviewReminderService.unit.test.ts
+++ b/src/__tests__/unit/CaseReviewReminderService.unit.test.ts
@@ -84,7 +84,9 @@ describe('CaseReviewReminderService (unit)', () => {
         metadata: expect.objectContaining({
           case_review_last_reminded_at: now.toISOString(),
         }),
-      })
+        updated_at: staleCase.updated_at,
+      }),
+      { touchUpdatedAt: false }
     );
   });
 

--- a/src/__tests__/unit/CaseReviewReminderService.unit.test.ts
+++ b/src/__tests__/unit/CaseReviewReminderService.unit.test.ts
@@ -1,0 +1,125 @@
+import type { TextChannel } from 'discord.js';
+import type { IConfigService } from '../../config/ConfigService';
+import type { IServerRepository } from '../../repositories/ServerRepository';
+import type { IVerificationEventRepository } from '../../repositories/VerificationEventRepository';
+import { Server, VerificationEvent, VerificationStatus } from '../../repositories/types';
+import { CaseReviewReminderService } from '../../services/CaseReviewReminderService';
+
+const buildServer = (settings: Server['settings']): Server => ({
+  guild_id: 'guild-1',
+  restricted_role_id: null,
+  admin_channel_id: 'admin-1',
+  verification_channel_id: null,
+  admin_notification_role_id: null,
+  heuristic_message_threshold: 5,
+  heuristic_message_timeframe_seconds: 60,
+  heuristic_suspicious_keywords: [],
+  created_at: null,
+  updated_at: null,
+  updated_by: null,
+  settings,
+  is_active: true,
+});
+
+const buildPendingCase = (
+  updatedAt: Date,
+  metadata: VerificationEvent['metadata'] = null
+): VerificationEvent => ({
+  id: 'ver-1',
+  server_id: 'guild-1',
+  user_id: 'user-1',
+  detection_event_id: 'det-1',
+  thread_id: 'case-thread-1',
+  private_evidence_thread_id: 'evidence-thread-1',
+  notification_message_id: 'message-1',
+  status: VerificationStatus.PENDING,
+  created_at: updatedAt,
+  updated_at: updatedAt,
+  resolved_at: null,
+  resolved_by: null,
+  notes: null,
+  metadata,
+});
+
+describe('CaseReviewReminderService (unit)', () => {
+  it('sends a rollup and stamps stale pending cases', async () => {
+    const now = new Date('2026-06-03T12:00:00.000Z');
+    const staleCase = buildPendingCase(new Date('2026-06-02T10:00:00.000Z'));
+    const send = jest.fn().mockResolvedValue(undefined);
+    const serverRepository = {
+      findAllActive: jest.fn().mockResolvedValue([
+        buildServer({
+          case_review_reminders_enabled: true,
+          case_review_reminder_stale_hours: 24,
+          case_review_reminder_repeat_hours: 24,
+          case_responder_role_ids: ['123456789012345678'],
+          case_responder_routing_mode: 'ping_only',
+        }),
+      ]),
+    } as unknown as jest.Mocked<IServerRepository>;
+    const verificationEventRepository = {
+      findPendingByServer: jest.fn().mockResolvedValue([staleCase]),
+      update: jest.fn().mockResolvedValue(staleCase),
+    } as unknown as jest.Mocked<IVerificationEventRepository>;
+    const configService = {
+      getAdminChannel: jest.fn().mockResolvedValue({ send } as unknown as TextChannel),
+    } as unknown as jest.Mocked<IConfigService>;
+
+    const service = new CaseReviewReminderService(
+      serverRepository,
+      verificationEventRepository,
+      configService
+    );
+
+    await service.runOnce(now);
+
+    expect(send).toHaveBeenCalledWith({
+      content: expect.stringContaining('There is 1 stale pending case needing review.'),
+      allowedMentions: { parse: [], users: [], roles: ['123456789012345678'], repliedUser: false },
+    });
+    expect(send.mock.calls[0][0].content).toContain('evidence-thread-1');
+    expect(verificationEventRepository.update).toHaveBeenCalledWith(
+      staleCase.id,
+      expect.objectContaining({
+        metadata: expect.objectContaining({
+          case_review_last_reminded_at: now.toISOString(),
+        }),
+      })
+    );
+  });
+
+  it('suppresses repeat reminders until the repeat interval elapses', async () => {
+    const now = new Date('2026-06-03T12:00:00.000Z');
+    const recentlyRemindedCase = buildPendingCase(new Date('2026-06-01T12:00:00.000Z'), {
+      case_review_last_reminded_at: '2026-06-03T10:00:00.000Z',
+    });
+    const send = jest.fn().mockResolvedValue(undefined);
+    const serverRepository = {
+      findAllActive: jest.fn().mockResolvedValue([
+        buildServer({
+          case_review_reminders_enabled: true,
+          case_review_reminder_stale_hours: 24,
+          case_review_reminder_repeat_hours: 24,
+        }),
+      ]),
+    } as unknown as jest.Mocked<IServerRepository>;
+    const verificationEventRepository = {
+      findPendingByServer: jest.fn().mockResolvedValue([recentlyRemindedCase]),
+      update: jest.fn(),
+    } as unknown as jest.Mocked<IVerificationEventRepository>;
+    const configService = {
+      getAdminChannel: jest.fn().mockResolvedValue({ send } as unknown as TextChannel),
+    } as unknown as jest.Mocked<IConfigService>;
+
+    const service = new CaseReviewReminderService(
+      serverRepository,
+      verificationEventRepository,
+      configService
+    );
+
+    await service.runOnce(now);
+
+    expect(send).not.toHaveBeenCalled();
+    expect(verificationEventRepository.update).not.toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/unit/InteractionHandler.unit.test.ts
+++ b/src/__tests__/unit/InteractionHandler.unit.test.ts
@@ -37,6 +37,7 @@ const buildMember = (guildId: string, userId: string): GuildMember =>
       username: 'test-user',
       tag: 'test-user#0001',
     } as User,
+    permissions: { has: jest.fn().mockReturnValue(false) },
   }) as unknown as GuildMember;
 
 const buildInteraction = (customId: string, guildId: string, user: User): ButtonInteraction => {
@@ -58,6 +59,9 @@ const buildInteraction = (customId: string, guildId: string, user: User): Button
     }),
     followUp: jest.fn().mockResolvedValue(undefined),
     reply: jest.fn().mockImplementation(async () => {
+      interaction.replied = true;
+    }),
+    update: jest.fn().mockImplementation(async () => {
       interaction.replied = true;
     }),
     showModal: jest.fn().mockResolvedValue(undefined),
@@ -110,6 +114,7 @@ describe('InteractionHandler (unit)', () => {
       restrictUser: jest.fn().mockResolvedValue(true),
       verifyUser: jest.fn().mockResolvedValue(true),
       banUser: jest.fn().mockResolvedValue(true),
+      syncAlreadyBannedUser: jest.fn().mockResolvedValue(1),
     };
     securityActionService = {
       handleSuspiciousMessage: jest.fn().mockResolvedValue(true),
@@ -173,6 +178,7 @@ describe('InteractionHandler (unit)', () => {
       findActiveByUserAndServer: jest.fn(),
       findByUserAndServer: jest.fn(),
       findByDetectionEvent: jest.fn(),
+      findPendingByServer: jest.fn(),
       createFromDetection: jest.fn(),
       getVerificationHistory: jest.fn(),
       findById: jest.fn(),
@@ -186,6 +192,9 @@ describe('InteractionHandler (unit)', () => {
       createReportReviewThread: jest
         .fn()
         .mockResolvedValue({ url: 'https://discord.com/channels/thread-1' } as any),
+      createPrivateEvidenceThread: jest
+        .fn()
+        .mockResolvedValue({ url: 'https://discord.com/channels/evidence-1' } as any),
       createReportIntakeThread: jest.fn().mockResolvedValue({
         id: 'report-thread-1',
         url: 'https://discord.com/channels/report-thread-1',
@@ -227,7 +236,7 @@ describe('InteractionHandler (unit)', () => {
       threadManager,
       adminActionRepository
     );
-    const interaction = buildInteraction('verify_user-1', 'guild-1', {
+    const interaction = buildInteraction('admin_actions:confirm_verify:case:user-1', 'guild-1', {
       id: 'admin-1',
     } as User);
     grantInteractionPermissions(interaction);
@@ -268,6 +277,93 @@ describe('InteractionHandler (unit)', () => {
     expect(JSON.stringify(modal.toJSON())).toContain('Final notes (optional)');
   });
 
+  it('shows sync existing ban to a Ban Members moderator when a pending case user is already banned', async () => {
+    const verificationEvent: VerificationEvent = {
+      id: 'ver-1',
+      server_id: 'guild-1',
+      user_id: 'user-1',
+      detection_event_id: null,
+      thread_id: null,
+      private_evidence_thread_id: null,
+      notification_message_id: 'message-1',
+      status: VerificationStatus.PENDING,
+      created_at: new Date(),
+      updated_at: new Date(),
+      resolved_at: null,
+      resolved_by: null,
+      notes: null,
+      metadata: null,
+    };
+    verificationEventRepository.findActiveByUserAndServer.mockResolvedValue(verificationEvent);
+    verificationEventRepository.findByUserAndServer.mockResolvedValue([verificationEvent]);
+    (client.guilds.fetch as jest.Mock).mockResolvedValue({
+      bans: { fetch: jest.fn().mockResolvedValue({ user: { id: 'user-1' } }) },
+      members: {
+        me: { permissions: { has: jest.fn().mockReturnValue(true) } },
+        fetch: jest.fn().mockResolvedValue(buildMember('guild-1', 'admin-1')),
+      },
+    });
+
+    const handler = new InteractionHandler(
+      client,
+      notificationManager,
+      userModerationService,
+      securityActionService,
+      configService,
+      verificationEventRepository,
+      threadManager,
+      adminActionRepository
+    );
+    const interaction = buildInteraction('admin_actions:menu:case:user-1', 'guild-1', {
+      id: 'admin-1',
+    } as User);
+    grantOnlyBanMembersPermission(interaction);
+
+    await handler.handleButtonInteraction(interaction);
+
+    expect(interaction.reply).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: expect.stringContaining('Discord already shows this user as banned'),
+        components: expect.any(Array),
+        flags: MessageFlags.Ephemeral,
+      })
+    );
+    const reply = (interaction.reply as jest.Mock).mock.calls[0][0];
+    expect(JSON.stringify(reply.components)).toContain('Sync Existing Ban');
+    expect(JSON.stringify(reply.components)).not.toContain('Ban User');
+  });
+
+  it('syncs pending cases for an already-banned user after confirmation', async () => {
+    const handler = new InteractionHandler(
+      client,
+      notificationManager,
+      userModerationService,
+      securityActionService,
+      configService,
+      verificationEventRepository,
+      threadManager,
+      adminActionRepository
+    );
+    const interaction = buildInteraction('admin_actions:confirm_sync_ban:case:user-1', 'guild-1', {
+      id: 'ban-mod-1',
+    } as User);
+    grantOnlyBanMembersPermission(interaction);
+
+    await handler.handleButtonInteraction(interaction);
+
+    expect(userModerationService.syncAlreadyBannedUser).toHaveBeenCalledWith(
+      expect.any(Object),
+      'user-1',
+      interaction.user
+    );
+    expect(interaction.followUp).toHaveBeenCalledWith({
+      content:
+        'Synced 1 pending verification case for <@user-1> to banned because Discord already has an existing ban.',
+      allowedMentions: { parse: [] },
+      flags: MessageFlags.Ephemeral,
+    });
+  });
+
   it('handles thread button and creates a verification thread', async () => {
     const verificationEvent: VerificationEvent = {
       id: 'ver-1',
@@ -275,6 +371,7 @@ describe('InteractionHandler (unit)', () => {
       user_id: 'user-1',
       detection_event_id: null,
       thread_id: null,
+      private_evidence_thread_id: null,
       notification_message_id: 'message-1',
       status: VerificationStatus.PENDING,
       created_at: new Date(),
@@ -296,7 +393,7 @@ describe('InteractionHandler (unit)', () => {
       threadManager,
       adminActionRepository
     );
-    const interaction = buildInteraction('thread_user-1', 'guild-1', {
+    const interaction = buildInteraction('admin_actions:confirm_thread:case:user-1', 'guild-1', {
       id: 'admin-1',
     } as User);
     grantInteractionPermissions(interaction);
@@ -318,6 +415,7 @@ describe('InteractionHandler (unit)', () => {
       user_id: 'user-1',
       detection_event_id: null,
       thread_id: null,
+      private_evidence_thread_id: null,
       notification_message_id: 'message-1',
       status: VerificationStatus.VERIFIED,
       created_at: new Date(),
@@ -339,7 +437,7 @@ describe('InteractionHandler (unit)', () => {
       threadManager,
       adminActionRepository
     );
-    const interaction = buildInteraction('reopen_user-1', 'guild-1', {
+    const interaction = buildInteraction('admin_actions:confirm_reopen:case:user-1', 'guild-1', {
       id: 'admin-1',
     } as User);
     grantInteractionPermissions(interaction);
@@ -630,9 +728,13 @@ describe('InteractionHandler (unit)', () => {
       threadManager,
       adminActionRepository
     );
-    const interaction = buildInteraction('observed:open:user-1:det-1', 'guild-1', {
-      id: 'admin-1',
-    } as User);
+    const interaction = buildInteraction(
+      'admin_actions:confirm_observed_open:observed:user-1:det-1',
+      'guild-1',
+      {
+        id: 'admin-1',
+      } as User
+    );
     grantInteractionPermissions(interaction);
 
     await handler.handleButtonInteraction(interaction);
@@ -689,9 +791,13 @@ describe('InteractionHandler (unit)', () => {
       threadManager,
       adminActionRepository
     );
-    const interaction = buildInteraction('observed:false_positive:user-1:det-1', 'guild-1', {
-      id: 'admin-1',
-    } as User);
+    const interaction = buildInteraction(
+      'admin_actions:confirm_observed_false_positive:observed:user-1:det-1',
+      'guild-1',
+      {
+        id: 'admin-1',
+      } as User
+    );
     grantInteractionPermissions(interaction);
 
     await handler.handleButtonInteraction(interaction);
@@ -746,7 +852,7 @@ describe('InteractionHandler (unit)', () => {
     });
   });
 
-  it('acknowledges observed popup action before fetching permissions', async () => {
+  it('shows confirmation for observed popup action before fetching permissions', async () => {
     (client.guilds.fetch as jest.Mock).mockResolvedValue({
       members: {
         fetch: jest.fn().mockResolvedValue({
@@ -764,26 +870,27 @@ describe('InteractionHandler (unit)', () => {
       threadManager,
       adminActionRepository
     );
-    const interaction = buildInteraction('observed:false_positive:user-1:det-1', 'guild-1', {
-      id: 'admin-1',
-    } as User);
+    const interaction = buildInteraction(
+      'admin_actions:observed_false_positive:observed:user-1:det-1',
+      'guild-1',
+      {
+        id: 'admin-1',
+      } as User
+    );
 
     await handler.handleButtonInteraction(interaction);
 
-    expect(interaction.deferReply).toHaveBeenCalledWith({ flags: MessageFlags.Ephemeral });
-    expect((interaction.deferReply as jest.Mock).mock.invocationCallOrder[0]).toBeLessThan(
-      (client.guilds.fetch as jest.Mock).mock.invocationCallOrder[0]
+    expect(interaction.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: expect.stringContaining('Mark this observed alert'),
+        components: expect.any(Array),
+      })
     );
-    expect(securityActionService.dismissObservedDetection).toHaveBeenCalledWith(
-      'guild-1',
-      'user-1',
-      'det-1',
-      interaction.user,
-      AdminActionType.FALSE_POSITIVE
-    );
+    expect(client.guilds.fetch).not.toHaveBeenCalled();
+    expect(securityActionService.dismissObservedDetection).not.toHaveBeenCalled();
   });
 
-  it('keeps observed popup permission denial private after acknowledgement', async () => {
+  it('keeps confirmed observed action permission denial private', async () => {
     (client.guilds.fetch as jest.Mock).mockResolvedValue({
       members: {
         fetch: jest.fn().mockResolvedValue({
@@ -801,16 +908,19 @@ describe('InteractionHandler (unit)', () => {
       threadManager,
       adminActionRepository
     );
-    const interaction = buildInteraction('observed:dismiss:user-1:det-1', 'guild-1', {
-      id: 'viewer-1',
-    } as User);
+    const interaction = buildInteraction(
+      'admin_actions:confirm_observed_dismiss:observed:user-1:det-1',
+      'guild-1',
+      {
+        id: 'viewer-1',
+      } as User
+    );
 
     await handler.handleButtonInteraction(interaction);
 
-    expect(interaction.deferReply).toHaveBeenCalledWith({ flags: MessageFlags.Ephemeral });
-    expect(interaction.editReply).toHaveBeenCalledWith({
-      content: 'You need moderation permissions to dismiss an alert.',
-      components: [],
+    expect(interaction.reply).toHaveBeenCalledWith({
+      content: 'You need moderation permissions to use this observed action.',
+      flags: MessageFlags.Ephemeral,
     });
     expect(securityActionService.dismissObservedDetection).not.toHaveBeenCalled();
   });
@@ -829,9 +939,13 @@ describe('InteractionHandler (unit)', () => {
       threadManager,
       adminActionRepository
     );
-    const interaction = buildInteraction('observed:undo_dismiss:user-1:det-1', 'guild-1', {
-      id: 'admin-1',
-    } as User);
+    const interaction = buildInteraction(
+      'admin_actions:confirm_observed_undo_dismiss:observed:user-1:det-1',
+      'guild-1',
+      {
+        id: 'admin-1',
+      } as User
+    );
     grantInteractionPermissions(interaction);
 
     await handler.handleButtonInteraction(interaction);

--- a/src/__tests__/unit/NotificationManager.unit.test.ts
+++ b/src/__tests__/unit/NotificationManager.unit.test.ts
@@ -72,6 +72,7 @@ const buildVerificationEvent = (overrides: Partial<VerificationEvent> = {}): Ver
   user_id: overrides.user_id ?? 'user-1',
   detection_event_id: overrides.detection_event_id ?? null,
   thread_id: overrides.thread_id ?? null,
+  private_evidence_thread_id: overrides.private_evidence_thread_id ?? null,
   notification_message_id: overrides.notification_message_id ?? null,
   status: overrides.status ?? VerificationStatus.PENDING,
   created_at: overrides.created_at ?? new Date(),
@@ -170,9 +171,8 @@ describe('NotificationManager (unit)', () => {
       repliedUser: false,
     });
     const labels = extractLabels(sendArgs.components);
-    expect(labels).toEqual(
-      expect.arrayContaining(['Verify User', 'Ban User', 'Create Thread', 'View Full History'])
-    );
+    expect(labels).toEqual(['Admin Actions']);
+    expect(JSON.stringify(sendArgs.components[0])).toContain('admin_actions:menu:case:user-1');
   });
 
   it('hides the ban action when explicitly disabled', async () => {
@@ -396,10 +396,7 @@ describe('NotificationManager (unit)', () => {
     });
     expect(sendArgs.components).toHaveLength(1);
     expect(JSON.stringify(sendArgs.components[0])).toContain(
-      `observed:open:user-1:${detectionEvent.id}`
-    );
-    expect(JSON.stringify(sendArgs.components[0])).toContain(
-      `observed:dismiss_menu:user-1:${detectionEvent.id}`
+      `admin_actions:menu:observed:user-1:${detectionEvent.id}`
     );
     expect(sendArgs.embeds[0].data.title).toBe('Suspicious Activity Observed');
     const fields = sendArgs.embeds[0].data.fields ?? [];
@@ -600,7 +597,7 @@ describe('NotificationManager (unit)', () => {
     );
 
     const editArgs = message.edit.mock.calls[0][0] as { components: unknown[] };
-    expect(extractLabels(editArgs.components)).toEqual(['Undo False Positive', 'History']);
+    expect(extractLabels(editArgs.components)).toEqual(['Admin Actions']);
   });
 
   it('restores observed action buttons after undo', async () => {
@@ -637,13 +634,7 @@ describe('NotificationManager (unit)', () => {
       components: unknown[];
       embeds: EmbedBuilder[];
     };
-    expect(extractLabels(editArgs.components)).toEqual([
-      'Open Case',
-      'Restrict',
-      'Ban',
-      'Dismiss...',
-      'History',
-    ]);
+    expect(extractLabels(editArgs.components)).toEqual(['Admin Actions']);
     expect(editArgs.embeds[0].data.fields?.[0].name).toBe('Action Reverted');
   });
 
@@ -723,8 +714,7 @@ describe('NotificationManager (unit)', () => {
     expect(editArgs.content).toBeUndefined();
     expect(editArgs.allowedMentions).toEqual({ parse: [] });
     const labels = extractLabels(editArgs.components);
-    expect(labels).toEqual(expect.arrayContaining(['Verify User', 'Ban User']));
-    expect(labels).not.toContain('Create Thread');
+    expect(labels).toEqual(['Admin Actions']);
   });
 
   it('updates notification buttons for pending status with thread action', async () => {
@@ -746,9 +736,7 @@ describe('NotificationManager (unit)', () => {
     expect(message.edit).toHaveBeenCalledTimes(1);
     const editArgs = message.edit.mock.calls[0][0] as { components: unknown[] };
     const labels = extractLabels(editArgs.components);
-    expect(labels).toEqual(
-      expect.arrayContaining(['Verify User', 'Ban User', 'View Full History', 'Create Thread'])
-    );
+    expect(labels).toEqual(['Admin Actions']);
   });
 
   it('updates notification buttons for verified status', async () => {
@@ -765,9 +753,7 @@ describe('NotificationManager (unit)', () => {
     expect(message.edit).toHaveBeenCalledTimes(1);
     const editArgs = message.edit.mock.calls[0][0] as { components: unknown[] };
     const labels = extractLabels(editArgs.components);
-    expect(labels).toEqual(expect.arrayContaining(['View Full History', 'Reopen Verification']));
-    expect(labels).not.toContain('Verify User');
-    expect(labels).not.toContain('Ban User');
+    expect(labels).toEqual(['Admin Actions']);
   });
 
   it('logs action and adds a thread field for create thread', async () => {
@@ -793,11 +779,15 @@ describe('NotificationManager (unit)', () => {
 
     const editArgs = message.edit.mock.calls[0][0] as { embeds: EmbedBuilder[] };
     const fields = editArgs.embeds[0].data.fields ?? [];
+    const latestAction = fields.find((field) => field.name === 'Latest Admin Action');
     const threadField = fields.find((field) => field.name === 'Verification Thread');
     const actionLog = fields.find((field) => field.name === 'Action Log');
 
+    expect(latestAction?.value).toContain('Created verification thread by <@admin-1> at <t:');
+    expect(latestAction?.value).toContain(':F>');
     expect(threadField?.value).toContain('Click here to view the thread');
-    expect(actionLog?.value).toContain('<@admin-1>');
+    expect(actionLog?.value).toContain('Created verification thread by <@admin-1> at <t:');
+    expect(actionLog?.value).toContain(':F>');
   });
 
   it('updates the admin notification with AI thread analysis details', async () => {

--- a/src/__tests__/unit/NotificationManager.unit.test.ts
+++ b/src/__tests__/unit/NotificationManager.unit.test.ts
@@ -20,6 +20,7 @@ import {
 import { IConfigService } from '../../config/ConfigService';
 import { VERIFICATION_ACTION_FAILURES_METADATA_KEY } from '../../utils/verificationActionFailures';
 import { MODERATOR_BAN_ACTION_ENABLED_SETTING_KEY } from '../../utils/detectionResponseSettings';
+import { parseAdminActionCustomId } from '../../utils/adminActionCustomIds';
 
 type MockTextChannel = {
   send: jest.Mock;
@@ -101,6 +102,14 @@ const extractLabels = (components: unknown[]): string[] => {
   );
 };
 
+const extractCustomIds = (components: unknown[]): string[] => {
+  return components.flatMap((row) =>
+    ((row as { components?: unknown[] }).components ?? []).map(
+      (button) => (button as { data?: { custom_id?: string } }).data?.custom_id ?? ''
+    )
+  );
+};
+
 describe('NotificationManager (unit)', () => {
   let detectionRepository: InMemoryDetectionEventsRepository;
   let adminChannel: MockTextChannel;
@@ -172,7 +181,11 @@ describe('NotificationManager (unit)', () => {
     });
     const labels = extractLabels(sendArgs.components);
     expect(labels).toEqual(['Admin Actions']);
-    expect(JSON.stringify(sendArgs.components[0])).toContain('admin_actions:menu:case:user-1');
+    expect(parseAdminActionCustomId(extractCustomIds(sendArgs.components)[0])).toEqual({
+      action: 'menu',
+      surface: 'case',
+      userId: 'user-1',
+    });
   });
 
   it('hides the ban action when explicitly disabled', async () => {
@@ -395,9 +408,12 @@ describe('NotificationManager (unit)', () => {
       repliedUser: false,
     });
     expect(sendArgs.components).toHaveLength(1);
-    expect(JSON.stringify(sendArgs.components[0])).toContain(
-      `admin_actions:menu:observed:user-1:${detectionEvent.id}`
-    );
+    expect(parseAdminActionCustomId(extractCustomIds(sendArgs.components)[0])).toEqual({
+      action: 'menu',
+      surface: 'observed',
+      userId: 'user-1',
+      detectionEventId: detectionEvent.id,
+    });
     expect(sendArgs.embeds[0].data.title).toBe('Suspicious Activity Observed');
     const fields = sendArgs.embeds[0].data.fields ?? [];
     const reasonsField = fields.find((field) => field.name === 'Reasons');

--- a/src/__tests__/unit/NotificationManager.unit.test.ts
+++ b/src/__tests__/unit/NotificationManager.unit.test.ts
@@ -608,8 +608,7 @@ describe('NotificationManager (unit)', () => {
     await manager.markObservedDetectionActionTaken(
       detectionEvent.id,
       'marked this detection as a false positive',
-      { id: 'admin-1' } as User,
-      { undoButtonLabel: 'Undo False Positive' }
+      { id: 'admin-1' } as User
     );
 
     const editArgs = message.edit.mock.calls[0][0] as { components: unknown[] };

--- a/src/__tests__/unit/SecurityActionService.unit.test.ts
+++ b/src/__tests__/unit/SecurityActionService.unit.test.ts
@@ -1924,8 +1924,7 @@ describe('SecurityActionService (unit)', () => {
     expect(notificationManager.markObservedDetectionActionTaken).toHaveBeenCalledWith(
       detectionEvent.id,
       'marked this detection as a false positive',
-      moderator,
-      { undoButtonLabel: 'Undo False Positive' }
+      moderator
     );
   });
 

--- a/src/__tests__/unit/SecurityActionService.unit.test.ts
+++ b/src/__tests__/unit/SecurityActionService.unit.test.ts
@@ -82,6 +82,10 @@ describe('SecurityActionService (unit)', () => {
       createReportReviewThread: jest
         .fn()
         .mockResolvedValue({ id: 'thread-1', url: 'https://discord.com/channels/thread-1' } as any),
+      createPrivateEvidenceThread: jest.fn().mockResolvedValue({
+        id: 'evidence-1',
+        url: 'https://discord.com/channels/evidence-1',
+      } as any),
       createReportIntakeThread: jest.fn().mockResolvedValue({} as any),
       activateReportIntakeThread: jest.fn().mockResolvedValue(true),
       resolveVerificationThread: jest.fn().mockResolvedValue(true),
@@ -104,6 +108,7 @@ describe('SecurityActionService (unit)', () => {
       }),
       verifyUser: jest.fn().mockResolvedValue(true),
       banUser: jest.fn().mockResolvedValue(true),
+      syncAlreadyBannedUser: jest.fn().mockResolvedValue(1),
     };
 
     adminActionService = {

--- a/src/__tests__/unit/ThreadManager.unit.test.ts
+++ b/src/__tests__/unit/ThreadManager.unit.test.ts
@@ -38,6 +38,7 @@ const buildVerificationEvent = (overrides: Partial<VerificationEvent> = {}): Ver
   user_id: overrides.user_id ?? 'user-1',
   detection_event_id: overrides.detection_event_id ?? null,
   thread_id: overrides.thread_id ?? null,
+  private_evidence_thread_id: overrides.private_evidence_thread_id ?? null,
   notification_message_id: overrides.notification_message_id ?? null,
   status: overrides.status ?? VerificationStatus.PENDING,
   created_at: overrides.created_at ?? new Date(),

--- a/src/__tests__/unit/UserModerationService.unit.test.ts
+++ b/src/__tests__/unit/UserModerationService.unit.test.ts
@@ -30,6 +30,17 @@ const buildMember = (guildId: string, userId: string): GuildMember =>
     ban: jest.fn().mockResolvedValue(undefined),
   }) as unknown as GuildMember;
 
+const buildGuildWithBan = (guildId: string, userId: string, reason?: string): Guild =>
+  ({
+    id: guildId,
+    bans: {
+      fetch: jest.fn().mockResolvedValue({
+        reason,
+        user: { id: userId, tag: 'test-user#0001' },
+      }),
+    },
+  }) as unknown as Guild;
+
 describe('UserModerationService (unit)', () => {
   let serverMemberRepository: InMemoryServerMemberRepository;
   let verificationEventRepository: InMemoryVerificationEventRepository;
@@ -72,6 +83,7 @@ describe('UserModerationService (unit)', () => {
     threadManager = {
       createVerificationThread: jest.fn().mockResolvedValue({} as any),
       createReportReviewThread: jest.fn().mockResolvedValue({} as any),
+      createPrivateEvidenceThread: jest.fn().mockResolvedValue({} as any),
       createReportIntakeThread: jest.fn().mockResolvedValue({} as any),
       activateReportIntakeThread: jest.fn().mockResolvedValue(true),
       resolveVerificationThread: jest.fn().mockResolvedValue(true),
@@ -203,6 +215,140 @@ describe('UserModerationService (unit)', () => {
     );
     expect(notificationManager.logActionToMessage).toHaveBeenCalled();
     expect(notificationManager.updateNotificationButtons).toHaveBeenCalled();
+  });
+
+  it('bans all duplicate pending cases for a user', async () => {
+    const guildId = 'guild-ban-duplicates';
+    const userId = 'user-ban-duplicates';
+    const moderator = { id: 'mod-ban' } as User;
+    const member = buildMember(guildId, userId);
+
+    await serverRepository.getOrCreateServer(guildId);
+    await userRepository.getOrCreateUser(userId, 'test-user');
+
+    const firstDetection = await detectionEventsRepository.create({
+      server_id: guildId,
+      user_id: userId,
+      detection_type: DetectionType.SUSPICIOUS_CONTENT,
+      confidence: 0.8,
+      reasons: ['Initial detection'],
+      detected_at: new Date(),
+    });
+    const secondDetection = await detectionEventsRepository.create({
+      server_id: guildId,
+      user_id: userId,
+      detection_type: DetectionType.GPT_ANALYSIS,
+      confidence: 0.9,
+      reasons: ['Manual follow-up'],
+      detected_at: new Date(),
+    });
+    const firstCase = await verificationEventRepository.createFromDetection(
+      firstDetection.id,
+      guildId,
+      userId,
+      VerificationStatus.PENDING
+    );
+    const secondCase = await verificationEventRepository.createFromDetection(
+      secondDetection.id,
+      guildId,
+      userId,
+      VerificationStatus.PENDING
+    );
+
+    const service = new UserModerationService(
+      serverMemberRepository,
+      notificationManager,
+      roleManager,
+      verificationEventRepository,
+      adminActionService,
+      threadManager
+    );
+
+    await service.banUser(member, 'banned duplicate cases', moderator);
+
+    await expect(verificationEventRepository.findById(firstCase.id)).resolves.toEqual(
+      expect.objectContaining({ status: VerificationStatus.BANNED, resolved_by: moderator.id })
+    );
+    await expect(verificationEventRepository.findById(secondCase.id)).resolves.toEqual(
+      expect.objectContaining({ status: VerificationStatus.BANNED, resolved_by: moderator.id })
+    );
+    const pendingCases = (
+      await verificationEventRepository.findByUserAndServer(userId, guildId)
+    ).filter((event) => event.status === VerificationStatus.PENDING);
+    expect(pendingCases).toHaveLength(0);
+    expect(threadManager.resolveVerificationThread).toHaveBeenCalledTimes(2);
+    const adminActions = await adminActionRepository.findByUserAndServer(userId, guildId);
+    expect(adminActions).toHaveLength(2);
+    expect(adminActions.map((action) => action.verification_event_id).sort()).toEqual(
+      [firstCase.id, secondCase.id].sort()
+    );
+  });
+
+  it('syncs all duplicate pending cases for a user Discord already banned', async () => {
+    const guildId = 'guild-sync-ban-duplicates';
+    const userId = 'user-sync-ban-duplicates';
+    const moderator = { id: 'mod-ban' } as User;
+    const guild = buildGuildWithBan(guildId, userId, 'existing Discord ban');
+
+    await serverRepository.getOrCreateServer(guildId);
+    await userRepository.getOrCreateUser(userId, 'test-user');
+
+    const firstDetection = await detectionEventsRepository.create({
+      server_id: guildId,
+      user_id: userId,
+      detection_type: DetectionType.SUSPICIOUS_CONTENT,
+      confidence: 0.8,
+      reasons: ['Initial detection'],
+      detected_at: new Date(),
+    });
+    const secondDetection = await detectionEventsRepository.create({
+      server_id: guildId,
+      user_id: userId,
+      detection_type: DetectionType.GPT_ANALYSIS,
+      confidence: 0.9,
+      reasons: ['Manual follow-up'],
+      detected_at: new Date(),
+    });
+    const firstCase = await verificationEventRepository.createFromDetection(
+      firstDetection.id,
+      guildId,
+      userId,
+      VerificationStatus.PENDING
+    );
+    const secondCase = await verificationEventRepository.createFromDetection(
+      secondDetection.id,
+      guildId,
+      userId,
+      VerificationStatus.PENDING
+    );
+
+    const service = new UserModerationService(
+      serverMemberRepository,
+      notificationManager,
+      roleManager,
+      verificationEventRepository,
+      adminActionService,
+      threadManager
+    );
+
+    await expect(service.syncAlreadyBannedUser(guild, userId, moderator)).resolves.toBe(2);
+
+    await expect(verificationEventRepository.findById(firstCase.id)).resolves.toEqual(
+      expect.objectContaining({ status: VerificationStatus.BANNED, resolved_by: moderator.id })
+    );
+    await expect(verificationEventRepository.findById(secondCase.id)).resolves.toEqual(
+      expect.objectContaining({ status: VerificationStatus.BANNED, resolved_by: moderator.id })
+    );
+    const serverMember = await serverMemberRepository.findByServerAndUser(guildId, userId);
+    expect(serverMember?.verification_status).toBe(VerificationStatus.BANNED);
+    expect(serverMember?.is_restricted).toBe(true);
+    expect(threadManager.resolveVerificationThread).toHaveBeenCalledTimes(2);
+    const adminActions = await adminActionRepository.findByUserAndServer(userId, guildId);
+    expect(adminActions).toHaveLength(2);
+    expect(adminActions.map((action) => action.notes)).toEqual([
+      'Synced existing Discord ban: existing Discord ban',
+      'Synced existing Discord ban: existing Discord ban',
+    ]);
   });
 
   it('returns success when post-ban notification updates fail', async () => {

--- a/src/__tests__/unit/VerificationHistoryFormatter.unit.test.ts
+++ b/src/__tests__/unit/VerificationHistoryFormatter.unit.test.ts
@@ -31,6 +31,7 @@ const buildEvent = (
   user_id: 'user-1',
   detection_event_id: null,
   thread_id: 'thread-1',
+  private_evidence_thread_id: null,
   notification_message_id: 'notif-1',
   status: VerificationStatus.VERIFIED,
   created_at: new Date('2024-01-01T00:00:00.000Z'),

--- a/src/__tests__/unit/adminActionCustomIds.unit.test.ts
+++ b/src/__tests__/unit/adminActionCustomIds.unit.test.ts
@@ -1,0 +1,26 @@
+import {
+  buildAdminActionCustomId,
+  parseAdminActionCustomId,
+} from '../../utils/adminActionCustomIds';
+
+describe('adminActionCustomIds (unit)', () => {
+  it('keeps observed confirmation IDs under Discord custom_id limits', () => {
+    const userId = '1234567890123456789';
+    const detectionEventId = '12345678-1234-1234-1234-123456789012';
+
+    const customId = buildAdminActionCustomId(
+      'confirm_observed_false_positive',
+      'observed',
+      userId,
+      detectionEventId
+    );
+
+    expect(customId.length).toBeLessThanOrEqual(100);
+    expect(parseAdminActionCustomId(customId)).toEqual({
+      action: 'confirm_observed_false_positive',
+      surface: 'observed',
+      userId,
+      detectionEventId,
+    });
+  });
+});

--- a/src/__tests__/unit/caseReviewReminderSettings.unit.test.ts
+++ b/src/__tests__/unit/caseReviewReminderSettings.unit.test.ts
@@ -1,0 +1,25 @@
+import { getCaseReviewReminderSettings } from '../../utils/caseReviewReminderSettings';
+
+describe('caseReviewReminderSettings (unit)', () => {
+  it('defaults reminders off with conservative intervals', () => {
+    expect(getCaseReviewReminderSettings({})).toEqual({
+      enabled: false,
+      staleHours: 24,
+      repeatHours: 24,
+    });
+  });
+
+  it('coerces configured hours into safe bounds', () => {
+    expect(
+      getCaseReviewReminderSettings({
+        case_review_reminders_enabled: true,
+        case_review_reminder_stale_hours: 0,
+        case_review_reminder_repeat_hours: 999,
+      })
+    ).toEqual({
+      enabled: true,
+      staleHours: 1,
+      repeatHours: 168,
+    });
+  });
+});

--- a/src/controllers/CommandHandler.ts
+++ b/src/controllers/CommandHandler.ts
@@ -133,6 +133,14 @@ import {
   RESTRICTED_LOCKDOWN_ALLOWED_CHANNEL_IDS_SETTING_KEY,
   RESTRICTED_LOCKDOWN_ENABLED_SETTING_KEY,
 } from '../utils/restrictedLockdownSettings';
+import {
+  CASE_REVIEW_REMINDER_REPEAT_HOURS_SETTING_KEY,
+  CASE_REVIEW_REMINDER_STALE_HOURS_SETTING_KEY,
+  CASE_REVIEW_REMINDERS_ENABLED_SETTING_KEY,
+  getCaseReviewReminderSettings,
+  MAX_CASE_REVIEW_REMINDER_HOURS,
+  MIN_CASE_REVIEW_REMINDER_HOURS,
+} from '../utils/caseReviewReminderSettings';
 import 'reflect-metadata';
 
 // Load environment variables
@@ -690,6 +698,46 @@ export class CommandHandler implements ICommandHandler {
                     .setRequired(true)
                     .setMinValue(1)
                     .setMaxValue(MAX_CASE_RESPONDER_THREAD_MEMBER_CAP)
+                )
+            )
+        )
+        .addSubcommandGroup((group) =>
+          group
+            .setName('case-review')
+            .setDescription('Manage stale case review reminders')
+            .addSubcommand((subcommand) =>
+              subcommand.setName('view').setDescription('View stale case review reminder settings')
+            )
+            .addSubcommand((subcommand) =>
+              subcommand.setName('enable').setDescription('Enable stale case review reminders')
+            )
+            .addSubcommand((subcommand) =>
+              subcommand.setName('disable').setDescription('Disable stale case review reminders')
+            )
+            .addSubcommand((subcommand) =>
+              subcommand
+                .setName('set-stale-hours')
+                .setDescription('Set how old a pending case must be before reminder')
+                .addIntegerOption((option) =>
+                  option
+                    .setName('hours')
+                    .setDescription('Hours before a pending case is stale')
+                    .setRequired(true)
+                    .setMinValue(MIN_CASE_REVIEW_REMINDER_HOURS)
+                    .setMaxValue(MAX_CASE_REVIEW_REMINDER_HOURS)
+                )
+            )
+            .addSubcommand((subcommand) =>
+              subcommand
+                .setName('set-repeat-hours')
+                .setDescription('Set minimum hours between repeated stale reminders')
+                .addIntegerOption((option) =>
+                  option
+                    .setName('hours')
+                    .setDescription('Hours between repeat reminders')
+                    .setRequired(true)
+                    .setMinValue(MIN_CASE_REVIEW_REMINDER_HOURS)
+                    .setMaxValue(MAX_CASE_REVIEW_REMINDER_HOURS)
                 )
             )
         )
@@ -2169,6 +2217,11 @@ export class CommandHandler implements ICommandHandler {
       return;
     }
 
+    if (subcommandGroup === 'case-review') {
+      await this.handleCaseReviewConfigCommand(interaction, guild.id);
+      return;
+    }
+
     if (subcommandGroup === 'report') {
       await this.handleReportConfigCommand(interaction, guild.id);
       return;
@@ -3322,6 +3375,101 @@ export class CommandHandler implements ICommandHandler {
         flags: MessageFlags.Ephemeral,
       });
     }
+  }
+
+  private async handleCaseReviewConfigCommand(
+    interaction: ChatInputCommandInteraction,
+    guildId: string
+  ): Promise<void> {
+    const subcommand = interaction.options.getSubcommand(true);
+
+    try {
+      switch (subcommand) {
+        case 'view': {
+          const serverConfig = await this.configService.getServerConfig(guildId);
+          const settings = getCaseReviewReminderSettings(serverConfig.settings);
+          await interaction.reply({
+            content:
+              'Current stale case review reminder settings:\n\n' +
+              this.formatCaseReviewReminderSettings(settings),
+            flags: MessageFlags.Ephemeral,
+          });
+          return;
+        }
+
+        case 'enable':
+        case 'disable': {
+          const enabled = subcommand === 'enable';
+          const updated = await this.configService.updateServerSettings(guildId, {
+            [CASE_REVIEW_REMINDERS_ENABLED_SETTING_KEY]: enabled,
+          });
+          const settings = getCaseReviewReminderSettings(updated.settings);
+          await interaction.reply({
+            content:
+              `${enabled ? 'Enabled' : 'Disabled'} stale case review reminders.\n\n` +
+              this.formatCaseReviewReminderSettings(settings),
+            flags: MessageFlags.Ephemeral,
+          });
+          return;
+        }
+
+        case 'set-stale-hours': {
+          const hours = interaction.options.getInteger('hours', true);
+          const updated = await this.configService.updateServerSettings(guildId, {
+            [CASE_REVIEW_REMINDER_STALE_HOURS_SETTING_KEY]: hours,
+          });
+          const settings = getCaseReviewReminderSettings(updated.settings);
+          await interaction.reply({
+            content:
+              'Updated stale case reminder threshold.\n\n' +
+              this.formatCaseReviewReminderSettings(settings),
+            flags: MessageFlags.Ephemeral,
+          });
+          return;
+        }
+
+        case 'set-repeat-hours': {
+          const hours = interaction.options.getInteger('hours', true);
+          const updated = await this.configService.updateServerSettings(guildId, {
+            [CASE_REVIEW_REMINDER_REPEAT_HOURS_SETTING_KEY]: hours,
+          });
+          const settings = getCaseReviewReminderSettings(updated.settings);
+          await interaction.reply({
+            content:
+              'Updated stale case reminder repeat interval.\n\n' +
+              this.formatCaseReviewReminderSettings(settings),
+            flags: MessageFlags.Ephemeral,
+          });
+          return;
+        }
+
+        default:
+          await interaction.reply({
+            content: 'Unsupported case-review subcommand.',
+            flags: MessageFlags.Ephemeral,
+          });
+      }
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error
+          ? error.message
+          : 'An error occurred while processing case review settings.';
+      await interaction.reply({
+        content: `Failed to process case review settings: ${errorMessage}`,
+        flags: MessageFlags.Ephemeral,
+      });
+    }
+  }
+
+  private formatCaseReviewReminderSettings(
+    settings: ReturnType<typeof getCaseReviewReminderSettings>
+  ): string {
+    return [
+      `Enabled: \`${settings.enabled ? 'yes' : 'no'}\``,
+      `Stale threshold: \`${settings.staleHours}h\``,
+      `Repeat interval: \`${settings.repeatHours}h\``,
+      'Reminders post to the admin channel and mention configured case responder roles.',
+    ].join('\n');
   }
 
   private async handleReportConfigCommand(

--- a/src/controllers/EventHandler.ts
+++ b/src/controllers/EventHandler.ts
@@ -36,6 +36,7 @@ import {
   SetupDiagnosticReport,
 } from '../services/SetupDiagnosticsService';
 import { IReportIntakeService } from '../services/ReportIntakeService';
+import { ICaseReviewReminderService } from '../services/CaseReviewReminderService';
 
 const RECENT_USER_CONTEXT_MESSAGE_LIMIT = 5;
 const RECENT_USER_CONTEXT_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
@@ -98,6 +99,7 @@ export class EventHandler implements IEventHandler {
   private productAnalyticsService: IProductAnalyticsService;
   private setupDiagnosticsService?: ISetupDiagnosticsService;
   private reportIntakeService?: IReportIntakeService;
+  private caseReviewReminderService?: ICaseReviewReminderService;
   private serverConfigWarmups: Set<string> = new Set();
   private configInitializePromise: Promise<void> | null = null;
   private recentMessagesByServer: Map<string, Map<string, RecentUserMessageContext[]>> = new Map();
@@ -121,7 +123,10 @@ export class EventHandler implements IEventHandler {
     setupDiagnosticsService?: ISetupDiagnosticsService,
     @inject(TYPES.ReportIntakeService)
     @optional()
-    reportIntakeService?: IReportIntakeService
+    reportIntakeService?: IReportIntakeService,
+    @inject(TYPES.CaseReviewReminderService)
+    @optional()
+    caseReviewReminderService?: ICaseReviewReminderService
   ) {
     this.client = client;
     this.detectionOrchestrator = detectionOrchestrator;
@@ -134,6 +139,7 @@ export class EventHandler implements IEventHandler {
     this.productAnalyticsService = productAnalyticsService ?? NOOP_PRODUCT_ANALYTICS_SERVICE;
     this.setupDiagnosticsService = setupDiagnosticsService;
     this.reportIntakeService = reportIntakeService;
+    this.caseReviewReminderService = caseReviewReminderService;
   }
 
   public async setupEventHandlers(): Promise<void> {
@@ -156,6 +162,7 @@ export class EventHandler implements IEventHandler {
     await this.ensureConfigInitialized();
 
     await this.commandHandler.registerCommands();
+    this.caseReviewReminderService?.start();
   }
 
   private async handleInteraction(interaction: Interaction): Promise<void> {

--- a/src/controllers/InteractionHandler.ts
+++ b/src/controllers/InteractionHandler.ts
@@ -55,6 +55,12 @@ import {
   SETUP_VERIFICATION_MODAL_ID,
   SETUP_VERIFICATION_RESTRICTED_ROLE_FIELD_ID,
 } from '../constants/setupVerificationWizard';
+import {
+  ADMIN_ACTION_CUSTOM_ID_PREFIX,
+  buildAdminActionCustomId,
+  parseAdminActionCustomId,
+  type ParsedAdminActionCustomId,
+} from '../utils/adminActionCustomIds';
 // Load environment variables
 dotenv.config();
 
@@ -154,6 +160,11 @@ export class InteractionHandler implements IInteractionHandler {
         return;
       }
 
+      if (customId.startsWith(`${ADMIN_ACTION_CUSTOM_ID_PREFIX}:`)) {
+        await this.handleAdminActionsButtonInteraction(interaction, guildId, customId);
+        return;
+      }
+
       if (customId.startsWith('observed:')) {
         await this.handleObservedButtonInteraction(interaction, guildId, customId);
         return;
@@ -179,7 +190,11 @@ export class InteractionHandler implements IInteractionHandler {
             );
             return;
           }
-          await this.handleVerifyButton(interaction, guildId, targetUserId);
+          await this.showLegacyAdminActionConfirmation(interaction, {
+            action: 'verify',
+            surface: 'case',
+            userId: targetUserId,
+          });
           break;
         case 'ban':
           if (
@@ -211,7 +226,11 @@ export class InteractionHandler implements IInteractionHandler {
             );
             return;
           }
-          await this.handleThreadButton(interaction, guildId, targetUserId);
+          await this.showLegacyAdminActionConfirmation(interaction, {
+            action: 'thread',
+            surface: 'case',
+            userId: targetUserId,
+          });
           break;
         case 'history':
           if (
@@ -235,7 +254,11 @@ export class InteractionHandler implements IInteractionHandler {
             );
             return;
           }
-          await this.handleReopenButton(interaction, guildId, targetUserId);
+          await this.showLegacyAdminActionConfirmation(interaction, {
+            action: 'reopen',
+            surface: 'case',
+            userId: targetUserId,
+          });
           break;
         default:
           await interaction.reply({
@@ -254,6 +277,617 @@ export class InteractionHandler implements IInteractionHandler {
       } else {
         await interaction.reply(response);
       }
+    }
+  }
+
+  private async handleAdminActionsButtonInteraction(
+    interaction: ButtonInteraction,
+    guildId: string,
+    customId: string
+  ): Promise<void> {
+    const parsed = parseAdminActionCustomId(customId);
+    if (!parsed) {
+      await interaction.reply({
+        content: 'Unknown admin action.',
+        flags: MessageFlags.Ephemeral,
+      });
+      return;
+    }
+
+    if (parsed.action === 'cancel') {
+      await interaction.update({ content: 'Cancelled.', components: [] });
+      return;
+    }
+
+    if (parsed.action === 'menu') {
+      await this.showAdminActionsMenu(interaction, guildId, parsed);
+      return;
+    }
+
+    if (parsed.action === 'history') {
+      if (!(await this.hasAnyPermission(interaction, guildId, this.getModerationPermissions()))) {
+        await this.replyPermissionDenied(
+          interaction,
+          'You need moderation permissions to view history.'
+        );
+        return;
+      }
+      if (parsed.surface === 'observed') {
+        await this.notificationManager.handleHistoryButtonClick(interaction, parsed.userId);
+      } else {
+        await this.handleHistoryButton(interaction, guildId, parsed.userId);
+      }
+      return;
+    }
+
+    if (parsed.action === 'ban' || parsed.action === 'observed_ban') {
+      await this.handleAdminActionBan(interaction, guildId, parsed);
+      return;
+    }
+
+    if (parsed.action.startsWith('confirm_')) {
+      await this.executeConfirmedAdminAction(interaction, guildId, parsed);
+      return;
+    }
+
+    const confirmation = this.getAdminActionConfirmation(parsed);
+    if (!confirmation) {
+      await interaction.reply({
+        content: 'Unknown admin action.',
+        flags: MessageFlags.Ephemeral,
+      });
+      return;
+    }
+
+    await this.showAdminActionConfirmation(interaction, parsed, confirmation);
+  }
+
+  private async showAdminActionsMenu(
+    interaction: ButtonInteraction,
+    guildId: string,
+    parsed: ParsedAdminActionCustomId
+  ): Promise<void> {
+    const hasModerationPermission = await this.hasAnyPermission(
+      interaction,
+      guildId,
+      this.getModerationPermissions()
+    );
+    const hasBanMembersPermission = await this.hasAnyPermission(interaction, guildId, [
+      PermissionFlagsBits.BanMembers,
+    ]);
+
+    if (!hasModerationPermission && !hasBanMembersPermission) {
+      await this.replyPermissionDenied(
+        interaction,
+        'You need moderation permissions to use admin actions.'
+      );
+      return;
+    }
+
+    if (parsed.surface === 'observed') {
+      await this.showObservedAdminActionsMenu(interaction, guildId, parsed, {
+        hasModerationPermission,
+        hasBanMembersPermission,
+      });
+      return;
+    }
+
+    const activeCase = await this.verificationEventRepository.findActiveByUserAndServer(
+      parsed.userId,
+      guildId
+    );
+    const history = await this.verificationEventRepository.findByUserAndServer(
+      parsed.userId,
+      guildId
+    );
+    const pendingCases = history.filter((event) => event.status === VerificationStatus.PENDING);
+    const latestHistoryCase = history.length > 0 ? history[0] : null;
+    const latestCase = activeCase ?? latestHistoryCase;
+    const alreadyBanned =
+      activeCase?.status === VerificationStatus.PENDING && hasBanMembersPermission
+        ? await this.isUserBanned(guildId, parsed.userId)
+        : false;
+    const canBan =
+      hasBanMembersPermission && !alreadyBanned && (await this.canUseModeratorBanAction(guildId));
+
+    const buttons: ButtonBuilder[] = [];
+    if (hasModerationPermission) {
+      buttons.push(this.adminActionButton(parsed, 'history', 'History', ButtonStyle.Secondary));
+    }
+
+    if (activeCase?.status === VerificationStatus.PENDING) {
+      if (hasModerationPermission) {
+        buttons.push(
+          this.adminActionButton(parsed, 'verify', 'Verify User', ButtonStyle.Success),
+          this.adminActionButton(parsed, 'repair', 'Repair Active Case', ButtonStyle.Primary)
+        );
+        if (!activeCase.thread_id) {
+          buttons.push(
+            this.adminActionButton(parsed, 'thread', 'Create Thread', ButtonStyle.Primary)
+          );
+        }
+      }
+      if (alreadyBanned) {
+        buttons.push(
+          this.adminActionButton(parsed, 'sync_ban', 'Sync Existing Ban', ButtonStyle.Danger)
+        );
+      }
+      if (canBan) {
+        buttons.push(this.adminActionButton(parsed, 'ban', 'Ban User...', ButtonStyle.Danger));
+      }
+    } else if (latestCase && hasModerationPermission) {
+      buttons.push(
+        this.adminActionButton(parsed, 'reopen', 'Reopen Verification', ButtonStyle.Primary)
+      );
+    }
+
+    const details = [
+      `Admin actions for <@${parsed.userId}>.`,
+      'Mutating actions require a confirmation step before they run.',
+    ];
+    if (activeCase?.thread_id) {
+      details.push(`Case thread: https://discord.com/channels/${guildId}/${activeCase.thread_id}`);
+    }
+    if (activeCase?.private_evidence_thread_id) {
+      details.push(
+        `Private evidence: https://discord.com/channels/${guildId}/${activeCase.private_evidence_thread_id}`
+      );
+    }
+    if (alreadyBanned) {
+      details.push(
+        'Discord already shows this user as banned. Use Sync Existing Ban to resolve pending case rows without attempting another ban.'
+      );
+    }
+    if (pendingCases.length > 1) {
+      details.push(
+        `Warning: ${pendingCases.length} pending cases exist for this user. Terminal actions will resolve all pending case rows.`
+      );
+      details.push(
+        ...pendingCases
+          .slice(0, 5)
+          .map(
+            (event) =>
+              `Pending case ${event.id}${event.thread_id ? `: https://discord.com/channels/${guildId}/${event.thread_id}` : ''}`
+          )
+      );
+    }
+    if (buttons.length === 0) {
+      details.push('No available actions for your current permissions and this case state.');
+    }
+
+    await interaction.reply({
+      content: details.join('\n'),
+      allowedMentions: { parse: [] },
+      components: this.createButtonRows(buttons),
+      flags: MessageFlags.Ephemeral,
+    });
+  }
+
+  private async showObservedAdminActionsMenu(
+    interaction: ButtonInteraction,
+    guildId: string,
+    parsed: ParsedAdminActionCustomId,
+    permissions: { hasModerationPermission: boolean; hasBanMembersPermission: boolean }
+  ): Promise<void> {
+    if (!parsed.detectionEventId) {
+      await interaction.reply({
+        content: 'This observed action is missing its detection event.',
+        flags: MessageFlags.Ephemeral,
+      });
+      return;
+    }
+
+    const canBan =
+      permissions.hasBanMembersPermission && (await this.canUseModeratorBanAction(guildId));
+    const buttons: ButtonBuilder[] = [];
+    if (permissions.hasModerationPermission) {
+      buttons.push(
+        this.adminActionButton(parsed, 'observed_open', 'Open Case', ButtonStyle.Primary),
+        this.adminActionButton(parsed, 'observed_restrict', 'Restrict', ButtonStyle.Danger),
+        this.adminActionButton(parsed, 'observed_dismiss', 'Dismiss Alert', ButtonStyle.Secondary),
+        this.adminActionButton(
+          parsed,
+          'observed_false_positive',
+          'False Positive',
+          ButtonStyle.Success
+        ),
+        this.adminActionButton(
+          parsed,
+          'observed_undo_dismiss',
+          'Undo Dismissal',
+          ButtonStyle.Primary
+        ),
+        this.adminActionButton(parsed, 'history', 'History', ButtonStyle.Secondary)
+      );
+    }
+    if (canBan) {
+      if (permissions.hasModerationPermission) {
+        buttons.splice(
+          2,
+          0,
+          this.adminActionButton(parsed, 'observed_ban', 'Ban...', ButtonStyle.Danger)
+        );
+      } else {
+        buttons.push(this.adminActionButton(parsed, 'observed_ban', 'Ban...', ButtonStyle.Danger));
+      }
+    }
+
+    await interaction.reply({
+      content:
+        `Admin actions for observed alert on <@${parsed.userId}>.\nMutating actions require a confirmation step before they run.` +
+        (buttons.length === 0
+          ? '\nNo available actions for your current permissions and this alert state.'
+          : ''),
+      allowedMentions: { parse: [] },
+      components: this.createButtonRows(buttons),
+      flags: MessageFlags.Ephemeral,
+    });
+  }
+
+  private adminActionButton(
+    parsed: ParsedAdminActionCustomId,
+    action: string,
+    label: string,
+    style: ButtonStyle
+  ): ButtonBuilder {
+    return new ButtonBuilder()
+      .setCustomId(
+        buildAdminActionCustomId(action, parsed.surface, parsed.userId, parsed.detectionEventId)
+      )
+      .setLabel(label)
+      .setStyle(style);
+  }
+
+  private createButtonRows(buttons: ButtonBuilder[]): ActionRowBuilder<ButtonBuilder>[] {
+    const rows: ActionRowBuilder<ButtonBuilder>[] = [];
+    for (let index = 0; index < buttons.length; index += 5) {
+      rows.push(
+        new ActionRowBuilder<ButtonBuilder>().addComponents(...buttons.slice(index, index + 5))
+      );
+    }
+    return rows;
+  }
+
+  private getAdminActionConfirmation(parsed: ParsedAdminActionCustomId): {
+    label: string;
+    message: string;
+    style: ButtonStyle.Danger | ButtonStyle.Primary | ButtonStyle.Success | ButtonStyle.Secondary;
+  } | null {
+    const target = `<@${parsed.userId}>`;
+    switch (parsed.action) {
+      case 'verify':
+        return {
+          label: 'Confirm Verify',
+          message: `Verify ${target} and remove verification restrictions?`,
+          style: ButtonStyle.Success,
+        };
+      case 'thread':
+        return {
+          label: 'Confirm Create Thread',
+          message: `Create a user-facing verification thread for ${target}?`,
+          style: ButtonStyle.Primary,
+        };
+      case 'repair':
+        return {
+          label: 'Confirm Repair',
+          message: `Repair the active verification case for ${target}?`,
+          style: ButtonStyle.Primary,
+        };
+      case 'sync_ban':
+        return {
+          label: 'Confirm Sync Ban',
+          message: `Sync pending verification cases for ${target} to banned because Discord already has an existing ban?`,
+          style: ButtonStyle.Danger,
+        };
+      case 'reopen':
+        return {
+          label: 'Confirm Reopen',
+          message: `Reopen verification for ${target} and restrict them again?`,
+          style: ButtonStyle.Primary,
+        };
+      case 'observed_open':
+        return {
+          label: 'Confirm Open Case',
+          message: `Open a verification case for observed alert on ${target}?`,
+          style: ButtonStyle.Primary,
+        };
+      case 'observed_restrict':
+        return {
+          label: 'Confirm Restrict',
+          message: `Restrict ${target} and open a verification case from this observed alert?`,
+          style: ButtonStyle.Danger,
+        };
+      case 'observed_dismiss':
+        return {
+          label: 'Confirm Dismiss',
+          message: `Dismiss this observed alert for ${target}?`,
+          style: ButtonStyle.Secondary,
+        };
+      case 'observed_false_positive':
+        return {
+          label: 'Confirm False Positive',
+          message: `Mark this observed alert for ${target} as a false positive?`,
+          style: ButtonStyle.Success,
+        };
+      case 'observed_undo_dismiss':
+        return {
+          label: 'Confirm Undo',
+          message: `Undo a dismissal or false-positive mark for this observed alert on ${target}?`,
+          style: ButtonStyle.Primary,
+        };
+      default:
+        return null;
+    }
+  }
+
+  private async showAdminActionConfirmation(
+    interaction: ButtonInteraction,
+    parsed: ParsedAdminActionCustomId,
+    confirmation: NonNullable<ReturnType<InteractionHandler['getAdminActionConfirmation']>>,
+    options?: { update?: boolean }
+  ): Promise<void> {
+    const confirmAction = `confirm_${parsed.action}`;
+    const components = [
+      new ActionRowBuilder<ButtonBuilder>().addComponents(
+        this.adminActionButton(parsed, confirmAction, confirmation.label, confirmation.style),
+        this.adminActionButton(parsed, 'cancel', 'Cancel', ButtonStyle.Secondary)
+      ),
+    ];
+    const response = {
+      content: confirmation.message,
+      allowedMentions: { parse: [] },
+      components,
+    };
+
+    if (options?.update === false) {
+      await interaction.reply({ ...response, flags: MessageFlags.Ephemeral });
+      return;
+    }
+
+    await interaction.update(response);
+  }
+
+  private async showLegacyAdminActionConfirmation(
+    interaction: ButtonInteraction,
+    parsed: ParsedAdminActionCustomId
+  ): Promise<void> {
+    const confirmation = this.getAdminActionConfirmation(parsed);
+    if (!confirmation) {
+      await interaction.reply({
+        content: 'Unknown admin action.',
+        flags: MessageFlags.Ephemeral,
+      });
+      return;
+    }
+
+    await this.showAdminActionConfirmation(interaction, parsed, confirmation, { update: false });
+  }
+
+  private async handleAdminActionBan(
+    interaction: ButtonInteraction,
+    guildId: string,
+    parsed: ParsedAdminActionCustomId
+  ): Promise<void> {
+    if (!(await this.hasAnyPermission(interaction, guildId, [PermissionFlagsBits.BanMembers]))) {
+      await this.replyPermissionDenied(
+        interaction,
+        'You need Ban Members permission to ban a user.'
+      );
+      return;
+    }
+    if (!(await this.canUseModeratorBanAction(guildId))) {
+      await interaction.reply({
+        content:
+          'Drasil ban actions are disabled for this server or the bot lacks Ban Members permission.',
+        flags: MessageFlags.Ephemeral,
+      });
+      return;
+    }
+
+    if (parsed.surface === 'observed') {
+      if (!parsed.detectionEventId) {
+        await interaction.reply({
+          content: 'This observed action is missing its detection event.',
+          flags: MessageFlags.Ephemeral,
+        });
+        return;
+      }
+      await this.showObservedBanModal(interaction, guildId, parsed.userId, parsed.detectionEventId);
+      return;
+    }
+
+    await this.handleBanButton(interaction, parsed.userId);
+  }
+
+  private async executeConfirmedAdminAction(
+    interaction: ButtonInteraction,
+    guildId: string,
+    parsed: ParsedAdminActionCustomId
+  ): Promise<void> {
+    const action = parsed.action.slice('confirm_'.length);
+    const moderationPermissions = this.getModerationPermissions();
+
+    if (action === 'verify') {
+      if (!(await this.hasAnyPermission(interaction, guildId, moderationPermissions))) {
+        await this.replyPermissionDenied(
+          interaction,
+          'You need moderation permissions to verify a user.'
+        );
+        return;
+      }
+      await this.handleVerifyButton(interaction, guildId, parsed.userId);
+      return;
+    }
+
+    if (action === 'thread') {
+      if (!(await this.hasAnyPermission(interaction, guildId, moderationPermissions))) {
+        await this.replyPermissionDenied(
+          interaction,
+          'You need moderation permissions to create a verification thread.'
+        );
+        return;
+      }
+      await this.handleThreadButton(interaction, guildId, parsed.userId);
+      return;
+    }
+
+    if (action === 'repair') {
+      if (!(await this.hasAnyPermission(interaction, guildId, moderationPermissions))) {
+        await this.replyPermissionDenied(
+          interaction,
+          'You need moderation permissions to repair a verification case.'
+        );
+        return;
+      }
+      await this.handleRepairActiveCaseButton(interaction, guildId, parsed.userId);
+      return;
+    }
+
+    if (action === 'sync_ban') {
+      if (!(await this.hasAnyPermission(interaction, guildId, [PermissionFlagsBits.BanMembers]))) {
+        await this.replyPermissionDenied(
+          interaction,
+          'You need Ban Members permission to sync an existing ban.'
+        );
+        return;
+      }
+      await this.handleSyncAlreadyBannedButton(interaction, guildId, parsed.userId);
+      return;
+    }
+
+    if (action === 'reopen') {
+      if (!(await this.hasAnyPermission(interaction, guildId, moderationPermissions))) {
+        await this.replyPermissionDenied(
+          interaction,
+          'You need moderation permissions to reopen verification.'
+        );
+        return;
+      }
+      await this.handleReopenButton(interaction, guildId, parsed.userId);
+      return;
+    }
+
+    if (!parsed.detectionEventId) {
+      await interaction.reply({
+        content: 'This observed action is missing its detection event.',
+        flags: MessageFlags.Ephemeral,
+      });
+      return;
+    }
+
+    if (
+      !(await this.hasAnyPermission(interaction, guildId, this.getObservedModerationPermissions()))
+    ) {
+      await this.replyPermissionDenied(
+        interaction,
+        'You need moderation permissions to use this observed action.'
+      );
+      return;
+    }
+
+    switch (action) {
+      case 'observed_open':
+        await interaction.deferUpdate();
+        await this.openObservedCase(interaction, guildId, parsed.userId, parsed.detectionEventId);
+        return;
+      case 'observed_restrict':
+        await interaction.deferUpdate();
+        await this.restrictObservedUser(
+          interaction,
+          guildId,
+          parsed.userId,
+          parsed.detectionEventId
+        );
+        return;
+      case 'observed_dismiss':
+      case 'observed_false_positive':
+        await interaction.deferReply({ flags: MessageFlags.Ephemeral });
+        await this.dismissObservedDetection(
+          interaction,
+          guildId,
+          parsed.userId,
+          parsed.detectionEventId,
+          action === 'observed_false_positive'
+            ? AdminActionType.FALSE_POSITIVE
+            : AdminActionType.DISMISS
+        );
+        return;
+      case 'observed_undo_dismiss':
+        await interaction.deferReply({ flags: MessageFlags.Ephemeral });
+        await this.undoObservedDismissal(
+          interaction,
+          guildId,
+          parsed.userId,
+          parsed.detectionEventId
+        );
+        return;
+      default:
+        await interaction.reply({
+          content: 'Unknown admin action.',
+          flags: MessageFlags.Ephemeral,
+        });
+    }
+  }
+
+  private async handleRepairActiveCaseButton(
+    interaction: ButtonInteraction,
+    guildId: string,
+    userId: string
+  ): Promise<void> {
+    await interaction.deferUpdate();
+
+    try {
+      const guild = await this.client.guilds.fetch(guildId);
+      const member = await guild.members.fetch(userId).catch(() => null);
+      if (!member) {
+        throw new Error('Could not find member in guild');
+      }
+
+      const result = await this.securityActionService.repairActiveCase(member);
+      await interaction.followUp({
+        content: result.message,
+        flags: MessageFlags.Ephemeral,
+      });
+    } catch (error) {
+      console.error('Error repairing active case:', error);
+      await interaction.followUp({
+        content: 'An error occurred while repairing the active case.',
+        flags: MessageFlags.Ephemeral,
+      });
+    }
+  }
+
+  private async handleSyncAlreadyBannedButton(
+    interaction: ButtonInteraction,
+    guildId: string,
+    userId: string
+  ): Promise<void> {
+    await interaction.deferUpdate();
+
+    try {
+      const guild = await this.client.guilds.fetch(guildId);
+      const syncedCount = await this.userModerationService.syncAlreadyBannedUser(
+        guild,
+        userId,
+        interaction.user
+      );
+
+      const caseWord = syncedCount === 1 ? 'case' : 'cases';
+      await interaction.followUp({
+        content:
+          syncedCount === 0
+            ? `No pending verification cases remain for <@${userId}>.`
+            : `Synced ${syncedCount} pending verification ${caseWord} for <@${userId}> to banned because Discord already has an existing ban.`,
+        allowedMentions: { parse: [] },
+        flags: MessageFlags.Ephemeral,
+      });
+    } catch (error) {
+      console.error('Error syncing already-banned user:', error);
+      await interaction.followUp({
+        content:
+          'Could not sync the existing ban. Confirm the user is still banned and Drasil can view server bans.',
+        flags: MessageFlags.Ephemeral,
+      });
     }
   }
 
@@ -1010,6 +1644,12 @@ export class InteractionHandler implements IInteractionHandler {
     return botMember?.permissions.has(PermissionFlagsBits.BanMembers) ?? false;
   }
 
+  private async isUserBanned(guildId: string, userId: string): Promise<boolean> {
+    const guild = await this.client.guilds.fetch(guildId).catch(() => null);
+    const ban = await guild?.bans.fetch(userId).catch(() => null);
+    return Boolean(ban);
+  }
+
   private async replyPermissionDenied(
     interaction: ButtonInteraction | ModalSubmitInteraction,
     message: string,
@@ -1076,8 +1716,12 @@ export class InteractionHandler implements IInteractionHandler {
           );
           return;
         }
-        await interaction.deferUpdate();
-        await this.openObservedCase(interaction, guildId, parsed.userId, parsed.detectionEventId);
+        await this.showLegacyAdminActionConfirmation(interaction, {
+          action: 'observed_open',
+          surface: 'observed',
+          userId: parsed.userId,
+          detectionEventId: parsed.detectionEventId,
+        });
         return;
 
       case 'restrict':
@@ -1088,13 +1732,12 @@ export class InteractionHandler implements IInteractionHandler {
           );
           return;
         }
-        await interaction.deferUpdate();
-        await this.restrictObservedUser(
-          interaction,
-          guildId,
-          parsed.userId,
-          parsed.detectionEventId
-        );
+        await this.showLegacyAdminActionConfirmation(interaction, {
+          action: 'observed_restrict',
+          surface: 'observed',
+          userId: parsed.userId,
+          detectionEventId: parsed.detectionEventId,
+        });
         return;
 
       case 'ban':
@@ -1153,7 +1796,6 @@ export class InteractionHandler implements IInteractionHandler {
 
       case 'dismiss':
       case 'false_positive':
-        await interaction.deferReply({ flags: MessageFlags.Ephemeral });
         if (!(await hasModerationPermission())) {
           await this.replyPermissionDenied(
             interaction,
@@ -1162,19 +1804,16 @@ export class InteractionHandler implements IInteractionHandler {
           );
           return;
         }
-        await this.dismissObservedDetection(
-          interaction,
-          guildId,
-          parsed.userId,
-          parsed.detectionEventId,
-          parsed.action === 'false_positive'
-            ? AdminActionType.FALSE_POSITIVE
-            : AdminActionType.DISMISS
-        );
+        await this.showLegacyAdminActionConfirmation(interaction, {
+          action:
+            parsed.action === 'false_positive' ? 'observed_false_positive' : 'observed_dismiss',
+          surface: 'observed',
+          userId: parsed.userId,
+          detectionEventId: parsed.detectionEventId,
+        });
         return;
 
       case 'undo_dismiss':
-        await interaction.deferReply({ flags: MessageFlags.Ephemeral });
         if (!(await hasModerationPermission())) {
           await this.replyPermissionDenied(
             interaction,
@@ -1183,12 +1822,12 @@ export class InteractionHandler implements IInteractionHandler {
           );
           return;
         }
-        await this.undoObservedDismissal(
-          interaction,
-          guildId,
-          parsed.userId,
-          parsed.detectionEventId
-        );
+        await this.showLegacyAdminActionConfirmation(interaction, {
+          action: 'observed_undo_dismiss',
+          surface: 'observed',
+          userId: parsed.userId,
+          detectionEventId: parsed.detectionEventId,
+        });
         return;
 
       case 'history':

--- a/src/di/container.ts
+++ b/src/di/container.ts
@@ -64,6 +64,10 @@ import {
   ReportCandidateService,
 } from '../services/ReportCandidateService';
 import { IReportIntakeService, ReportIntakeService } from '../services/ReportIntakeService';
+import {
+  CaseReviewReminderService,
+  ICaseReviewReminderService,
+} from '../services/CaseReviewReminderService';
 // Initialize container
 const container = new Container();
 
@@ -229,6 +233,11 @@ function configureServices(container: Container): void {
   container
     .bind<IReportIntakeService>(TYPES.ReportIntakeService)
     .to(ReportIntakeService)
+    .inSingletonScope();
+
+  container
+    .bind<ICaseReviewReminderService>(TYPES.CaseReviewReminderService)
+    .to(CaseReviewReminderService)
     .inSingletonScope();
 }
 

--- a/src/di/symbols.ts
+++ b/src/di/symbols.ts
@@ -24,6 +24,7 @@ export const TYPES = {
   RestrictedRoleLockdownService: Symbol.for('RestrictedRoleLockdownService'),
   ReportCandidateService: Symbol.for('ReportCandidateService'),
   ReportIntakeService: Symbol.for('ReportIntakeService'),
+  CaseReviewReminderService: Symbol.for('CaseReviewReminderService'),
 
   // Repositories
   BaseRepository: Symbol.for('BaseRepository'),

--- a/src/repositories/VerificationEventRepository.ts
+++ b/src/repositories/VerificationEventRepository.ts
@@ -22,7 +22,11 @@ export interface IVerificationEventRepository {
   getVerificationHistory(userId: string, serverId: string): Promise<VerificationEvent[]>;
   findById(id: string): Promise<VerificationEvent | null>;
   findByThreadId(threadId: string): Promise<VerificationEvent | null>;
-  update(id: string, data: Partial<VerificationEvent>): Promise<VerificationEvent | null>; // Return null if not found
+  update(
+    id: string,
+    data: Partial<VerificationEvent>,
+    options?: { touchUpdatedAt?: boolean }
+  ): Promise<VerificationEvent | null>; // Return null if not found
 }
 
 @injectable()
@@ -200,7 +204,11 @@ export class VerificationEventRepository implements IVerificationEventRepository
     return this.findByUserAndServer(userId, serverId, { limit: 100 });
   }
 
-  async update(id: string, data: Partial<VerificationEvent>): Promise<VerificationEvent | null> {
+  async update(
+    id: string,
+    data: Partial<VerificationEvent>,
+    options: { touchUpdatedAt?: boolean } = {}
+  ): Promise<VerificationEvent | null> {
     try {
       const now = new Date();
       // Map partial VerificationEvent to Prisma update input
@@ -212,7 +220,7 @@ export class VerificationEventRepository implements IVerificationEventRepository
         notes: data.notes,
         // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- data.metadata can be null or undefined
         metadata: (data.metadata as Prisma.InputJsonValue) ?? undefined, // Handle potential null/undefined
-        updated_at: now, // Always update timestamp
+        updated_at: options.touchUpdatedAt === false ? data.updated_at : now,
       };
 
       // Handle status and resolution fields if provided

--- a/src/repositories/VerificationEventRepository.ts
+++ b/src/repositories/VerificationEventRepository.ts
@@ -12,6 +12,7 @@ export interface IVerificationEventRepository {
   ): Promise<VerificationEvent[]>;
   findActiveByUserAndServer(userId: string, serverId: string): Promise<VerificationEvent | null>;
   findByDetectionEvent(detectionEventId: string): Promise<VerificationEvent[]>;
+  findPendingByServer(serverId: string): Promise<VerificationEvent[]>;
   createFromDetection(
     detectionEventId: string | null,
     serverId: string, // Explicitly require server/user IDs
@@ -126,6 +127,21 @@ export class VerificationEventRepository implements IVerificationEventRepository
     }
   }
 
+  async findPendingByServer(serverId: string): Promise<VerificationEvent[]> {
+    try {
+      const events = await this.prisma.verification_events.findMany({
+        where: {
+          server_id: serverId,
+          status: VerificationStatus.PENDING,
+        },
+        orderBy: { updated_at: 'asc' },
+      });
+      return events as VerificationEvent[];
+    } catch (error) {
+      this.handleError(error, 'findPendingByServer');
+    }
+  }
+
   // Modified: Requires serverId and userId explicitly now
   async createFromDetection(
     detectionEventId: string | null,
@@ -191,6 +207,7 @@ export class VerificationEventRepository implements IVerificationEventRepository
       const updateData: Prisma.verification_eventsUpdateInput = {
         // Existing fields
         thread_id: data.thread_id,
+        private_evidence_thread_id: data.private_evidence_thread_id,
         notification_message_id: data.notification_message_id,
         notes: data.notes,
         // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- data.metadata can be null or undefined

--- a/src/repositories/types.ts
+++ b/src/repositories/types.ts
@@ -80,6 +80,9 @@ export interface ServerSettings {
   restricted_lockdown_enabled?: boolean;
   restricted_lockdown_allowed_channel_ids?: string[];
   restricted_lockdown_allowed_category_ids?: string[];
+  case_review_reminders_enabled?: boolean;
+  case_review_reminder_stale_hours?: number;
+  case_review_reminder_repeat_hours?: number;
   setup_nudge_last_attempt_at?: string | null;
   setup_nudge_last_recipient_id?: string | null;
   setup_nudge_last_result?: 'sent' | 'dm_failed' | 'no_recipient' | null;
@@ -178,6 +181,7 @@ export interface VerificationEvent {
   user_id: string;
   detection_event_id: string | null;
   thread_id: string | null;
+  private_evidence_thread_id: string | null;
   notification_message_id: string | null;
   status: VerificationStatus;
   created_at: Date; // Use Date type

--- a/src/services/CaseReviewReminderService.ts
+++ b/src/services/CaseReviewReminderService.ts
@@ -171,12 +171,17 @@ export class CaseReviewReminderService implements ICaseReviewReminderService {
   }
 
   private async stampReminder(event: VerificationEvent, now: Date): Promise<void> {
-    await this.verificationEventRepository.update(event.id, {
-      metadata: {
-        ...this.metadataToRecord(event.metadata),
-        [CASE_REVIEW_LAST_REMINDED_AT_METADATA_KEY]: now.toISOString(),
-      } as VerificationEvent['metadata'],
-    });
+    await this.verificationEventRepository.update(
+      event.id,
+      {
+        metadata: {
+          ...this.metadataToRecord(event.metadata),
+          [CASE_REVIEW_LAST_REMINDED_AT_METADATA_KEY]: now.toISOString(),
+        } as VerificationEvent['metadata'],
+        updated_at: event.updated_at,
+      },
+      { touchUpdatedAt: false }
+    );
   }
 
   private metadataToRecord(metadata: unknown): Record<string, unknown> {

--- a/src/services/CaseReviewReminderService.ts
+++ b/src/services/CaseReviewReminderService.ts
@@ -1,0 +1,198 @@
+import { inject, injectable } from 'inversify';
+import { IConfigService } from '../config/ConfigService';
+import { TYPES } from '../di/symbols';
+import { IServerRepository } from '../repositories/ServerRepository';
+import { IVerificationEventRepository } from '../repositories/VerificationEventRepository';
+import { Server, VerificationEvent } from '../repositories/types';
+import { getCaseResponderSettings } from '../utils/caseResponderSettings';
+import { getCaseReviewReminderSettings } from '../utils/caseReviewReminderSettings';
+
+const CASE_REVIEW_LAST_REMINDED_AT_METADATA_KEY = 'case_review_last_reminded_at';
+const CASE_REVIEW_REMINDER_INTERVAL_MS = 15 * 60 * 1000;
+const CASE_REVIEW_REMINDER_MAX_CASES = 10;
+
+export interface ICaseReviewReminderService {
+  start(): void;
+  stop(): void;
+  runOnce(now?: Date): Promise<void>;
+}
+
+@injectable()
+export class CaseReviewReminderService implements ICaseReviewReminderService {
+  private timer: ReturnType<typeof setInterval> | null = null;
+  private running = false;
+
+  constructor(
+    @inject(TYPES.ServerRepository) private readonly serverRepository: IServerRepository,
+    @inject(TYPES.VerificationEventRepository)
+    private readonly verificationEventRepository: IVerificationEventRepository,
+    @inject(TYPES.ConfigService) private readonly configService: IConfigService
+  ) {}
+
+  public start(): void {
+    if (this.timer) {
+      return;
+    }
+
+    void this.runOnce();
+    this.timer = setInterval(() => {
+      void this.runOnce();
+    }, CASE_REVIEW_REMINDER_INTERVAL_MS);
+  }
+
+  public stop(): void {
+    if (!this.timer) {
+      return;
+    }
+
+    clearInterval(this.timer);
+    this.timer = null;
+  }
+
+  public async runOnce(now = new Date()): Promise<void> {
+    if (this.running) {
+      return;
+    }
+
+    this.running = true;
+    try {
+      const servers = await this.serverRepository.findAllActive();
+      for (const server of servers) {
+        await this.processServer(server, now).catch((error) => {
+          console.error(
+            `Failed to process case review reminders for guild ${server.guild_id}:`,
+            error
+          );
+        });
+      }
+    } finally {
+      this.running = false;
+    }
+  }
+
+  private async processServer(server: Server, now: Date): Promise<void> {
+    const settings = getCaseReviewReminderSettings(server.settings);
+    if (!settings.enabled) {
+      return;
+    }
+
+    const pendingCases = await this.verificationEventRepository.findPendingByServer(
+      server.guild_id
+    );
+    const staleCases = pendingCases.filter((event) =>
+      this.shouldRemind(event, now, settings.staleHours, settings.repeatHours)
+    );
+    if (staleCases.length === 0) {
+      return;
+    }
+
+    const channel = await this.configService.getAdminChannel(server.guild_id);
+    if (!channel) {
+      return;
+    }
+
+    const roleIds = getCaseResponderSettings(server.settings).roleIds;
+    await channel.send({
+      content: this.buildReminderMessage(server.guild_id, staleCases, roleIds, now),
+      allowedMentions: {
+        parse: [],
+        users: [],
+        roles: roleIds,
+        repliedUser: false,
+      },
+    });
+
+    for (const event of staleCases) {
+      await this.stampReminder(event, now).catch((error) => {
+        console.error(`Failed to stamp case reminder metadata for ${event.id}:`, error);
+      });
+    }
+  }
+
+  private shouldRemind(
+    event: VerificationEvent,
+    now: Date,
+    staleHours: number,
+    repeatHours: number
+  ): boolean {
+    const lastMovementAt = event.updated_at;
+    if (now.getTime() - lastMovementAt.getTime() < staleHours * 60 * 60 * 1000) {
+      return false;
+    }
+
+    const metadata = this.metadataToRecord(event.metadata);
+    const remindedAt = this.parseDate(metadata[CASE_REVIEW_LAST_REMINDED_AT_METADATA_KEY]);
+    if (!remindedAt) {
+      return true;
+    }
+
+    return now.getTime() - remindedAt.getTime() >= repeatHours * 60 * 60 * 1000;
+  }
+
+  private buildReminderMessage(
+    guildId: string,
+    events: VerificationEvent[],
+    roleIds: string[],
+    now: Date
+  ): string {
+    const roleMentions = roleIds.map((roleId) => `<@&${roleId}>`).join(' ');
+    const visibleEvents = events.slice(0, CASE_REVIEW_REMINDER_MAX_CASES);
+    const lines = [
+      roleMentions || 'Case review reminder',
+      `There ${events.length === 1 ? 'is' : 'are'} ${events.length} stale pending case${events.length === 1 ? '' : 's'} needing review.`,
+      '',
+      ...visibleEvents.map((event) => this.formatCaseLine(guildId, event, now)),
+    ];
+
+    if (events.length > visibleEvents.length) {
+      lines.push(
+        '',
+        `Showing first ${visibleEvents.length}; ${events.length - visibleEvents.length} more pending case(s) are also stale.`
+      );
+    }
+
+    return lines.join('\n');
+  }
+
+  private formatCaseLine(guildId: string, event: VerificationEvent, now: Date): string {
+    const lastMovementAt = event.updated_at;
+    const ageHours = Math.max(
+      1,
+      Math.floor((now.getTime() - lastMovementAt.getTime()) / (60 * 60 * 1000))
+    );
+    const links = [
+      event.private_evidence_thread_id
+        ? `evidence: https://discord.com/channels/${guildId}/${event.private_evidence_thread_id}`
+        : null,
+      event.thread_id ? `case: https://discord.com/channels/${guildId}/${event.thread_id}` : null,
+    ].filter((value): value is string => Boolean(value));
+
+    return `- <@${event.user_id}> (${event.user_id}) stale for ${ageHours}h${links.length ? ` - ${links.join(' | ')}` : ''}`;
+  }
+
+  private async stampReminder(event: VerificationEvent, now: Date): Promise<void> {
+    await this.verificationEventRepository.update(event.id, {
+      metadata: {
+        ...this.metadataToRecord(event.metadata),
+        [CASE_REVIEW_LAST_REMINDED_AT_METADATA_KEY]: now.toISOString(),
+      } as VerificationEvent['metadata'],
+    });
+  }
+
+  private metadataToRecord(metadata: unknown): Record<string, unknown> {
+    if (!metadata || typeof metadata !== 'object' || Array.isArray(metadata)) {
+      return {};
+    }
+
+    return { ...(metadata as Record<string, unknown>) };
+  }
+
+  private parseDate(value: unknown): Date | null {
+    if (typeof value !== 'string') {
+      return null;
+    }
+
+    const date = new Date(value);
+    return Number.isNaN(date.getTime()) ? null : date;
+  }
+}

--- a/src/services/NotificationManager.ts
+++ b/src/services/NotificationManager.ts
@@ -38,6 +38,10 @@ import { getVerificationActionFailures } from '../utils/verificationActionFailur
 import { getCaseResponderSettings } from '../utils/caseResponderSettings';
 import { CASE_STAFF_ROUTING_METADATA_KEY } from './ThreadManager';
 import { isDetectionEventExcludedFromAccounting } from '../utils/detectionEventAccounting';
+import {
+  buildCaseAdminActionsCustomId,
+  buildObservedAdminActionsCustomId,
+} from '../utils/adminActionCustomIds';
 
 const VERIFICATION_CHANNEL_NAME = 'verification';
 
@@ -165,6 +169,7 @@ export class NotificationManager implements INotificationManager {
   private configService: IConfigService;
   private detectionEventsRepository: IDetectionEventsRepository;
   private static readonly THREAD_ANALYSIS_FIELD_NAME = 'AI Thread Analysis';
+  private static readonly LATEST_ADMIN_ACTION_FIELD_NAME = 'Latest Admin Action';
 
   constructor(
     @inject(TYPES.DiscordClient) client: Client,
@@ -205,22 +210,7 @@ export class NotificationManager implements INotificationManager {
         sourceMessage
       );
       const serverConfig = await this.configService.getServerConfig(member.guild.id);
-      const responseSettings = getDetectionResponseSettings(serverConfig.settings);
-      const canShowBanAction = await this.canShowModeratorBanAction(member.guild, responseSettings);
-
-      // Get detection events
-      const detectionEvents = await this.detectionEventsRepository.findByServerAndUser(
-        member.guild.id,
-        member.id
-      );
-
-      // Create the action row, passing the thread status
-      const actionRow = this.createActionRow(
-        member.id,
-        detectionEvents,
-        !!verificationEvent.thread_id, // Check for truthiness (not null/undefined)
-        canShowBanAction
-      );
+      const actionRow = this.createActionRow(member.id);
 
       // If we have an existing message, update it, otherwise create new
       if (verificationEvent.notification_message_id) {
@@ -230,7 +220,7 @@ export class NotificationManager implements INotificationManager {
         return await existingMessage.edit({
           allowedMentions: { parse: [] },
           embeds: [embed],
-          components: [actionRow], // Use the conditionally created action row
+          components: [actionRow],
         });
       }
 
@@ -240,7 +230,7 @@ export class NotificationManager implements INotificationManager {
         content: this.formatRoleMentions(notificationRoleIds),
         allowedMentions: this.createAdminAllowedMentions(notificationRoleIds),
         embeds: [embed],
-        components: [actionRow], // Use the conditionally created action row
+        components: [actionRow],
       });
     } catch (error) {
       console.error('Failed to upsert suspicious user notification:', error);
@@ -281,9 +271,8 @@ export class NotificationManager implements INotificationManager {
         sourceMessage
       );
       const actionDetectionEventId = detectionResult.detectionEventId ?? detectionEvents[0]?.id;
-      const canShowBanAction = await this.canShowModeratorBanAction(member.guild, responseSettings);
       const components = actionDetectionEventId
-        ? this.createObservedActionRows(member.id, actionDetectionEventId, canShowBanAction)
+        ? this.createObservedActionRows(member.id, actionDetectionEventId)
         : [];
 
       let notificationMessage: Message | null = null;
@@ -333,8 +322,9 @@ export class NotificationManager implements INotificationManager {
     detectionEventId: string,
     actionDescription: string,
     admin: User,
-    options?: { undoButtonLabel?: string }
+    _options?: { undoButtonLabel?: string }
   ): Promise<boolean> {
+    void _options;
     try {
       const detectionEvent = await this.detectionEventsRepository.findById(detectionEventId);
       if (!detectionEvent?.server_id) {
@@ -382,13 +372,7 @@ export class NotificationManager implements INotificationManager {
         ) ?? [];
       updatedEmbed.setFields(...existingFields, field);
 
-      const components = options?.undoButtonLabel
-        ? this.createObservedUndoRows(
-            detectionEvent.user_id,
-            detectionEvent.id,
-            options.undoButtonLabel
-          )
-        : [];
+      const components = this.createObservedActionRows(detectionEvent.user_id, detectionEvent.id);
 
       await message.edit({
         allowedMentions: { parse: [] },
@@ -420,10 +404,6 @@ export class NotificationManager implements INotificationManager {
 
       const serverConfig = await this.configService.getServerConfig(detectionEvent.server_id);
       const responseSettings = getDetectionResponseSettings(serverConfig.settings);
-      const guild = await this.fetchGuild(detectionEvent.server_id);
-      const canShowBanAction = guild
-        ? await this.canShowModeratorBanAction(guild, responseSettings)
-        : false;
       const notificationChannel = await this.getObservedDetectionNotificationChannel(
         detectionEvent.server_id,
         responseSettings
@@ -439,11 +419,7 @@ export class NotificationManager implements INotificationManager {
         return false;
       }
 
-      const components = this.createObservedActionRows(
-        detectionEvent.user_id,
-        detectionEvent.id,
-        canShowBanAction
-      );
+      const components = this.createObservedActionRows(detectionEvent.user_id, detectionEvent.id);
       if (!message.embeds.length) {
         await message.edit({ allowedMentions: { parse: [] }, components });
         return true;
@@ -501,16 +477,15 @@ export class NotificationManager implements INotificationManager {
       // Create a new embed based on the existing one
       const updatedEmbed = EmbedBuilder.from(existingEmbed);
 
-      // Add or update the Action Log field
       const timestamp = Math.floor(Date.now() / 1000);
       const actionLogField = updatedEmbed.data.fields?.find((field) => field.name === 'Action Log');
+      this.upsertLatestAdminActionField(updatedEmbed, actionTaken, admin.id, timestamp);
 
-      // Create log entry
-      let actionLogContent = `• <@${admin.id}> ${actionTaken} <t:${timestamp}:R>`;
+      let actionLogContent = `• ${this.formatAdminActionEvent(actionTaken, admin.id, timestamp)}`;
 
       // If a thread was created, update the log entry and add/update a dedicated thread link field
       if (thread && actionTaken === AdminActionType.CREATE_THREAD) {
-        actionLogContent = `• <@${admin.id}> created a verification thread <t:${timestamp}:R>`; // Keep log simple
+        actionLogContent = `• ${this.formatAdminActionEvent(actionTaken, admin.id, timestamp)}`;
         const threadField = {
           name: 'Verification Thread',
           value: `[Click here to view the thread](${thread.url})`,
@@ -611,6 +586,89 @@ export class NotificationManager implements INotificationManager {
     return `${value.slice(0, maxLength - 3)}...`;
   }
 
+  private formatAdminActionLabel(actionTaken: AdminActionType): string {
+    switch (actionTaken) {
+      case AdminActionType.BAN:
+        return 'Banned';
+      case AdminActionType.VERIFY:
+        return 'Verified';
+      case AdminActionType.CREATE_THREAD:
+        return 'Created verification thread';
+      case AdminActionType.REOPEN:
+        return 'Reopened verification';
+      case AdminActionType.RESTRICT:
+        return 'Restricted';
+      case AdminActionType.OPEN_CASE:
+        return 'Opened case';
+      case AdminActionType.DISMISS:
+        return 'Dismissed alert';
+      case AdminActionType.FALSE_POSITIVE:
+        return 'Marked false positive';
+      case AdminActionType.UNDO_OBSERVED_ACTION:
+        return 'Undid observed action';
+      case AdminActionType.REJECT:
+        return 'Rejected';
+      default:
+        return actionTaken;
+    }
+  }
+
+  private formatAdminActionEvent(
+    actionTaken: AdminActionType,
+    adminId: string,
+    timestamp: number
+  ): string {
+    return `${this.formatAdminActionLabel(actionTaken)} by <@${adminId}> at <t:${timestamp}:F>`;
+  }
+
+  private upsertLatestAdminActionField(
+    embed: EmbedBuilder,
+    actionTaken: AdminActionType,
+    adminId: string,
+    timestamp: number
+  ): void {
+    const field = {
+      name: NotificationManager.LATEST_ADMIN_ACTION_FIELD_NAME,
+      value: this.formatAdminActionEvent(actionTaken, adminId, timestamp),
+      inline: false,
+    };
+    const fields = (embed.data.fields ?? []).filter(
+      (existingField) => existingField.name !== field.name
+    );
+    const confidenceIndex = fields.findIndex(
+      (existingField) => existingField.name === 'Detection Confidence'
+    );
+    const insertIndex = confidenceIndex >= 0 ? confidenceIndex + 1 : 0;
+    fields.splice(insertIndex, 0, field);
+    embed.setFields(...fields);
+  }
+
+  private upsertLatestResolutionField(
+    embed: EmbedBuilder,
+    verificationEvent: VerificationEvent
+  ): void {
+    if (!verificationEvent.resolved_by || !verificationEvent.resolved_at) {
+      return;
+    }
+
+    const actionTaken =
+      verificationEvent.status === VerificationStatus.BANNED
+        ? AdminActionType.BAN
+        : verificationEvent.status === VerificationStatus.VERIFIED
+          ? AdminActionType.VERIFY
+          : null;
+    if (!actionTaken) {
+      return;
+    }
+
+    this.upsertLatestAdminActionField(
+      embed,
+      actionTaken,
+      verificationEvent.resolved_by,
+      Math.floor(verificationEvent.resolved_at.getTime() / 1000)
+    );
+  }
+
   private metadataToRecord(metadata: DetectionEvent['metadata']): Record<string, unknown> {
     if (!metadata || typeof metadata !== 'object' || Array.isArray(metadata)) {
       return {};
@@ -651,33 +709,6 @@ export class NotificationManager implements INotificationManager {
     }
 
     return [...roleIds];
-  }
-
-  private async canShowModeratorBanAction(
-    guild: Guild,
-    responseSettings: ReturnType<typeof getDetectionResponseSettings>
-  ): Promise<boolean> {
-    if (!responseSettings.moderatorBanActionEnabled) {
-      return false;
-    }
-
-    const botMember =
-      guild.members.me ??
-      (typeof guild.members.fetchMe === 'function'
-        ? await guild.members.fetchMe().catch(() => null)
-        : null);
-    return botMember?.permissions.has(PermissionFlagsBits.BanMembers) ?? false;
-  }
-
-  private async fetchGuild(guildId: string): Promise<Guild | null> {
-    const guildManager = this.client.guilds as unknown as
-      | { fetch?: (guildId: string) => Promise<Guild> }
-      | undefined;
-    if (typeof guildManager?.fetch !== 'function') {
-      return null;
-    }
-
-    return guildManager.fetch(guildId).catch(() => null);
   }
 
   private formatRoleMentions(roleIds: readonly string[]): string | undefined {
@@ -1007,6 +1038,8 @@ export class NotificationManager implements INotificationManager {
       )
       .setTimestamp();
 
+    this.upsertLatestResolutionField(embed, verificationEvent);
+
     const aiDiagnosticFieldValue = this.formatGptDiagnosticFieldValue(detectionResult);
     if (aiDiagnosticFieldValue) {
       embed.addFields({
@@ -1096,7 +1129,11 @@ export class NotificationManager implements INotificationManager {
       .map((failure) => {
         const timestamp = Math.floor(new Date(failure.at).getTime() / 1000);
         const action =
-          failure.action === 'restrict' ? 'Apply restricted role' : 'Create case thread';
+          failure.action === 'restrict'
+            ? 'Apply restricted role'
+            : failure.action === 'private_evidence_thread'
+              ? 'Create private evidence thread'
+              : 'Create case thread';
         const when = Number.isFinite(timestamp) ? ` <t:${timestamp}:R>` : '';
         return `Warning: ${action} failed${when}: ${failure.message}`;
       })
@@ -1318,109 +1355,27 @@ export class NotificationManager implements INotificationManager {
   /**
    * Creates an action row with admin action buttons
    * @param userId The ID of the user the actions apply to
-   * @param detectionEvents Array of detection events to determine if history button is needed
-   * @param hasThread Whether a verification thread exists for the user
    * @returns An ActionRowBuilder with buttons
    */
-  private createActionRow(
-    userId: string,
-    detectionEvents: DetectionEvent[],
-    hasThread: boolean,
-    canShowBanAction: boolean
-  ): ActionRowBuilder<ButtonBuilder> {
-    // Create action buttons with user ID in the custom ID
-    const verifyButton = new ButtonBuilder()
-      .setCustomId(`verify_${userId}`)
-      .setLabel('Verify User')
-      .setStyle(ButtonStyle.Success);
-
-    // Base buttons
-    const buttons = [verifyButton];
-    if (canShowBanAction) {
-      buttons.push(
-        new ButtonBuilder()
-          .setCustomId(`ban_${userId}`)
-          .setLabel('Ban User')
-          .setStyle(ButtonStyle.Danger)
-      );
-    }
-
-    // Add thread button ONLY if no verification event was found OR if the event exists but has no thread_id yet
-    if (!hasThread) {
-      const threadButton = new ButtonBuilder()
-        .setCustomId(`thread_${userId}`)
-        .setLabel('Create Thread')
-        .setStyle(ButtonStyle.Primary);
-      buttons.push(threadButton);
-    }
-
-    // Add view history button if we have more than 5 detection events
-    if (detectionEvents.length > 5) {
-      const historyButton = new ButtonBuilder()
-        .setCustomId(`history_${userId}`)
-        .setLabel('View Full History')
-        .setStyle(ButtonStyle.Secondary);
-      buttons.push(historyButton);
-    }
-
-    // Add buttons to an action row
-    return new ActionRowBuilder<ButtonBuilder>().addComponents(...buttons);
+  private createActionRow(userId: string): ActionRowBuilder<ButtonBuilder> {
+    return new ActionRowBuilder<ButtonBuilder>().addComponents(
+      new ButtonBuilder()
+        .setCustomId(buildCaseAdminActionsCustomId(userId))
+        .setLabel('Admin Actions')
+        .setStyle(ButtonStyle.Primary)
+    );
   }
 
   private createObservedActionRows(
     userId: string,
-    detectionEventId: string,
-    canShowBanAction: boolean
-  ): ActionRowBuilder<ButtonBuilder>[] {
-    const buttons = [
-      new ButtonBuilder()
-        .setCustomId(`observed:open:${userId}:${detectionEventId}`)
-        .setLabel('Open Case')
-        .setStyle(ButtonStyle.Primary),
-      new ButtonBuilder()
-        .setCustomId(`observed:restrict:${userId}:${detectionEventId}`)
-        .setLabel('Restrict')
-        .setStyle(ButtonStyle.Danger),
-    ];
-
-    if (canShowBanAction) {
-      buttons.push(
-        new ButtonBuilder()
-          .setCustomId(`observed:ban:${userId}:${detectionEventId}`)
-          .setLabel('Ban')
-          .setStyle(ButtonStyle.Danger)
-      );
-    }
-
-    buttons.push(
-      new ButtonBuilder()
-        .setCustomId(`observed:dismiss_menu:${userId}:${detectionEventId}`)
-        .setLabel('Dismiss...')
-        .setStyle(ButtonStyle.Secondary),
-      new ButtonBuilder()
-        .setCustomId(`observed:history:${userId}:${detectionEventId}`)
-        .setLabel('History')
-        .setStyle(ButtonStyle.Secondary)
-    );
-
-    return [new ActionRowBuilder<ButtonBuilder>().addComponents(...buttons)];
-  }
-
-  private createObservedUndoRows(
-    userId: string,
-    detectionEventId: string,
-    undoButtonLabel: string
+    detectionEventId: string
   ): ActionRowBuilder<ButtonBuilder>[] {
     return [
       new ActionRowBuilder<ButtonBuilder>().addComponents(
         new ButtonBuilder()
-          .setCustomId(`observed:undo_dismiss:${userId}:${detectionEventId}`)
-          .setLabel(undoButtonLabel)
-          .setStyle(ButtonStyle.Primary),
-        new ButtonBuilder()
-          .setCustomId(`observed:history:${userId}:${detectionEventId}`)
-          .setLabel('History')
-          .setStyle(ButtonStyle.Secondary)
+          .setCustomId(buildObservedAdminActionsCustomId(userId, detectionEventId))
+          .setLabel('Admin Actions')
+          .setStyle(ButtonStyle.Primary)
       ),
     ];
   }
@@ -1711,91 +1666,10 @@ export class NotificationManager implements INotificationManager {
     verificationEvent: VerificationEvent,
     newStatus: VerificationStatus
   ): Promise<void> {
-    let components: ActionRowBuilder<ButtonBuilder>[] = [];
+    void newStatus;
 
     if (!verificationEvent.notification_message_id) {
       throw new Error('No notification message ID found for verification event');
-    }
-
-    switch (newStatus) {
-      case VerificationStatus.VERIFIED:
-        // Keep history and add reopen button
-        components = [
-          new ActionRowBuilder<ButtonBuilder>().addComponents(
-            new ButtonBuilder()
-              .setCustomId(`history_${verificationEvent.user_id}`)
-              .setLabel('View Full History')
-              .setStyle(ButtonStyle.Secondary),
-            new ButtonBuilder()
-              .setCustomId(`reopen_${verificationEvent.user_id}`)
-              .setLabel('Reopen Verification')
-              .setStyle(ButtonStyle.Primary)
-          ),
-        ];
-        break;
-
-      case VerificationStatus.BANNED:
-        // Keep history and add reopen button
-        components = [
-          new ActionRowBuilder<ButtonBuilder>().addComponents(
-            new ButtonBuilder()
-              .setCustomId(`history_${verificationEvent.user_id}`)
-              .setLabel('View Full History')
-              .setStyle(ButtonStyle.Secondary),
-            new ButtonBuilder()
-              .setCustomId(`reopen_${verificationEvent.user_id}`)
-              .setLabel('Reopen Verification')
-              .setStyle(ButtonStyle.Primary)
-          ),
-        ];
-        break;
-
-      case VerificationStatus.PENDING: {
-        const serverConfig = await this.configService.getServerConfig(verificationEvent.server_id);
-        const responseSettings = getDetectionResponseSettings(serverConfig.settings);
-        const guild = await this.fetchGuild(verificationEvent.server_id);
-        const canShowBanAction = guild
-          ? await this.canShowModeratorBanAction(guild, responseSettings)
-          : false;
-        // Show all buttons
-        const pendingButtons = [
-          new ButtonBuilder()
-            .setCustomId(`verify_${verificationEvent.user_id}`)
-            .setLabel('Verify User')
-            .setStyle(ButtonStyle.Success),
-        ];
-
-        if (canShowBanAction) {
-          pendingButtons.push(
-            new ButtonBuilder()
-              .setCustomId(`ban_${verificationEvent.user_id}`)
-              .setLabel('Ban User')
-              .setStyle(ButtonStyle.Danger)
-          );
-        }
-
-        pendingButtons.push(
-          new ButtonBuilder()
-            .setCustomId(`history_${verificationEvent.user_id}`)
-            .setLabel('View Full History')
-            .setStyle(ButtonStyle.Secondary)
-        );
-
-        components = [new ActionRowBuilder<ButtonBuilder>().addComponents(...pendingButtons)];
-        break;
-      }
-    }
-
-    // Add create thread button if pending and no thread exists
-    if (newStatus === VerificationStatus.PENDING && !verificationEvent.thread_id) {
-      components.push(
-        new ActionRowBuilder<ButtonBuilder>().addComponents(
-          new ButtonBuilder()
-            .setCustomId(`thread_${verificationEvent.user_id}`)
-            .setLabel('Create Thread')
-            .setStyle(ButtonStyle.Primary)
-        )
-      );
     }
 
     const adminChannel = await this.configService.getAdminChannel(verificationEvent.server_id);
@@ -1806,6 +1680,9 @@ export class NotificationManager implements INotificationManager {
 
     const message = await adminChannel.messages.fetch(verificationEvent.notification_message_id);
 
-    await message.edit({ allowedMentions: { parse: [] }, components });
+    await message.edit({
+      allowedMentions: { parse: [] },
+      components: [this.createActionRow(verificationEvent.user_id)],
+    });
   }
 }

--- a/src/services/NotificationManager.ts
+++ b/src/services/NotificationManager.ts
@@ -126,8 +126,7 @@ export interface INotificationManager {
   markObservedDetectionActionTaken(
     detectionEventId: string,
     actionDescription: string,
-    admin: User,
-    options?: { undoButtonLabel?: string }
+    admin: User
   ): Promise<boolean>;
 
   restoreObservedDetectionActions(
@@ -321,10 +320,8 @@ export class NotificationManager implements INotificationManager {
   public async markObservedDetectionActionTaken(
     detectionEventId: string,
     actionDescription: string,
-    admin: User,
-    _options?: { undoButtonLabel?: string }
+    admin: User
   ): Promise<boolean> {
-    void _options;
     try {
       const detectionEvent = await this.detectionEventsRepository.findById(detectionEventId);
       if (!detectionEvent?.server_id) {
@@ -483,9 +480,8 @@ export class NotificationManager implements INotificationManager {
 
       let actionLogContent = `• ${this.formatAdminActionEvent(actionTaken, admin.id, timestamp)}`;
 
-      // If a thread was created, update the log entry and add/update a dedicated thread link field
+      // If a thread was created, add/update a dedicated thread link field
       if (thread && actionTaken === AdminActionType.CREATE_THREAD) {
-        actionLogContent = `• ${this.formatAdminActionEvent(actionTaken, admin.id, timestamp)}`;
         const threadField = {
           name: 'Verification Thread',
           value: `[Click here to view the thread](${thread.url})`,

--- a/src/services/SecurityActionService.ts
+++ b/src/services/SecurityActionService.ts
@@ -2115,13 +2115,7 @@ export class SecurityActionService implements ISecurityActionService {
         actionType === AdminActionType.FALSE_POSITIVE
           ? 'marked this detection as a false positive'
           : 'dismissed this alert',
-        moderator,
-        {
-          undoButtonLabel:
-            actionType === AdminActionType.FALSE_POSITIVE
-              ? 'Undo False Positive'
-              : 'Undo Dismissal',
-        }
+        moderator
       );
       void this.productAnalyticsService.captureUserEvent(
         guildId,

--- a/src/services/SecurityActionService.ts
+++ b/src/services/SecurityActionService.ts
@@ -555,7 +555,7 @@ export class SecurityActionService implements ISecurityActionService {
     detectionResult: DetectionResult,
     useReportReviewThread: boolean,
     sourceMessage?: Message
-  ): Promise<void> {
+  ): Promise<VerificationEvent> {
     const thread = useReportReviewThread
       ? await this.threadManager.createReportReviewThread(
           member,
@@ -569,6 +569,71 @@ export class SecurityActionService implements ISecurityActionService {
       const threadKind = useReportReviewThread ? 'report review thread' : 'verification thread';
       throw new Error(`Failed to create ${threadKind} for ${member.user.tag}`);
     }
+
+    return verificationEvent;
+  }
+
+  private async tryCreatePrivateEvidenceThread(
+    member: GuildMember,
+    verificationEvent: VerificationEvent,
+    detectionResult: DetectionResult,
+    sourceMessage?: Message
+  ): Promise<VerificationEvent> {
+    try {
+      const thread = await this.threadManager.createPrivateEvidenceThread(
+        member,
+        verificationEvent,
+        detectionResult,
+        sourceMessage
+      );
+      if (!thread) {
+        throw new Error(`Failed to create private evidence thread for ${member.user.tag}`);
+      }
+      return verificationEvent;
+    } catch (error) {
+      console.error(
+        `Failed to create private evidence thread for ${member.user.tag}; continuing case flow:`,
+        error
+      );
+      return this.recordVerificationActionFailure(
+        verificationEvent,
+        'private_evidence_thread',
+        error
+      );
+    }
+  }
+
+  private async ensurePrivateEvidenceThread(
+    member: GuildMember,
+    verificationEvent: VerificationEvent,
+    detectionResult: DetectionResult,
+    sourceMessage?: Message
+  ): Promise<VerificationEvent> {
+    if (verificationEvent.private_evidence_thread_id) {
+      return verificationEvent;
+    }
+
+    if (this.hasReportReviewThread(verificationEvent)) {
+      if (!verificationEvent.thread_id) {
+        return verificationEvent;
+      }
+      const updatedEvent = await this.verificationEventRepository.update(verificationEvent.id, {
+        private_evidence_thread_id: verificationEvent.thread_id,
+      });
+      return (
+        updatedEvent ?? {
+          ...verificationEvent,
+          private_evidence_thread_id: verificationEvent.thread_id,
+        }
+      );
+    }
+
+    return this.tryCreatePrivateEvidenceThread(
+      member,
+      verificationEvent,
+      detectionResult,
+      sourceMessage
+    );
   }
 
   private formatActionFailureMessage(error: unknown): string {
@@ -634,14 +699,22 @@ export class SecurityActionService implements ISecurityActionService {
     sourceMessage?: Message
   ): Promise<VerificationEvent> {
     try {
-      await this.createCaseThread(
+      let updatedEvent = await this.createCaseThread(
         member,
         verificationEvent,
         detectionResult,
         useReportReviewThread,
         sourceMessage
       );
-      return verificationEvent;
+      if (!useReportReviewThread) {
+        updatedEvent = await this.tryCreatePrivateEvidenceThread(
+          member,
+          updatedEvent,
+          detectionResult,
+          sourceMessage
+        );
+      }
+      return updatedEvent;
     } catch (error) {
       console.error(
         `Failed to create case thread for ${member.user.tag}; continuing notification:`,
@@ -1001,6 +1074,12 @@ export class SecurityActionService implements ISecurityActionService {
           );
         }
       }
+      notificationVerificationEvent = await this.ensurePrivateEvidenceThread(
+        member,
+        notificationVerificationEvent,
+        detectionResult,
+        sourceMessage
+      );
       await this.upsertNotification(
         member,
         detectionResult,

--- a/src/services/ThreadManager.ts
+++ b/src/services/ThreadManager.ts
@@ -28,6 +28,7 @@ import { getCaseResponderSettings } from '../utils/caseResponderSettings';
 export const VERIFICATION_THREAD_TYPE_METADATA_KEY = 'thread_type';
 export const VERIFICATION_THREAD_TYPE = 'verification';
 export const REPORT_REVIEW_THREAD_TYPE = 'report_review';
+export const PRIVATE_EVIDENCE_THREAD_TYPE = 'private_evidence';
 export const REPORT_INTAKE_THREAD_NAME_PREFIX = 'Report intake:';
 export const CASE_STAFF_ROUTING_METADATA_KEY = 'case_staff_routing';
 const FLAGGED_USER_THREAD_ADD_RETRY_DELAYS_MS = [750, 1500, 3000] as const;
@@ -61,6 +62,13 @@ export interface IThreadManager {
   ): Promise<VerificationThreadRepairResult>;
 
   createReportReviewThread(
+    member: GuildMember,
+    verificationEvent: VerificationEvent,
+    detectionResult: DetectionResult,
+    sourceMessage?: Message
+  ): Promise<ThreadChannel | null>;
+
+  createPrivateEvidenceThread(
     member: GuildMember,
     verificationEvent: VerificationEvent,
     detectionResult: DetectionResult,
@@ -177,6 +185,39 @@ export class ThreadManager implements IThreadManager {
     return enforceDiscordMessageLimit(contentLines.join('\n'));
   }
 
+  private buildPrivateEvidenceThreadMessage(
+    member: GuildMember,
+    verificationEvent: VerificationEvent,
+    detectionResult: DetectionResult,
+    sourceMessage?: Message
+  ): string {
+    const reasonLines = detectionResult.reasons.length
+      ? detectionResult.reasons.map((reason) => `- ${reason}`)
+      : ['- No reason provided.'];
+    const links = [
+      verificationEvent.thread_id
+        ? `User-facing case thread: https://discord.com/channels/${member.guild.id}/${verificationEvent.thread_id}`
+        : null,
+      sourceMessage?.url ? `Source message: ${sourceMessage.url}` : null,
+    ].filter((line): line is string => Boolean(line));
+
+    return enforceDiscordMessageLimit(
+      [
+        `Private evidence workspace for ${member.user.tag} (${member.id}).`,
+        'Admin-only discussion and evidence can be added here. Do not add the user under review to this thread.',
+        '',
+        `Case ID: ${verificationEvent.id}`,
+        ...links,
+        '',
+        'Case details:',
+        ...reasonLines,
+        detectionResult.triggerContent ? `Context: ${detectionResult.triggerContent}` : null,
+      ]
+        .filter((line): line is string => Boolean(line))
+        .join('\n')
+    );
+  }
+
   private buildReportIntakeThreadMessage(reporter: GuildMember): string {
     return enforceDiscordMessageLimit(
       [
@@ -214,6 +255,16 @@ export class ThreadManager implements IThreadManager {
       ...extraMetadata,
     };
     await this.verificationEventRepository.update(verificationEvent.id, verificationEvent);
+  }
+
+  private async storePrivateEvidenceThreadId(
+    verificationEvent: VerificationEvent,
+    threadId: string
+  ): Promise<void> {
+    verificationEvent.private_evidence_thread_id = threadId;
+    await this.verificationEventRepository.update(verificationEvent.id, {
+      private_evidence_thread_id: threadId,
+    });
   }
 
   private async addCaseResponderMembers(
@@ -388,6 +439,21 @@ export class ThreadManager implements IThreadManager {
     )?.fetch;
     const fetchedChannel = fetchChannel
       ? await fetchChannel.call(this.client.channels, verificationEvent.thread_id).catch(() => null)
+      : null;
+    if (!fetchedChannel) {
+      return null;
+    }
+
+    const maybeThread = fetchedChannel as ThreadChannel;
+    return maybeThread.isThread() ? maybeThread : null;
+  }
+
+  private async fetchThreadById(threadId: string): Promise<ThreadChannel | null> {
+    const fetchChannel = (
+      this.client.channels as { fetch?: (id: string) => Promise<unknown> } | undefined
+    )?.fetch;
+    const fetchedChannel = fetchChannel
+      ? await fetchChannel.call(this.client.channels, threadId).catch(() => null)
       : null;
     if (!fetchedChannel) {
       return null;
@@ -608,6 +674,7 @@ export class ThreadManager implements IThreadManager {
       // failures do not orphan a thread that was already created.
       setupStage = 'store report review thread id';
       await this.storeThreadId(verificationEvent, thread.id, REPORT_REVIEW_THREAD_TYPE);
+      await this.storePrivateEvidenceThreadId(verificationEvent, thread.id);
 
       try {
         await thread.setInvitable(false, 'Keep report review thread moderator-only');
@@ -642,6 +709,90 @@ export class ThreadManager implements IThreadManager {
       return thread;
     } catch (error) {
       console.error('Failed to create report review thread:', error);
+      if (threadWasCreated) {
+        throw this.buildThreadSetupError(setupStage, error);
+      }
+      return null;
+    }
+  }
+
+  public async createPrivateEvidenceThread(
+    member: GuildMember,
+    verificationEvent: VerificationEvent,
+    detectionResult: DetectionResult,
+    sourceMessage?: Message
+  ): Promise<ThreadChannel | null> {
+    if (verificationEvent.private_evidence_thread_id) {
+      const existing = await this.fetchThreadById(verificationEvent.private_evidence_thread_id);
+      if (existing) {
+        return existing;
+      }
+    }
+
+    const channel =
+      (await this.configService.getVerificationChannel(member.guild.id)) ||
+      (await this.configService.getAdminChannel(member.guild.id));
+
+    if (!channel) {
+      console.error('No verification or admin channel ID configured');
+      return null;
+    }
+
+    let setupStage = 'prepare private evidence thread records';
+    let threadWasCreated = false;
+
+    try {
+      await this.serverRepository.getOrCreateServer(member.guild.id);
+      await this.userRepository.getOrCreateUser(member.id, member.user.username);
+      await this.serverMemberRepository.getOrCreateMember(
+        member.guild.id,
+        member.id,
+        member.joinedAt ?? undefined
+      );
+
+      setupStage = 'create private evidence thread';
+      const thread = await channel.threads.create({
+        name: `Evidence: ${member.user.username}`,
+        autoArchiveDuration: ThreadAutoArchiveDuration.OneWeek,
+        reason: `Private evidence thread for user: ${member.user.tag}`,
+        type: ChannelType.PrivateThread,
+      });
+      threadWasCreated = true;
+
+      setupStage = 'store private evidence thread id';
+      await this.storePrivateEvidenceThreadId(verificationEvent, thread.id);
+
+      try {
+        await thread.setInvitable(false, 'Keep private evidence thread moderator-only');
+      } catch (error) {
+        console.warn(
+          `Failed to set invitable=false for private evidence thread ${thread.id} (continuing):`,
+          error
+        );
+      }
+
+      setupStage = 'route case responders to private evidence thread';
+      await this.addCaseResponderMembers(member.guild, thread, [member.id]);
+
+      setupStage = 'send private evidence thread prompt';
+      await thread.send({
+        content: this.buildPrivateEvidenceThreadMessage(
+          member,
+          verificationEvent,
+          detectionResult,
+          sourceMessage
+        ),
+        allowedMentions: {
+          parse: [],
+          users: [],
+          roles: [],
+          repliedUser: false,
+        },
+      });
+
+      return thread;
+    } catch (error) {
+      console.error('Failed to create private evidence thread:', error);
       if (threadWasCreated) {
         throw this.buildThreadSetupError(setupStage, error);
       }

--- a/src/services/UserModerationService.ts
+++ b/src/services/UserModerationService.ts
@@ -1,11 +1,11 @@
-import { GuildMember, User } from 'discord.js';
+import { Guild, GuildMember, User } from 'discord.js';
 import { injectable, inject, optional } from 'inversify';
 import { TYPES } from '../di/symbols';
 import { IServerMemberRepository } from '../repositories/ServerMemberRepository';
 import { INotificationManager } from './NotificationManager';
 import { IRoleManager } from './RoleManager';
 import { IVerificationEventRepository } from '../repositories/VerificationEventRepository';
-import { AdminActionType, VerificationStatus } from '../repositories/types';
+import { AdminActionType, VerificationEvent, VerificationStatus } from '../repositories/types';
 import { IAdminActionService } from './AdminActionService';
 import { IThreadManager } from './ThreadManager';
 import {
@@ -45,6 +45,17 @@ export interface IUserModerationService {
     moderator: User,
     detectionEventId?: string
   ): Promise<boolean>;
+
+  /**
+   * Synchronizes pending verification cases when Discord already has an existing ban.
+   */
+  syncAlreadyBannedUser(guild: Guild, userId: string, moderator: User): Promise<number>;
+}
+
+interface ModerationTarget {
+  guildId: string;
+  userId: string;
+  userTag: string;
 }
 
 /**
@@ -99,6 +110,70 @@ export class UserModerationService implements IUserModerationService {
         detectionEventId: detectionEventId ?? undefined,
       }
     );
+  }
+
+  private async getPendingVerificationEvents(member: GuildMember): Promise<VerificationEvent[]> {
+    const verificationEvents = await this.verificationEventRepository.findByUserAndServer(
+      member.id,
+      member.guild.id
+    );
+    return verificationEvents.filter((event) => event.status === VerificationStatus.PENDING);
+  }
+
+  private getModerationTarget(member: GuildMember): ModerationTarget {
+    return {
+      guildId: member.guild.id,
+      userId: member.id,
+      userTag: member.user.tag,
+    };
+  }
+
+  private async finalizeResolvedVerificationEvent(
+    target: ModerationTarget,
+    verificationEvent: VerificationEvent,
+    previousStatus: VerificationStatus,
+    newStatus: VerificationStatus.VERIFIED | VerificationStatus.BANNED,
+    actionType: AdminActionType.VERIFY | AdminActionType.BAN,
+    moderator: User,
+    strictNotification: boolean,
+    options: { notes?: string | null; detectionEventId?: string | null } = {}
+  ): Promise<void> {
+    await this.threadManager.resolveVerificationThread(verificationEvent, newStatus, moderator.id);
+
+    const logged = await this.notificationManager.logActionToMessage(
+      verificationEvent,
+      actionType,
+      moderator
+    );
+    if (!logged && strictNotification) {
+      throw new Error(`Failed to log ${actionType} action for ${target.userTag}`);
+    }
+
+    if (verificationEvent.notification_message_id || strictNotification) {
+      try {
+        await this.notificationManager.updateNotificationButtons(verificationEvent, newStatus);
+      } catch (error) {
+        if (strictNotification) {
+          throw error;
+        }
+        console.warn(
+          `Failed to update notification buttons for duplicate resolved case ${verificationEvent.id}:`,
+          error
+        );
+      }
+    }
+
+    await this.adminActionService.recordAction({
+      server_id: target.guildId,
+      user_id: target.userId,
+      admin_id: moderator.id,
+      verification_event_id: verificationEvent.id,
+      detection_event_id: options.detectionEventId,
+      action_type: actionType,
+      previous_status: previousStatus,
+      new_status: newStatus,
+      notes: options.notes ?? null,
+    });
   }
 
   /**
@@ -166,30 +241,40 @@ export class UserModerationService implements IUserModerationService {
    */
   public async verifyUser(member: GuildMember, moderator: User): Promise<boolean> {
     try {
-      const verificationEvent = await this.verificationEventRepository.findActiveByUserAndServer(
-        member.id,
-        member.guild.id
-      );
+      const pendingVerificationEvents = await this.getPendingVerificationEvents(member);
+      const verificationEvent =
+        pendingVerificationEvents.length > 0 ? pendingVerificationEvents[0] : null;
 
       if (!verificationEvent) {
         throw new Error('No active verification event found to verify');
       }
 
-      const previousStatus = verificationEvent.status;
+      const resolvedAt = new Date();
+      const resolvedEvents: Array<{
+        event: VerificationEvent;
+        previousStatus: VerificationStatus;
+      }> = [];
 
-      // Set status and resolution details
-      verificationEvent.status = VerificationStatus.VERIFIED;
-      verificationEvent.resolved_by = moderator.id;
-      verificationEvent.resolved_at = new Date();
-      const updatedEvent = await this.verificationEventRepository.update(
-        verificationEvent.id,
-        verificationEvent
-      );
-
-      if (!updatedEvent) {
-        throw new Error(
-          `Failed to update verification event ${verificationEvent.id} status to VERIFIED.`
+      for (const pendingEvent of pendingVerificationEvents) {
+        const previousStatus = pendingEvent.status;
+        const eventToUpdate = {
+          ...pendingEvent,
+          status: VerificationStatus.VERIFIED,
+          resolved_by: moderator.id,
+          resolved_at: resolvedAt,
+        };
+        const updatedEvent = await this.verificationEventRepository.update(
+          pendingEvent.id,
+          eventToUpdate
         );
+
+        if (!updatedEvent) {
+          throw new Error(
+            `Failed to update verification event ${pendingEvent.id} status to VERIFIED.`
+          );
+        }
+
+        resolvedEvents.push({ event: updatedEvent, previousStatus });
       }
 
       const roleRemoved = await this.roleManager.removeRestrictedRole(member);
@@ -204,36 +289,17 @@ export class UserModerationService implements IUserModerationService {
         last_verified_at: new Date().toISOString(),
       });
 
-      await this.threadManager.resolveVerificationThread(
-        verificationEvent,
-        VerificationStatus.VERIFIED,
-        moderator.id
-      );
-
-      const logged = await this.notificationManager.logActionToMessage(
-        verificationEvent,
-        AdminActionType.VERIFY,
-        moderator
-      );
-      if (!logged) {
-        throw new Error(`Failed to log verify action for ${member.user.tag}`);
+      for (const resolvedEvent of resolvedEvents) {
+        await this.finalizeResolvedVerificationEvent(
+          this.getModerationTarget(member),
+          resolvedEvent.event,
+          resolvedEvent.previousStatus,
+          VerificationStatus.VERIFIED,
+          AdminActionType.VERIFY,
+          moderator,
+          resolvedEvent.event.id === verificationEvent.id
+        );
       }
-
-      await this.notificationManager.updateNotificationButtons(
-        verificationEvent,
-        VerificationStatus.VERIFIED
-      );
-
-      await this.adminActionService.recordAction({
-        server_id: member.guild.id,
-        user_id: member.id,
-        admin_id: moderator.id,
-        verification_event_id: verificationEvent.id,
-        action_type: AdminActionType.VERIFY,
-        previous_status: previousStatus,
-        new_status: VerificationStatus.VERIFIED,
-        notes: null,
-      });
 
       console.log(`User ${member.user.tag} verification process completed successfully.`);
       this.captureModerationAction(
@@ -264,32 +330,36 @@ export class UserModerationService implements IUserModerationService {
     detectionEventId?: string
   ): Promise<boolean> {
     try {
-      const verificationEvent = await this.verificationEventRepository.findActiveByUserAndServer(
-        member.id,
-        member.guild.id
-      );
+      const pendingVerificationEvents = await this.getPendingVerificationEvents(member);
+      const verificationEvent =
+        pendingVerificationEvents.length > 0 ? pendingVerificationEvents[0] : null;
+      const resolvedAt = new Date();
+      const resolvedEvents: Array<{
+        event: VerificationEvent;
+        previousStatus: VerificationStatus;
+      }> = [];
 
-      const previousStatus = verificationEvent?.status;
-
-      // Allow banning even if no active verification event exists
-      // if (!verificationEvent) {
-      //   throw new Error('No active verification event found to ban');
-      // }
-
-      // Update verification event status if it exists
-      if (verificationEvent) {
-        verificationEvent.status = VerificationStatus.BANNED;
-        verificationEvent.resolved_by = moderator.id;
-        verificationEvent.resolved_at = new Date();
+      for (const pendingEvent of pendingVerificationEvents) {
+        const previousStatus = pendingEvent.status;
+        const eventToUpdate = {
+          ...pendingEvent,
+          status: VerificationStatus.BANNED,
+          resolved_by: moderator.id,
+          resolved_at: resolvedAt,
+        };
         const updatedEvent = await this.verificationEventRepository.update(
-          verificationEvent.id,
-          verificationEvent
+          pendingEvent.id,
+          eventToUpdate
         );
         if (!updatedEvent) {
           console.warn(
-            `Failed to update verification event ${verificationEvent.id} status to BANNED, but proceeding with ban.`
+            `Failed to update verification event ${pendingEvent.id} status to BANNED, but proceeding with ban.`
           );
+          resolvedEvents.push({ event: eventToUpdate, previousStatus });
+          continue;
         }
+
+        resolvedEvents.push({ event: updatedEvent, previousStatus });
       }
 
       // Perform the ban
@@ -304,38 +374,20 @@ export class UserModerationService implements IUserModerationService {
           last_status_change: new Date(),
         });
 
-        if (verificationEvent) {
-          await this.threadManager.resolveVerificationThread(
-            verificationEvent,
+        for (const resolvedEvent of resolvedEvents) {
+          await this.finalizeResolvedVerificationEvent(
+            this.getModerationTarget(member),
+            resolvedEvent.event,
+            resolvedEvent.previousStatus,
             VerificationStatus.BANNED,
-            moderator.id
-          );
-
-          const logged = await this.notificationManager.logActionToMessage(
-            verificationEvent,
             AdminActionType.BAN,
-            moderator
+            moderator,
+            resolvedEvent.event.id === verificationEvent?.id,
+            {
+              notes: reason,
+              detectionEventId: detectionEventId ?? resolvedEvent.event.detection_event_id,
+            }
           );
-          if (!logged) {
-            throw new Error(`Failed to log ban action for ${member.user.tag}`);
-          }
-
-          await this.notificationManager.updateNotificationButtons(
-            verificationEvent,
-            VerificationStatus.BANNED
-          );
-
-          await this.adminActionService.recordAction({
-            server_id: member.guild.id,
-            user_id: member.id,
-            admin_id: moderator.id,
-            verification_event_id: verificationEvent.id,
-            detection_event_id: detectionEventId,
-            action_type: AdminActionType.BAN,
-            previous_status: previousStatus ?? VerificationStatus.PENDING,
-            new_status: VerificationStatus.BANNED,
-            notes: reason,
-          });
         }
       } catch (postBanError) {
         console.error(
@@ -354,6 +406,107 @@ export class UserModerationService implements IUserModerationService {
       return true; // Ban succeeded
     } catch (error) {
       console.error(`Failed to ban user ${member.user.tag}:`, error);
+      throw error;
+    }
+  }
+
+  public async syncAlreadyBannedUser(
+    guild: Guild,
+    userId: string,
+    moderator: User
+  ): Promise<number> {
+    try {
+      const existingBan = await guild.bans.fetch(userId).catch(() => null);
+      if (!existingBan) {
+        throw new Error(`User ${userId} is not banned in guild ${guild.id}`);
+      }
+
+      const verificationEvents = await this.verificationEventRepository.findByUserAndServer(
+        userId,
+        guild.id
+      );
+      const pendingVerificationEvents = verificationEvents.filter(
+        (event) => event.status === VerificationStatus.PENDING
+      );
+      if (pendingVerificationEvents.length === 0) {
+        return 0;
+      }
+
+      const resolvedAt = new Date();
+      const resolvedEvents: Array<{
+        event: VerificationEvent;
+        previousStatus: VerificationStatus;
+      }> = [];
+
+      for (const pendingEvent of pendingVerificationEvents) {
+        const previousStatus = pendingEvent.status;
+        const eventToUpdate = {
+          ...pendingEvent,
+          status: VerificationStatus.BANNED,
+          resolved_by: moderator.id,
+          resolved_at: resolvedAt,
+        };
+        const updatedEvent = await this.verificationEventRepository.update(
+          pendingEvent.id,
+          eventToUpdate
+        );
+        resolvedEvents.push({ event: updatedEvent ?? eventToUpdate, previousStatus });
+      }
+
+      await this.serverMemberRepository.upsertMember(guild.id, userId, {
+        verification_status: VerificationStatus.BANNED,
+        is_restricted: true,
+        last_status_change: new Date(),
+      });
+
+      const existingBanReason = existingBan.reason?.trim() ?? '';
+      const notes = existingBanReason
+        ? `Synced existing Discord ban: ${existingBanReason}`
+        : 'Synced existing Discord ban.';
+      const target = {
+        guildId: guild.id,
+        userId,
+        userTag: existingBan.user.tag,
+      };
+
+      try {
+        for (const resolvedEvent of resolvedEvents) {
+          await this.finalizeResolvedVerificationEvent(
+            target,
+            resolvedEvent.event,
+            resolvedEvent.previousStatus,
+            VerificationStatus.BANNED,
+            AdminActionType.BAN,
+            moderator,
+            resolvedEvent.event.id === resolvedEvents[0].event.id,
+            {
+              notes,
+              detectionEventId: resolvedEvent.event.detection_event_id,
+            }
+          );
+        }
+      } catch (postSyncError) {
+        console.error(
+          `Existing ban sync succeeded for ${target.userTag}, but post-sync updates failed:`,
+          postSyncError
+        );
+      }
+
+      void this.productAnalyticsService.captureUserEvent(
+        guild.id,
+        userId,
+        'moderation action completed',
+        { action_type: AdminActionType.BAN, synced_already_banned: true },
+        {
+          moderatorId: moderator.id,
+          verificationEventId: resolvedEvents[0].event.id,
+          detectionEventId: resolvedEvents[0].event.detection_event_id ?? undefined,
+        }
+      );
+
+      return resolvedEvents.length;
+    } catch (error) {
+      console.error(`Failed to sync already-banned user ${userId}:`, error);
       throw error;
     }
   }

--- a/src/utils/adminActionCustomIds.ts
+++ b/src/utils/adminActionCustomIds.ts
@@ -1,0 +1,49 @@
+export const ADMIN_ACTION_CUSTOM_ID_PREFIX = 'admin_actions';
+
+export type AdminActionSurface = 'case' | 'observed';
+
+export function buildCaseAdminActionsCustomId(userId: string): string {
+  return `${ADMIN_ACTION_CUSTOM_ID_PREFIX}:menu:case:${userId}`;
+}
+
+export function buildObservedAdminActionsCustomId(
+  userId: string,
+  detectionEventId: string
+): string {
+  return `${ADMIN_ACTION_CUSTOM_ID_PREFIX}:menu:observed:${userId}:${detectionEventId}`;
+}
+
+export function buildAdminActionCustomId(
+  action: string,
+  surface: AdminActionSurface,
+  userId: string,
+  detectionEventId?: string
+): string {
+  return [ADMIN_ACTION_CUSTOM_ID_PREFIX, action, surface, userId, detectionEventId]
+    .filter((part): part is string => Boolean(part))
+    .join(':');
+}
+
+export interface ParsedAdminActionCustomId {
+  readonly action: string;
+  readonly surface: AdminActionSurface;
+  readonly userId: string;
+  readonly detectionEventId?: string;
+}
+
+export function parseAdminActionCustomId(customId: string): ParsedAdminActionCustomId | null {
+  const [prefix, action, surface, userId, detectionEventId] = customId.split(':');
+  if (prefix !== ADMIN_ACTION_CUSTOM_ID_PREFIX || !action || !surface || !userId) {
+    return null;
+  }
+  if (surface !== 'case' && surface !== 'observed') {
+    return null;
+  }
+
+  return {
+    action,
+    surface,
+    userId,
+    ...(detectionEventId ? { detectionEventId } : {}),
+  };
+}

--- a/src/utils/adminActionCustomIds.ts
+++ b/src/utils/adminActionCustomIds.ts
@@ -1,16 +1,78 @@
 export const ADMIN_ACTION_CUSTOM_ID_PREFIX = 'admin_actions';
+const DISCORD_CUSTOM_ID_MAX_LENGTH = 100;
 
 export type AdminActionSurface = 'case' | 'observed';
 
+const SURFACE_TO_CODE: Record<AdminActionSurface, string> = {
+  case: 'c',
+  observed: 'o',
+};
+const CODE_TO_SURFACE: Record<string, AdminActionSurface> = {
+  c: 'case',
+  o: 'observed',
+};
+
+const ACTION_TO_CODE: Record<string, string> = {
+  menu: 'm',
+  history: 'h',
+  ban: 'b',
+  observed_ban: 'ob',
+  verify: 'v',
+  thread: 't',
+  repair: 'rp',
+  sync_ban: 'sb',
+  reopen: 'ro',
+  observed_open: 'oo',
+  observed_restrict: 'or',
+  observed_dismiss: 'od',
+  observed_false_positive: 'ofp',
+  observed_undo_dismiss: 'oud',
+  confirm_verify: 'cv',
+  confirm_thread: 'ct',
+  confirm_repair: 'crp',
+  confirm_sync_ban: 'csb',
+  confirm_reopen: 'cro',
+  confirm_observed_open: 'coo',
+  confirm_observed_restrict: 'cor',
+  confirm_observed_dismiss: 'cod',
+  confirm_observed_false_positive: 'cofp',
+  confirm_observed_undo_dismiss: 'coud',
+  cancel: 'x',
+};
+const CODE_TO_ACTION = Object.fromEntries(
+  Object.entries(ACTION_TO_CODE).map(([action, code]) => [code, action])
+) as Record<string, string>;
+
+function assertCustomIdLength(customId: string): string {
+  if (customId.length > DISCORD_CUSTOM_ID_MAX_LENGTH) {
+    throw new Error(
+      `Admin action custom_id exceeds Discord's ${DISCORD_CUSTOM_ID_MAX_LENGTH}-character limit.`
+    );
+  }
+
+  return customId;
+}
+
+function parseSurface(value: string): AdminActionSurface | null {
+  if (value === 'c' || value === 'case') {
+    return 'case';
+  }
+  if (value === 'o' || value === 'observed') {
+    return 'observed';
+  }
+
+  return null;
+}
+
 export function buildCaseAdminActionsCustomId(userId: string): string {
-  return `${ADMIN_ACTION_CUSTOM_ID_PREFIX}:menu:case:${userId}`;
+  return buildAdminActionCustomId('menu', 'case', userId);
 }
 
 export function buildObservedAdminActionsCustomId(
   userId: string,
   detectionEventId: string
 ): string {
-  return `${ADMIN_ACTION_CUSTOM_ID_PREFIX}:menu:observed:${userId}:${detectionEventId}`;
+  return buildAdminActionCustomId('menu', 'observed', userId, detectionEventId);
 }
 
 export function buildAdminActionCustomId(
@@ -19,9 +81,17 @@ export function buildAdminActionCustomId(
   userId: string,
   detectionEventId?: string
 ): string {
-  return [ADMIN_ACTION_CUSTOM_ID_PREFIX, action, surface, userId, detectionEventId]
-    .filter((part): part is string => Boolean(part))
-    .join(':');
+  return assertCustomIdLength(
+    [
+      ADMIN_ACTION_CUSTOM_ID_PREFIX,
+      ACTION_TO_CODE[action] ?? action,
+      SURFACE_TO_CODE[surface],
+      userId,
+      detectionEventId,
+    ]
+      .filter((part): part is string => Boolean(part))
+      .join(':')
+  );
 }
 
 export interface ParsedAdminActionCustomId {
@@ -32,11 +102,13 @@ export interface ParsedAdminActionCustomId {
 }
 
 export function parseAdminActionCustomId(customId: string): ParsedAdminActionCustomId | null {
-  const [prefix, action, surface, userId, detectionEventId] = customId.split(':');
-  if (prefix !== ADMIN_ACTION_CUSTOM_ID_PREFIX || !action || !surface || !userId) {
+  const [prefix, actionCode, surfaceCode, userId, detectionEventId] = customId.split(':');
+  if (prefix !== ADMIN_ACTION_CUSTOM_ID_PREFIX || !actionCode || !surfaceCode || !userId) {
     return null;
   }
-  if (surface !== 'case' && surface !== 'observed') {
+  const action = CODE_TO_ACTION[actionCode] ?? actionCode;
+  const surface = parseSurface(CODE_TO_SURFACE[surfaceCode] ?? surfaceCode);
+  if (!surface) {
     return null;
   }
 

--- a/src/utils/caseReviewReminderSettings.ts
+++ b/src/utils/caseReviewReminderSettings.ts
@@ -1,0 +1,40 @@
+import type { ServerSettings } from '../repositories/types';
+
+export const CASE_REVIEW_REMINDERS_ENABLED_SETTING_KEY = 'case_review_reminders_enabled';
+export const CASE_REVIEW_REMINDER_STALE_HOURS_SETTING_KEY = 'case_review_reminder_stale_hours';
+export const CASE_REVIEW_REMINDER_REPEAT_HOURS_SETTING_KEY = 'case_review_reminder_repeat_hours';
+
+export const DEFAULT_CASE_REVIEW_REMINDER_STALE_HOURS = 24;
+export const DEFAULT_CASE_REVIEW_REMINDER_REPEAT_HOURS = 24;
+export const MIN_CASE_REVIEW_REMINDER_HOURS = 1;
+export const MAX_CASE_REVIEW_REMINDER_HOURS = 168;
+
+export interface CaseReviewReminderSettings {
+  readonly enabled: boolean;
+  readonly staleHours: number;
+  readonly repeatHours: number;
+}
+
+function readHours(value: unknown, fallback: number): number {
+  if (typeof value !== 'number' || !Number.isInteger(value)) {
+    return fallback;
+  }
+
+  return Math.min(Math.max(value, MIN_CASE_REVIEW_REMINDER_HOURS), MAX_CASE_REVIEW_REMINDER_HOURS);
+}
+
+export function getCaseReviewReminderSettings(
+  settings: ServerSettings = {}
+): CaseReviewReminderSettings {
+  return {
+    enabled: settings[CASE_REVIEW_REMINDERS_ENABLED_SETTING_KEY] === true,
+    staleHours: readHours(
+      settings[CASE_REVIEW_REMINDER_STALE_HOURS_SETTING_KEY],
+      DEFAULT_CASE_REVIEW_REMINDER_STALE_HOURS
+    ),
+    repeatHours: readHours(
+      settings[CASE_REVIEW_REMINDER_REPEAT_HOURS_SETTING_KEY],
+      DEFAULT_CASE_REVIEW_REMINDER_REPEAT_HOURS
+    ),
+  };
+}

--- a/src/utils/verificationActionFailures.ts
+++ b/src/utils/verificationActionFailures.ts
@@ -1,6 +1,6 @@
 export const VERIFICATION_ACTION_FAILURES_METADATA_KEY = 'action_failures';
 
-export type VerificationActionFailureKind = 'restrict' | 'thread';
+export type VerificationActionFailureKind = 'restrict' | 'thread' | 'private_evidence_thread';
 
 export interface VerificationActionFailure {
   action: VerificationActionFailureKind;
@@ -17,7 +17,7 @@ function metadataToRecord(metadata: unknown): Record<string, unknown> {
 }
 
 function isVerificationActionFailureKind(value: unknown): value is VerificationActionFailureKind {
-  return value === 'restrict' || value === 'thread';
+  return value === 'restrict' || value === 'thread' || value === 'private_evidence_thread';
 }
 
 function isVerificationActionFailure(value: unknown): value is VerificationActionFailure {


### PR DESCRIPTION
## Summary
- Add a single persistent Admin Actions entry point with ephemeral action panels and confirmations.
- Add private evidence thread linkage/backfill plus explicit `private_evidence_thread_id` storage.
- Add configurable stale pending-case reminders and duplicate/already-banned pending-case cleanup paths.

## Why
Implements #108 by reducing persistent one-click moderation buttons, keeping admin-only evidence separate from user-facing case threads, and making stale/orphaned pending cases easier to surface and resolve.

## Testing
- `npm run lint`
- `npm run format:check`
- `npm run build`
- `git diff --check`
- `npm test`
- `npm run test:integration` attempted, blocked by local DB unavailable: `connect ECONNREFUSED 127.0.0.1:54322`

## Risk Notes
- Reminder defaults are disabled unless configured.
- Private evidence thread creation is non-blocking and records a warning if it fails.
- Existing banned-user sync requires explicit Admin Actions confirmation and Discord ban-list confirmation.

Closes #108