### PR TITLE
Add admin evidence threads and message context

### DIFF
--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -29,6 +29,26 @@ events, admin actions, and Discord surfaces.
      restricts the user, creates a verification thread, and upserts the admin
      notification.
 
+## Recent message context
+
+Drasil persists short-lived message context for moderation inference by default.
+Normal guild messages from non-bot users are stored in `message_contexts` as a
+truncated `content_preview` plus lightweight derived features such as URL count,
+mention count, attachment count, invite presence, and thread status. This store is
+for moderation context, not analytics or model training.
+
+Retention and bounds are intentionally tight:
+
+- Message context expires after 30 days.
+- At most 20 recent messages are retained per user per server.
+- At most 50,000 message context rows are retained per server.
+- Expired rows are pruned opportunistically during message handling.
+
+When GPT profile analysis runs for a message, `EventHandler` reads recent context
+from this persistent store instead of relying on process-local memory. If the store
+is unavailable, Drasil continues without recent-message context rather than blocking
+moderation flow.
+
 ## AI detection diagnostics
 
 When `DetectionOrchestrator` asks GPT to classify profile/message context, the
@@ -59,8 +79,40 @@ if one is set.
 ## Manual flag
 
 1. Admin initiates a manual flag.
-2. `SecurityActionService.handleManualFlag` creates a `detection_event` with
-   `metadata.type = "admin_flag"` and follows the same case flow as above.
+2. `SecurityActionService.handleManualFlag` creates a detection event with
+   `detection_type = ADMIN_FLAG` and `metadata.type = "admin_flag"`, then follows
+   the same case flow as above.
+
+## Admin-opened case and role intake
+
+Admin-opened cases and bulk role intake are explicit moderator/server workflows,
+not GPT detections.
+
+- `/case open` and `/case restrict` create `detection_type = ADMIN_CASE` events.
+- `/case intake-role` creates `detection_type = ROLE_INTAKE` events with source
+  role ID/name and batch metadata.
+- Admin-facing reasons render Discord mentions for the moderator and, for role
+  intake, the source role. Embed allowed-mentions remain disabled so these fields
+  render clearly without causing extra pings.
+
+## Case threads and private evidence
+
+Case notifications are posted in the configured admin channel. Drasil then starts
+an attached evidence thread from that admin notification message and stores it as
+`verification_events.private_evidence_thread_id`. Because the evidence thread is
+attached to the notification message, the embed is visible at the top of the thread
+without duplicating/mirroring the embed contents.
+
+Responder routing follows `/config case-staff`:
+
+- `off`: no case responder role routing.
+- `ping_only`: the evidence-thread prompt pings configured admin/case roles.
+- `ping_and_add_members`: configured case responder members are added when under
+  the member cap, and admin/case roles are also mentioned in the prompt.
+
+The user-facing verification thread, when present, remains separate in the
+verification/quarantine channel and is linked prominently in the admin embed's
+`Case Threads` field.
 
 ## User report
 

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -95,13 +95,17 @@ not GPT detections.
   intake, the source role. Embed allowed-mentions remain disabled so these fields
   render clearly without causing extra pings.
 
-## Case threads and private evidence
+## Case threads and admin evidence
 
 Case notifications are posted in the configured admin channel. Drasil then starts
 an attached evidence thread from that admin notification message and stores it as
 `verification_events.private_evidence_thread_id`. Because the evidence thread is
 attached to the notification message, the embed is visible at the top of the thread
 without duplicating/mirroring the embed contents.
+
+Attached evidence threads are not Discord `PrivateThread`s. Their visibility follows
+the admin notification channel and thread membership, so servers should keep the
+admin notification channel restricted to staff allowed to see case evidence.
 
 Responder routing follows `/config case-staff`:
 

--- a/prisma/migrations/20260603150000_add_admin_detection_types_and_message_contexts/migration.sql
+++ b/prisma/migrations/20260603150000_add_admin_detection_types_and_message_contexts/migration.sql
@@ -26,4 +26,14 @@ CREATE INDEX IF NOT EXISTS idx_message_contexts_server_created_at
   ON public.message_contexts(server_id, created_at DESC);
 
 ALTER TABLE public.message_contexts ENABLE ROW LEVEL SECURITY;
-REVOKE ALL ON TABLE public.message_contexts FROM anon, authenticated;
+
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'anon') THEN
+    REVOKE ALL ON TABLE public.message_contexts FROM anon;
+  END IF;
+
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'authenticated') THEN
+    REVOKE ALL ON TABLE public.message_contexts FROM authenticated;
+  END IF;
+END $$;

--- a/prisma/migrations/20260603150000_add_admin_detection_types_and_message_contexts/migration.sql
+++ b/prisma/migrations/20260603150000_add_admin_detection_types_and_message_contexts/migration.sql
@@ -1,0 +1,29 @@
+ALTER TYPE public.detection_type ADD VALUE IF NOT EXISTS 'admin_case';
+ALTER TYPE public.detection_type ADD VALUE IF NOT EXISTS 'admin_flag';
+ALTER TYPE public.detection_type ADD VALUE IF NOT EXISTS 'role_intake';
+
+CREATE TABLE IF NOT EXISTS public.message_contexts (
+  id uuid NOT NULL DEFAULT extensions.uuid_generate_v4(),
+  server_id text NOT NULL,
+  user_id text NOT NULL,
+  message_id text NOT NULL,
+  channel_id text,
+  content_preview text NOT NULL,
+  content_features jsonb DEFAULT '{}',
+  created_at timestamptz(6) NOT NULL,
+  observed_at timestamptz(6) NOT NULL DEFAULT now(),
+  expires_at timestamptz(6) NOT NULL,
+  CONSTRAINT message_contexts_pkey PRIMARY KEY (id)
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS message_contexts_server_message_key
+  ON public.message_contexts(server_id, message_id);
+CREATE INDEX IF NOT EXISTS idx_message_contexts_expires_at
+  ON public.message_contexts(expires_at);
+CREATE INDEX IF NOT EXISTS idx_message_contexts_server_user_created_at
+  ON public.message_contexts(server_id, user_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_message_contexts_server_created_at
+  ON public.message_contexts(server_id, created_at DESC);
+
+ALTER TABLE public.message_contexts ENABLE ROW LEVEL SECURITY;
+REVOKE ALL ON TABLE public.message_contexts FROM anon, authenticated;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -67,6 +67,24 @@ model detection_events {
   @@index([user_id, server_id, detection_type], map: "idx_detection_events_user_server_type")
 }
 
+model message_contexts {
+  id               String   @id @default(dbgenerated("extensions.uuid_generate_v4()")) @db.Uuid
+  server_id        String
+  user_id          String
+  message_id       String
+  channel_id       String?
+  content_preview  String
+  content_features Json?    @default("{}")
+  created_at       DateTime @db.Timestamptz(6)
+  observed_at      DateTime @default(now()) @db.Timestamptz(6)
+  expires_at       DateTime @db.Timestamptz(6)
+
+  @@unique([server_id, message_id], map: "message_contexts_server_message_key")
+  @@index([expires_at], map: "idx_message_contexts_expires_at")
+  @@index([server_id, user_id, created_at], map: "idx_message_contexts_server_user_created_at")
+  @@index([server_id, created_at], map: "idx_message_contexts_server_created_at")
+}
+
 /// This model or at least one of its fields has comments in the database, and requires an additional setup for migrations: Read more: https://pris.ly/d/database-comments
 /// This model contains row level security and requires additional setup for migrations. Visit https://pris.ly/d/row-level-security for more info.
 model server_members {
@@ -226,6 +244,9 @@ enum detection_type {
   new_account
   pattern_match
   user_report
+  admin_case
+  admin_flag
+  role_intake
 }
 
 enum report_intake_status {

--- a/src/__tests__/unit/EventHandler.unit.test.ts
+++ b/src/__tests__/unit/EventHandler.unit.test.ts
@@ -17,6 +17,7 @@ describe('EventHandler (unit)', () => {
     notificationManager?: Record<string, jest.Mock>;
     setupDiagnosticsService?: Record<string, jest.Mock>;
     reportIntakeService?: Record<string, jest.Mock>;
+    messageContextRepository?: Record<string, jest.Mock>;
   }): EventHandler {
     const client = overrides?.client ?? { on: jest.fn(), user: { id: 'bot-1' } };
     const detectionOrchestrator = overrides?.detectionOrchestrator ?? {
@@ -67,7 +68,9 @@ describe('EventHandler (unit)', () => {
       { handleThreadMessage: jest.fn().mockResolvedValue(false) } as any,
       undefined,
       overrides?.setupDiagnosticsService as any,
-      overrides?.reportIntakeService as any
+      overrides?.reportIntakeService as any,
+      undefined,
+      overrides?.messageContextRepository as any
     );
   }
 
@@ -405,7 +408,16 @@ describe('EventHandler (unit)', () => {
       }),
       detectNewJoin: jest.fn(),
     };
-    const handler = buildHandler({ detectionOrchestrator });
+    const messageContextRepository = {
+      findRecentByServerAndUser: jest.fn().mockResolvedValue([
+        {
+          content_preview: 'hello everyone',
+        },
+      ]),
+      recordMessage: jest.fn().mockResolvedValue(undefined),
+      pruneExpired: jest.fn().mockResolvedValue(0),
+    };
+    const handler = buildHandler({ detectionOrchestrator, messageContextRepository });
     const permissions = new PermissionsBitField();
     const firstMessage = buildMessage(permissions) as any;
     firstMessage.id = 'message-1';
@@ -454,6 +466,7 @@ describe('EventHandler (unit)', () => {
         channelContext: ['other_user: We are joking about giveaways'],
       })
     );
+    expect(messageContextRepository.recordMessage).toHaveBeenCalled();
   });
 
   it('loads config before exempting moderators when no cached config exists', async () => {

--- a/src/__tests__/unit/SecurityActionService.unit.test.ts
+++ b/src/__tests__/unit/SecurityActionService.unit.test.ts
@@ -676,9 +676,10 @@ describe('SecurityActionService (unit)', () => {
     expect(detectionEvents[0].metadata).toMatchObject({
       reason: 'No reason provided.',
     });
-    expect(detectionEvents[0].reasons[0]).toContain('No reason provided.');
+    expect(detectionEvents[0].reasons[0]).toBe('Admin case opened by <@admin-blank-reason>.');
     const detectionResult = notificationManager.upsertSuspiciousUserNotification.mock.calls[0][1];
-    expect(detectionResult.triggerContent).toBe('Admin-opened case');
+    expect(detectionResult.triggerSource).toBe(DetectionType.ADMIN_CASE);
+    expect(detectionResult.triggerContent).toBe('Opened by <@admin-blank-reason>');
   });
 
   it('preserves trusted admin case metadata over caller metadata', async () => {
@@ -1418,7 +1419,7 @@ describe('SecurityActionService (unit)', () => {
 
     const detectionEvents = await detectionEventsRepository.findByServerAndUser(guildId, userId);
     expect(detectionEvents).toHaveLength(1);
-    expect(detectionEvents[0].detection_type).toBe(DetectionType.GPT_ANALYSIS);
+    expect(detectionEvents[0].detection_type).toBe(DetectionType.ADMIN_FLAG);
     expect(detectionEvents[0].metadata).toMatchObject({
       type: 'admin_flag',
       adminId: moderatorId,

--- a/src/__tests__/unit/ThreadManager.unit.test.ts
+++ b/src/__tests__/unit/ThreadManager.unit.test.ts
@@ -565,6 +565,94 @@ describe('ThreadManager (unit)', () => {
     }
   });
 
+  it('creates an admin evidence thread from the notification message', async () => {
+    const manager = new ThreadManager(
+      {} as any,
+      configService,
+      verificationEventRepository,
+      userRepository,
+      serverRepository,
+      serverMemberRepository
+    );
+    const member = buildMember('guild-1', 'user-1');
+    const event = await verificationEventRepository.createFromDetection(
+      null,
+      'guild-1',
+      'user-1',
+      VerificationStatus.PENDING
+    );
+    const notificationMessage = {
+      startThread: jest.fn().mockResolvedValue(thread),
+      fetch: jest.fn().mockResolvedValue({ thread: null }),
+    } as any;
+
+    const createdThread = await manager.createPrivateEvidenceThread(
+      member,
+      event,
+      {
+        label: 'SUSPICIOUS',
+        confidence: 1.0,
+        reasons: ['Admin case opened by <@admin-1>.'],
+        triggerSource: DetectionType.ADMIN_CASE,
+        triggerContent: 'Opened by <@admin-1>',
+      },
+      notificationMessage
+    );
+    const storedEvent = await verificationEventRepository.findById(event.id);
+
+    expect(notificationMessage.startThread).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'Evidence: test-user' })
+    );
+    expect(createdThread?.id).toBe('thread-1');
+    expect(storedEvent?.private_evidence_thread_id).toBe('thread-1');
+    expect(thread.send).toHaveBeenCalledWith(
+      expect.objectContaining({ content: expect.stringContaining('Admin evidence workspace') })
+    );
+  });
+
+  it('recovers an already-attached admin evidence thread when duplicate start fails', async () => {
+    const manager = new ThreadManager(
+      {} as any,
+      configService,
+      verificationEventRepository,
+      userRepository,
+      serverRepository,
+      serverMemberRepository
+    );
+    const member = buildMember('guild-1', 'user-1');
+    const event = await verificationEventRepository.createFromDetection(
+      null,
+      'guild-1',
+      'user-1',
+      VerificationStatus.PENDING
+    );
+    const notificationMessage = {
+      startThread: jest
+        .fn()
+        .mockRejectedValue(new Error('Thread already created for this message')),
+      fetch: jest.fn().mockResolvedValueOnce({ thread: null }).mockResolvedValueOnce({ thread }),
+    } as any;
+
+    const recoveredThread = await manager.createPrivateEvidenceThread(
+      member,
+      event,
+      {
+        label: 'SUSPICIOUS',
+        confidence: 1.0,
+        reasons: ['Admin case opened by <@admin-1>.'],
+        triggerSource: DetectionType.ADMIN_CASE,
+        triggerContent: 'Opened by <@admin-1>',
+      },
+      notificationMessage
+    );
+    const storedEvent = await verificationEventRepository.findById(event.id);
+
+    expect(notificationMessage.startThread).toHaveBeenCalled();
+    expect(notificationMessage.fetch).toHaveBeenCalledTimes(2);
+    expect(recoveredThread?.id).toBe('thread-1');
+    expect(storedEvent?.private_evidence_thread_id).toBe('thread-1');
+  });
+
   it('creates an inactive report intake thread before adding the reporter', async () => {
     const manager = new ThreadManager(
       {} as any,

--- a/src/controllers/EventHandler.ts
+++ b/src/controllers/EventHandler.ts
@@ -37,13 +37,15 @@ import {
 } from '../services/SetupDiagnosticsService';
 import { IReportIntakeService } from '../services/ReportIntakeService';
 import { ICaseReviewReminderService } from '../services/CaseReviewReminderService';
+import {
+  IMessageContextRepository,
+  MESSAGE_CONTEXT_PREVIEW_MAX_LENGTH,
+  MESSAGE_CONTEXT_RETENTION_DAYS,
+  MESSAGE_CONTEXT_USER_LIMIT,
+} from '../repositories/MessageContextRepository';
 
-const RECENT_USER_CONTEXT_MESSAGE_LIMIT = 5;
-const RECENT_USER_CONTEXT_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
-const RECENT_USER_CONTEXT_CLEANUP_INTERVAL_MS = 60 * 1000;
-const RECENT_USER_CONTEXT_MAX_USERS_PER_SERVER = 1000;
-const RECENT_USER_CONTEXT_MAX_SERVERS = 100;
 const CHANNEL_CONTEXT_MESSAGE_LIMIT = 5;
+const MESSAGE_CONTEXT_PRUNE_INTERVAL_MS = 60 * 60 * 1000;
 const SETUP_NUDGE_SUPPRESSION_MS = 7 * 24 * 60 * 60 * 1000;
 const SETUP_WARNING_VALIDATION_PRECHECK_MS = 5 * 60 * 1000;
 const SETUP_WARNING_LAST_FINGERPRINT_SETTING_KEY = 'setup_warning_last_fingerprint';
@@ -60,12 +62,6 @@ interface SetupNudgeUser {
   readonly id: string;
   readonly bot?: boolean;
   send(content: string): Promise<unknown>;
-}
-
-interface RecentUserMessageContext {
-  content: string;
-  createdTimestamp: number;
-  channelId?: string;
 }
 
 type CachedMessageChannel = Message['channel'] & {
@@ -100,10 +96,10 @@ export class EventHandler implements IEventHandler {
   private setupDiagnosticsService?: ISetupDiagnosticsService;
   private reportIntakeService?: IReportIntakeService;
   private caseReviewReminderService?: ICaseReviewReminderService;
+  private messageContextRepository?: IMessageContextRepository;
   private serverConfigWarmups: Set<string> = new Set();
   private configInitializePromise: Promise<void> | null = null;
-  private recentMessagesByServer: Map<string, Map<string, RecentUserMessageContext[]>> = new Map();
-  private lastRecentMessageContextCleanupAt = 0;
+  private lastMessageContextPruneAt = 0;
 
   constructor(
     @inject(TYPES.DiscordClient) client: Client,
@@ -126,7 +122,10 @@ export class EventHandler implements IEventHandler {
     reportIntakeService?: IReportIntakeService,
     @inject(TYPES.CaseReviewReminderService)
     @optional()
-    caseReviewReminderService?: ICaseReviewReminderService
+    caseReviewReminderService?: ICaseReviewReminderService,
+    @inject(TYPES.MessageContextRepository)
+    @optional()
+    messageContextRepository?: IMessageContextRepository
   ) {
     this.client = client;
     this.detectionOrchestrator = detectionOrchestrator;
@@ -140,6 +139,7 @@ export class EventHandler implements IEventHandler {
     this.setupDiagnosticsService = setupDiagnosticsService;
     this.reportIntakeService = reportIntakeService;
     this.caseReviewReminderService = caseReviewReminderService;
+    this.messageContextRepository = messageContextRepository;
   }
 
   public async setupEventHandlers(): Promise<void> {
@@ -233,8 +233,6 @@ export class EventHandler implements IEventHandler {
     const userId = message.author.id;
     const serverId = message.guild.id;
     const content = message.content;
-    const recentMessages = this.getRecentUserMessages(serverId, userId);
-
     if (this.isAutomaticDetectionExemptByCachedSettings(message.member)) {
       this.rememberRecentMessage(message);
       return;
@@ -272,6 +270,8 @@ export class EventHandler implements IEventHandler {
       ) {
         return;
       }
+
+      const recentMessages = await this.getRecentUserMessages(serverId, userId);
 
       // Get user profile data for detection context
       const profileData = this.extractUserProfileData(message.member, {
@@ -567,25 +567,29 @@ export class EventHandler implements IEventHandler {
     return permissions.filter(({ flag }) => member.permissions.has(flag)).map(({ label }) => label);
   }
 
-  private getRecentUserMessages(serverId: string, userId: string): string[] {
-    const serverMessages = this.recentMessagesByServer.get(serverId);
-    const messages = serverMessages?.get(userId) ?? [];
-    const cutoff = Date.now() - RECENT_USER_CONTEXT_MAX_AGE_MS;
-    const recentMessages = messages.filter((message) => message.createdTimestamp > cutoff);
-
-    if (serverMessages && recentMessages.length !== messages.length) {
-      if (recentMessages.length > 0) {
-        serverMessages.set(userId, recentMessages);
-      } else {
-        serverMessages.delete(userId);
-      }
+  private async getRecentUserMessages(serverId: string, userId: string): Promise<string[]> {
+    if (!this.messageContextRepository) {
+      return [];
     }
 
-    return recentMessages.map((message) => message.content);
+    try {
+      const messages = await this.messageContextRepository.findRecentByServerAndUser(
+        serverId,
+        userId,
+        MESSAGE_CONTEXT_USER_LIMIT
+      );
+      return messages.map((message) => message.content_preview);
+    } catch (error) {
+      console.warn(
+        `Failed to load persistent message context for user ${userId} in guild ${serverId}:`,
+        error
+      );
+      return [];
+    }
   }
 
   private rememberRecentMessage(message: Message): void {
-    if (!message.guild || message.author.bot) {
+    if (!this.messageContextRepository || !message.guild || message.author.bot) {
       return;
     }
 
@@ -595,65 +599,51 @@ export class EventHandler implements IEventHandler {
     }
 
     const now = Date.now();
-    this.pruneRecentMessageContext(now);
+    const expiresAt = new Date(now + MESSAGE_CONTEXT_RETENTION_DAYS * 24 * 60 * 60 * 1000);
 
-    const serverId = message.guild.id;
-    const userId = message.author.id;
-    const serverMessages =
-      this.recentMessagesByServer.get(serverId) ?? new Map<string, RecentUserMessageContext[]>();
-    const cutoff = now - RECENT_USER_CONTEXT_MAX_AGE_MS;
-    const previousMessages = serverMessages.get(userId) ?? [];
-    const nextMessages = [
-      ...previousMessages.filter((entry) => entry.createdTimestamp > cutoff),
-      {
-        content,
-        createdTimestamp: message.createdTimestamp || now,
+    void this.messageContextRepository
+      .recordMessage({
+        serverId: message.guild.id,
+        userId: message.author.id,
+        messageId: message.id,
         channelId: message.channelId,
-      },
-    ].slice(-RECENT_USER_CONTEXT_MESSAGE_LIMIT);
+        contentPreview: content.slice(0, MESSAGE_CONTEXT_PREVIEW_MAX_LENGTH),
+        contentFeatures: this.extractMessageContextFeatures(message, content),
+        createdAt: new Date(message.createdTimestamp || now),
+        observedAt: new Date(now),
+        expiresAt,
+      })
+      .catch((error) => {
+        console.warn(
+          `Failed to persist message context for ${message.author.id} in guild ${message.guild?.id}:`,
+          error
+        );
+      });
 
-    serverMessages.delete(userId);
-    serverMessages.set(userId, nextMessages);
-    while (serverMessages.size > RECENT_USER_CONTEXT_MAX_USERS_PER_SERVER) {
-      const oldestUserId = serverMessages.keys().next().value as string | undefined;
-      if (!oldestUserId) {
-        break;
-      }
-      serverMessages.delete(oldestUserId);
+    if (now - this.lastMessageContextPruneAt >= MESSAGE_CONTEXT_PRUNE_INTERVAL_MS) {
+      this.lastMessageContextPruneAt = now;
+      void this.messageContextRepository.pruneExpired(new Date(now)).catch((error) => {
+        console.warn('Failed to prune expired message context:', error);
+      });
     }
-
-    this.recentMessagesByServer.set(serverId, serverMessages);
   }
 
-  private pruneRecentMessageContext(now: number): void {
-    if (now - this.lastRecentMessageContextCleanupAt < RECENT_USER_CONTEXT_CLEANUP_INTERVAL_MS) {
-      return;
-    }
-    this.lastRecentMessageContextCleanupAt = now;
+  private extractMessageContextFeatures(
+    message: Message,
+    content: string
+  ): Record<string, unknown> {
+    const urlMatches = content.match(/https?:\/\/\S+|www\.\S+/gi) ?? [];
+    const mentionMatches = content.match(/<[@#&!?]*\d{17,20}>|@(everyone|here)\b/gi) ?? [];
+    const attachmentCount = (message as { attachments?: { size: number } }).attachments?.size ?? 0;
 
-    const cutoff = now - RECENT_USER_CONTEXT_MAX_AGE_MS;
-    for (const [serverId, serverMessages] of this.recentMessagesByServer.entries()) {
-      for (const [userId, messages] of serverMessages.entries()) {
-        const recentMessages = messages.filter((message) => message.createdTimestamp > cutoff);
-        if (recentMessages.length > 0) {
-          serverMessages.set(userId, recentMessages);
-        } else {
-          serverMessages.delete(userId);
-        }
-      }
-
-      if (serverMessages.size === 0) {
-        this.recentMessagesByServer.delete(serverId);
-      }
-    }
-
-    while (this.recentMessagesByServer.size > RECENT_USER_CONTEXT_MAX_SERVERS) {
-      const oldestServerId = this.recentMessagesByServer.keys().next().value as string | undefined;
-      if (!oldestServerId) {
-        break;
-      }
-      this.recentMessagesByServer.delete(oldestServerId);
-    }
+    return {
+      length: content.length,
+      url_count: urlMatches.length,
+      mention_count: mentionMatches.length,
+      attachment_count: attachmentCount,
+      has_discord_invite: /(?:discord\.gg|discord\.com\/invite)\//i.test(content),
+      in_thread: message.channel.isThread(),
+    };
   }
 
   private getCachedChannelContext(message: Message): string[] {

--- a/src/controllers/InteractionHandler.ts
+++ b/src/controllers/InteractionHandler.ts
@@ -426,7 +426,7 @@ export class InteractionHandler implements IInteractionHandler {
     }
     if (activeCase?.private_evidence_thread_id) {
       details.push(
-        `Private evidence: https://discord.com/channels/${guildId}/${activeCase.private_evidence_thread_id}`
+        `Admin evidence: https://discord.com/channels/${guildId}/${activeCase.private_evidence_thread_id}`
       );
     }
     if (alreadyBanned) {

--- a/src/di/container.ts
+++ b/src/di/container.ts
@@ -21,6 +21,10 @@ import {
   DetectionEventsRepository,
   IDetectionEventsRepository,
 } from '../repositories/DetectionEventsRepository';
+import {
+  IMessageContextRepository,
+  MessageContextRepository,
+} from '../repositories/MessageContextRepository';
 import { DetectionOrchestrator, IDetectionOrchestrator } from '../services/DetectionOrchestrator';
 import { ConfigService, IConfigService } from '../config/ConfigService';
 import { SecurityActionService, ISecurityActionService } from '../services/SecurityActionService';
@@ -133,6 +137,11 @@ function configureRepositories(container: Container): void {
   container
     .bind<IDetectionEventsRepository>(TYPES.DetectionEventsRepository)
     .to(DetectionEventsRepository)
+    .inSingletonScope();
+
+  container
+    .bind<IMessageContextRepository>(TYPES.MessageContextRepository)
+    .to(MessageContextRepository)
     .inSingletonScope();
 
   // New repositories

--- a/src/di/symbols.ts
+++ b/src/di/symbols.ts
@@ -33,6 +33,7 @@ export const TYPES = {
   ServerMemberRepository: Symbol.for('ServerMemberRepository'),
   PrismaClient: Symbol.for('PrismaClient'),
   DetectionEventsRepository: Symbol.for('DetectionEventsRepository'),
+  MessageContextRepository: Symbol.for('MessageContextRepository'),
   ReportIntakeRepository: Symbol.for('ReportIntakeRepository'),
 
   // External dependencies

--- a/src/repositories/MessageContextRepository.ts
+++ b/src/repositories/MessageContextRepository.ts
@@ -1,0 +1,154 @@
+import { injectable, inject } from 'inversify';
+import { PrismaClient } from '../db/prisma';
+import { TYPES } from '../di/symbols';
+import { RepositoryError } from './BaseRepository';
+import type { MessageContext, MessageContextCreate } from './types';
+
+export const MESSAGE_CONTEXT_RETENTION_DAYS = 30;
+export const MESSAGE_CONTEXT_USER_LIMIT = 20;
+export const MESSAGE_CONTEXT_SERVER_LIMIT = 50_000;
+export const MESSAGE_CONTEXT_PREVIEW_MAX_LENGTH = 500;
+
+export interface IMessageContextRepository {
+  recordMessage(data: MessageContextCreate): Promise<void>;
+  findRecentByServerAndUser(
+    serverId: string,
+    userId: string,
+    limit?: number
+  ): Promise<MessageContext[]>;
+  pruneExpired(now?: Date): Promise<number>;
+}
+
+@injectable()
+export class MessageContextRepository implements IMessageContextRepository {
+  constructor(@inject(TYPES.PrismaClient) private prisma: PrismaClient) {}
+
+  private handleError(error: unknown, operation: string): never {
+    console.error(`Repository error during ${operation}:`, error);
+    if (error instanceof Error) {
+      throw new RepositoryError(`Unexpected error during ${operation}: ${error.message}`, error);
+    }
+
+    throw new RepositoryError(`Unknown error during ${operation}`, error);
+  }
+
+  async recordMessage(data: MessageContextCreate): Promise<void> {
+    try {
+      const contentPreview = data.contentPreview.slice(0, MESSAGE_CONTEXT_PREVIEW_MAX_LENGTH);
+      const contentFeaturesJson = JSON.stringify(data.contentFeatures ?? {});
+      const observedAt = data.observedAt ?? new Date();
+
+      await this.prisma.$transaction(async (tx) => {
+        await tx.$executeRaw`
+          INSERT INTO public.message_contexts (
+            server_id,
+            user_id,
+            message_id,
+            channel_id,
+            content_preview,
+            content_features,
+            created_at,
+            observed_at,
+            expires_at
+          ) VALUES (
+            ${data.serverId},
+            ${data.userId},
+            ${data.messageId},
+            ${data.channelId ?? null},
+            ${contentPreview},
+            CAST(${contentFeaturesJson} AS jsonb),
+            ${data.createdAt},
+            ${observedAt},
+            ${data.expiresAt}
+          )
+          ON CONFLICT (server_id, message_id) DO UPDATE SET
+            user_id = EXCLUDED.user_id,
+            channel_id = EXCLUDED.channel_id,
+            content_preview = EXCLUDED.content_preview,
+            content_features = EXCLUDED.content_features,
+            created_at = EXCLUDED.created_at,
+            observed_at = EXCLUDED.observed_at,
+            expires_at = EXCLUDED.expires_at
+        `;
+
+        await tx.$executeRaw`
+          DELETE FROM public.message_contexts
+          WHERE id IN (
+            SELECT id FROM (
+              SELECT
+                id,
+                row_number() OVER (
+                  PARTITION BY server_id, user_id
+                  ORDER BY created_at DESC, observed_at DESC
+                ) AS row_number
+              FROM public.message_contexts
+              WHERE server_id = ${data.serverId}
+                AND user_id = ${data.userId}
+            ) ranked
+            WHERE ranked.row_number > ${MESSAGE_CONTEXT_USER_LIMIT}
+          )
+        `;
+
+        await tx.$executeRaw`
+          DELETE FROM public.message_contexts
+          WHERE id IN (
+            SELECT id FROM (
+              SELECT
+                id,
+                row_number() OVER (ORDER BY created_at DESC, observed_at DESC) AS row_number
+              FROM public.message_contexts
+              WHERE server_id = ${data.serverId}
+            ) ranked
+            WHERE ranked.row_number > ${MESSAGE_CONTEXT_SERVER_LIMIT}
+          )
+        `;
+      });
+    } catch (error) {
+      this.handleError(error, 'recordMessage');
+    }
+  }
+
+  async findRecentByServerAndUser(
+    serverId: string,
+    userId: string,
+    limit = MESSAGE_CONTEXT_USER_LIMIT
+  ): Promise<MessageContext[]> {
+    try {
+      const rows = await this.prisma.$queryRaw<MessageContext[]>`
+        SELECT
+          id,
+          server_id,
+          user_id,
+          message_id,
+          channel_id,
+          content_preview,
+          COALESCE(content_features, '{}'::jsonb) AS content_features,
+          created_at,
+          observed_at,
+          expires_at
+        FROM public.message_contexts
+        WHERE server_id = ${serverId}
+          AND user_id = ${userId}
+          AND expires_at > now()
+        ORDER BY created_at DESC, observed_at DESC
+        LIMIT ${Math.max(1, Math.min(limit, MESSAGE_CONTEXT_USER_LIMIT))}
+      `;
+
+      return rows.reverse();
+    } catch (error) {
+      this.handleError(error, 'findRecentByServerAndUser');
+    }
+  }
+
+  async pruneExpired(now = new Date()): Promise<number> {
+    try {
+      const result = await this.prisma.$executeRaw`
+        DELETE FROM public.message_contexts
+        WHERE expires_at <= ${now}
+      `;
+      return Number(result);
+    } catch (error) {
+      this.handleError(error, 'pruneExpired');
+    }
+  }
+}

--- a/src/repositories/MessageContextRepository.ts
+++ b/src/repositories/MessageContextRepository.ts
@@ -88,20 +88,6 @@ export class MessageContextRepository implements IMessageContextRepository {
             WHERE ranked.row_number > ${MESSAGE_CONTEXT_USER_LIMIT}
           )
         `;
-
-        await tx.$executeRaw`
-          DELETE FROM public.message_contexts
-          WHERE id IN (
-            SELECT id FROM (
-              SELECT
-                id,
-                row_number() OVER (ORDER BY created_at DESC, observed_at DESC) AS row_number
-              FROM public.message_contexts
-              WHERE server_id = ${data.serverId}
-            ) ranked
-            WHERE ranked.row_number > ${MESSAGE_CONTEXT_SERVER_LIMIT}
-          )
-        `;
       });
     } catch (error) {
       this.handleError(error, 'recordMessage');
@@ -142,11 +128,28 @@ export class MessageContextRepository implements IMessageContextRepository {
 
   async pruneExpired(now = new Date()): Promise<number> {
     try {
-      const result = await this.prisma.$executeRaw`
-        DELETE FROM public.message_contexts
-        WHERE expires_at <= ${now}
-      `;
-      return Number(result);
+      const [expiredCount, overflowCount] = await this.prisma.$transaction([
+        this.prisma.$executeRaw`
+          DELETE FROM public.message_contexts
+          WHERE expires_at <= ${now}
+        `,
+        this.prisma.$executeRaw`
+          DELETE FROM public.message_contexts
+          WHERE id IN (
+            SELECT id FROM (
+              SELECT
+                id,
+                row_number() OVER (
+                  PARTITION BY server_id
+                  ORDER BY created_at DESC, observed_at DESC
+                ) AS row_number
+              FROM public.message_contexts
+            ) ranked
+            WHERE ranked.row_number > ${MESSAGE_CONTEXT_SERVER_LIMIT}
+          )
+        `,
+      ]);
+      return Number(expiredCount) + Number(overflowCount);
     } catch (error) {
       this.handleError(error, 'pruneExpired');
     }

--- a/src/repositories/types.ts
+++ b/src/repositories/types.ts
@@ -135,6 +135,9 @@ export enum DetectionType {
   NEW_ACCOUNT = 'new_account',
   PATTERN_MATCH = 'pattern_match',
   USER_REPORT = 'user_report',
+  ADMIN_CASE = 'admin_case',
+  ADMIN_FLAG = 'admin_flag',
+  ROLE_INTAKE = 'role_intake',
 }
 
 /**
@@ -209,6 +212,31 @@ export interface AdminAction {
 
 export interface VerificationEventWithActions extends VerificationEvent {
   actions: AdminAction[];
+}
+
+export interface MessageContext {
+  id: string;
+  server_id: string;
+  user_id: string;
+  message_id: string;
+  channel_id: string | null;
+  content_preview: string;
+  content_features: Record<string, unknown>;
+  created_at: Date;
+  observed_at: Date;
+  expires_at: Date;
+}
+
+export interface MessageContextCreate {
+  serverId: string;
+  userId: string;
+  messageId: string;
+  channelId?: string | null;
+  contentPreview: string;
+  contentFeatures?: Record<string, unknown>;
+  createdAt: Date;
+  observedAt?: Date;
+  expiresAt: Date;
 }
 
 export enum ReportIntakeStatus {

--- a/src/services/NotificationManager.ts
+++ b/src/services/NotificationManager.ts
@@ -786,6 +786,18 @@ export class NotificationManager implements INotificationManager {
       return `Observed via user report: \`${detectionResult.triggerContent || 'No reason provided'}\``;
     }
 
+    if (detectionResult.triggerSource === DetectionType.ADMIN_CASE) {
+      return `Observed via admin-opened case: ${detectionResult.triggerContent || 'Manual review'}`;
+    }
+
+    if (detectionResult.triggerSource === DetectionType.ADMIN_FLAG) {
+      return `Observed via admin flag: ${detectionResult.triggerContent || 'Manual flag'}`;
+    }
+
+    if (detectionResult.triggerSource === DetectionType.ROLE_INTAKE) {
+      return `Observed via role intake: ${detectionResult.triggerContent || 'Role intake'}`;
+    }
+
     if (detectionResult.triggerSource === DetectionType.GPT_ANALYSIS) {
       return `Observed via manual review: \`${detectionResult.triggerContent || 'Manual flag'}\``;
     }
@@ -810,7 +822,7 @@ export class NotificationManager implements INotificationManager {
     const detectionHistory = recentEvents
       .map((event) => {
         const timestamp = Math.floor(new Date(event.detected_at).getTime() / 1000);
-        return `• <t:${timestamp}:R>: ${event.detection_type} (${Math.round(event.confidence * 100)}% confidence)${this.formatAccountingSuffix(event)}`;
+        return `• <t:${timestamp}:R>: ${this.formatDetectionTypeLabel(event.detection_type)} (${Math.round(event.confidence * 100)}% confidence)${this.formatAccountingSuffix(event)}`;
       })
       .join('\n');
 
@@ -956,6 +968,12 @@ export class NotificationManager implements INotificationManager {
         ? `\`${detectionResult.triggerContent}\``
         : '`No report reason provided`';
       triggerInfo = `Flagged via user report: ${safeContent}`;
+    } else if (detectionResult.triggerSource === DetectionType.ADMIN_CASE) {
+      triggerInfo = `Admin-opened case: ${detectionResult.triggerContent || 'Manual review'}`;
+    } else if (detectionResult.triggerSource === DetectionType.ADMIN_FLAG) {
+      triggerInfo = `Admin flag: ${detectionResult.triggerContent || 'Manual flag'}`;
+    } else if (detectionResult.triggerSource === DetectionType.ROLE_INTAKE) {
+      triggerInfo = `Role intake: ${detectionResult.triggerContent || 'Role intake'}`;
     } else if (detectionResult.triggerSource === DetectionType.GPT_ANALYSIS) {
       const safeContent = detectionResult.triggerContent
         ? `\`${detectionResult.triggerContent}\``
@@ -991,7 +1009,7 @@ export class NotificationManager implements INotificationManager {
       detectionHistory = recentEvents
         .map((event) => {
           const timestamp = Math.floor(new Date(event.detected_at).getTime() / 1000);
-          let entry = `• <t:${timestamp}:R>: ${event.detection_type}`;
+          let entry = `• <t:${timestamp}:R>: ${this.formatDetectionTypeLabel(event.detection_type)}`;
           if (event.message_id) {
             entry += ` - [View Message](https://discord.com/channels/${member.guild.id}/${event.channel_id}/${event.message_id})`;
           }
@@ -1080,25 +1098,20 @@ export class NotificationManager implements INotificationManager {
       });
     }
 
+    const caseThreadsFieldValue = this.formatCaseThreadsFieldValue(member, verificationEvent);
+    if (caseThreadsFieldValue) {
+      embed.addFields({
+        name: 'Case Threads',
+        value: caseThreadsFieldValue,
+        inline: false,
+      });
+    }
+
     // Add detection history if we have any
     if (detectionHistory) {
       embed.addFields({
         name: 'Detection History',
         value: detectionHistory,
-        inline: false,
-      });
-    }
-
-    // Add verification thread status if it exists
-    if (verificationEvent.thread_id) {
-      const threadStatus =
-        verificationEvent.status === VerificationStatus.VERIFIED ||
-        verificationEvent.status === VerificationStatus.BANNED
-          ? `${verificationEvent.status} by <@${verificationEvent.resolved_by}>`
-          : 'pending'; // Use 'pending' for unresolved states
-      embed.addFields({
-        name: 'Verification Status',
-        value: `[Thread](https://discord.com/channels/${member.guild.id}/${verificationEvent.thread_id}) status: ${threadStatus}`,
         inline: false,
       });
     }
@@ -1298,6 +1311,55 @@ export class NotificationManager implements INotificationManager {
 
   private formatAccountingSuffix(event: DetectionEvent): string {
     return isDetectionEventExcludedFromAccounting(event) ? ' - ignored for future accounting' : '';
+  }
+
+  private formatDetectionTypeLabel(detectionType: DetectionType): string {
+    switch (detectionType) {
+      case DetectionType.MESSAGE_FREQUENCY:
+        return 'message frequency';
+      case DetectionType.SUSPICIOUS_CONTENT:
+        return 'suspicious content';
+      case DetectionType.GPT_ANALYSIS:
+        return 'GPT analysis';
+      case DetectionType.NEW_ACCOUNT:
+        return 'new account';
+      case DetectionType.PATTERN_MATCH:
+        return 'pattern match';
+      case DetectionType.USER_REPORT:
+        return 'user report';
+      case DetectionType.ADMIN_CASE:
+        return 'admin-opened case';
+      case DetectionType.ADMIN_FLAG:
+        return 'admin flag';
+      case DetectionType.ROLE_INTAKE:
+        return 'role intake';
+    }
+  }
+
+  private formatCaseThreadsFieldValue(
+    member: GuildMember,
+    verificationEvent: VerificationEvent
+  ): string | null {
+    const lines: string[] = [];
+    const threadStatus =
+      verificationEvent.status === VerificationStatus.VERIFIED ||
+      verificationEvent.status === VerificationStatus.BANNED
+        ? `${verificationEvent.status}${verificationEvent.resolved_by ? ` by <@${verificationEvent.resolved_by}>` : ''}`
+        : 'pending';
+
+    if (verificationEvent.thread_id) {
+      lines.push(
+        `Verification/review: [thread](https://discord.com/channels/${member.guild.id}/${verificationEvent.thread_id}) status: ${threadStatus}`
+      );
+    }
+
+    if (verificationEvent.private_evidence_thread_id) {
+      lines.push(
+        `Private evidence: [thread](https://discord.com/channels/${member.guild.id}/${verificationEvent.private_evidence_thread_id})`
+      );
+    }
+
+    return lines.length > 0 ? lines.join('\n') : null;
   }
 
   private getThreadAnalysisMetadata(

--- a/src/services/NotificationManager.ts
+++ b/src/services/NotificationManager.ts
@@ -1142,7 +1142,7 @@ export class NotificationManager implements INotificationManager {
           failure.action === 'restrict'
             ? 'Apply restricted role'
             : failure.action === 'private_evidence_thread'
-              ? 'Create private evidence thread'
+              ? 'Create admin evidence thread'
               : 'Create case thread';
         const when = Number.isFinite(timestamp) ? ` <t:${timestamp}:R>` : '';
         return `Warning: ${action} failed${when}: ${failure.message}`;
@@ -1333,6 +1333,10 @@ export class NotificationManager implements INotificationManager {
         return 'admin flag';
       case DetectionType.ROLE_INTAKE:
         return 'role intake';
+      default: {
+        const exhaustive: never = detectionType;
+        return String(exhaustive);
+      }
     }
   }
 
@@ -1355,7 +1359,7 @@ export class NotificationManager implements INotificationManager {
 
     if (verificationEvent.private_evidence_thread_id) {
       lines.push(
-        `Private evidence: [thread](https://discord.com/channels/${member.guild.id}/${verificationEvent.private_evidence_thread_id})`
+        `Admin evidence: [thread](https://discord.com/channels/${member.guild.id}/${verificationEvent.private_evidence_thread_id})`
       );
     }
 

--- a/src/services/SecurityActionService.ts
+++ b/src/services/SecurityActionService.ts
@@ -496,12 +496,12 @@ export class SecurityActionService implements ISecurityActionService {
         sourceMessage
       );
       if (!thread) {
-        throw new Error(`Failed to create private evidence thread for ${member.user.tag}`);
+        throw new Error(`Failed to create admin evidence thread for ${member.user.tag}`);
       }
       return verificationEvent;
     } catch (error) {
       console.error(
-        `Failed to create private evidence thread for ${member.user.tag}; continuing case flow:`,
+        `Failed to create admin evidence thread for ${member.user.tag}; continuing case flow:`,
         error
       );
       return this.recordVerificationActionFailure(

--- a/src/services/SecurityActionService.ts
+++ b/src/services/SecurityActionService.ts
@@ -396,7 +396,7 @@ export class SecurityActionService implements ISecurityActionService {
     detectionResult: DetectionResult,
     verificationEvent: VerificationEvent,
     sourceMessage?: Message
-  ): Promise<void> {
+  ): Promise<Message> {
     const notificationMessage = await this.notificationManager.upsertSuspiciousUserNotification(
       member,
       detectionResult,
@@ -412,7 +412,10 @@ export class SecurityActionService implements ISecurityActionService {
       await this.verificationEventRepository.update(verificationEvent.id, {
         notification_message_id: notificationMessage.id,
       });
+      verificationEvent.notification_message_id = notificationMessage.id;
     }
+
+    return notificationMessage;
   }
 
   private createDetectionResultFromEvent(detectionEvent: DetectionEvent): DetectionResult {
@@ -481,6 +484,7 @@ export class SecurityActionService implements ISecurityActionService {
     member: GuildMember,
     verificationEvent: VerificationEvent,
     detectionResult: DetectionResult,
+    notificationMessage: Message,
     sourceMessage?: Message
   ): Promise<VerificationEvent> {
     try {
@@ -488,6 +492,7 @@ export class SecurityActionService implements ISecurityActionService {
         member,
         verificationEvent,
         detectionResult,
+        notificationMessage,
         sourceMessage
       );
       if (!thread) {
@@ -511,33 +516,53 @@ export class SecurityActionService implements ISecurityActionService {
     member: GuildMember,
     verificationEvent: VerificationEvent,
     detectionResult: DetectionResult,
+    notificationMessage: Message,
     sourceMessage?: Message
   ): Promise<VerificationEvent> {
     if (verificationEvent.private_evidence_thread_id) {
       return verificationEvent;
     }
 
-    if (this.hasReportReviewThread(verificationEvent)) {
-      if (!verificationEvent.thread_id) {
-        return verificationEvent;
-      }
-      const updatedEvent = await this.verificationEventRepository.update(verificationEvent.id, {
-        private_evidence_thread_id: verificationEvent.thread_id,
-      });
-      return (
-        updatedEvent ?? {
-          ...verificationEvent,
-          private_evidence_thread_id: verificationEvent.thread_id,
-        }
-      );
-    }
-
     return this.tryCreatePrivateEvidenceThread(
       member,
       verificationEvent,
       detectionResult,
+      notificationMessage,
       sourceMessage
     );
+  }
+
+  private async upsertNotificationAndEnsurePrivateEvidenceThread(
+    member: GuildMember,
+    detectionResult: DetectionResult,
+    verificationEvent: VerificationEvent,
+    sourceMessage?: Message
+  ): Promise<VerificationEvent> {
+    const notificationMessage = await this.upsertNotification(
+      member,
+      detectionResult,
+      verificationEvent,
+      sourceMessage
+    );
+    const previousPrivateEvidenceThreadId = verificationEvent.private_evidence_thread_id;
+    const previousMetadata = verificationEvent.metadata;
+
+    const updatedEvent = await this.ensurePrivateEvidenceThread(
+      member,
+      verificationEvent,
+      detectionResult,
+      notificationMessage,
+      sourceMessage
+    );
+
+    if (
+      updatedEvent.private_evidence_thread_id !== previousPrivateEvidenceThreadId ||
+      updatedEvent.metadata !== previousMetadata
+    ) {
+      await this.upsertNotification(member, detectionResult, updatedEvent, sourceMessage);
+    }
+
+    return updatedEvent;
   }
 
   private formatActionFailureMessage(error: unknown): string {
@@ -648,14 +673,6 @@ export class SecurityActionService implements ISecurityActionService {
         useReportReviewThread,
         sourceMessage
       );
-      if (!useReportReviewThread) {
-        updatedEvent = await this.tryCreatePrivateEvidenceThread(
-          member,
-          updatedEvent,
-          detectionResult,
-          sourceMessage
-        );
-      }
       return updatedEvent;
     } catch (error) {
       console.error(
@@ -1016,13 +1033,7 @@ export class SecurityActionService implements ISecurityActionService {
           );
         }
       }
-      notificationVerificationEvent = await this.ensurePrivateEvidenceThread(
-        member,
-        notificationVerificationEvent,
-        detectionResult,
-        sourceMessage
-      );
-      await this.upsertNotification(
+      notificationVerificationEvent = await this.upsertNotificationAndEnsurePrivateEvidenceThread(
         member,
         detectionResult,
         notificationVerificationEvent,
@@ -1081,7 +1092,12 @@ export class SecurityActionService implements ISecurityActionService {
       sourceMessage
     );
 
-    await this.upsertNotification(member, detectionResult, newVerificationEvent, sourceMessage);
+    newVerificationEvent = await this.upsertNotificationAndEnsurePrivateEvidenceThread(
+      member,
+      detectionResult,
+      newVerificationEvent,
+      sourceMessage
+    );
     this.captureDetectionCaseAnalytics(
       member,
       'verification case opened',
@@ -1185,13 +1201,27 @@ export class SecurityActionService implements ISecurityActionService {
 
       const restrictUser = options.action === 'restrict';
       const normalizedReason = options.reason?.trim() || undefined;
-      const reasonText = normalizedReason ? `Reason: ${normalizedReason}` : 'No reason provided.';
+      const isRoleIntake = options.metadata?.type === 'admin_role_intake';
+      const sourceRoleId =
+        typeof options.metadata?.sourceRoleId === 'string' ? options.metadata.sourceRoleId : null;
+      const reasonSuffix = normalizedReason ? ` Reason: ${normalizedReason}` : '';
+      const reasonText = isRoleIntake
+        ? sourceRoleId
+          ? `Role intake from <@&${sourceRoleId}> started by <@${moderator.id}>.${reasonSuffix}`
+          : `Role intake started by <@${moderator.id}>.${reasonSuffix}`
+        : `Admin case opened by <@${moderator.id}>.${reasonSuffix}`;
+      const triggerContent = isRoleIntake
+        ? sourceRoleId
+          ? `Role intake from <@&${sourceRoleId}> by <@${moderator.id}>${normalizedReason ? `: ${normalizedReason}` : ''}`
+          : `Role intake by <@${moderator.id}>${normalizedReason ? `: ${normalizedReason}` : ''}`
+        : `Opened by <@${moderator.id}>${normalizedReason ? `: ${normalizedReason}` : ''}`;
+      const detectionType = isRoleIntake ? DetectionType.ROLE_INTAKE : DetectionType.ADMIN_CASE;
       const detectionEvent = await this.detectionEventsRepository.create({
         server_id: member.guild.id,
         user_id: member.id,
-        detection_type: DetectionType.GPT_ANALYSIS,
+        detection_type: detectionType,
         confidence: 1.0,
-        reasons: [`Admin case opened by ${moderator.id}. ${reasonText}`],
+        reasons: [reasonText],
         detected_at: new Date(),
         metadata: withDetectionTestingMetadata(
           {
@@ -1208,9 +1238,9 @@ export class SecurityActionService implements ISecurityActionService {
       const detectionResult: DetectionResult = {
         label: 'SUSPICIOUS',
         confidence: 1.0,
-        reasons: [`Admin case opened by ${moderator.id}. ${reasonText}`],
-        triggerSource: DetectionType.GPT_ANALYSIS,
-        triggerContent: normalizedReason ?? 'Admin-opened case',
+        reasons: [reasonText],
+        triggerSource: detectionType,
+        triggerContent,
         detectionEventId: detectionEvent.id,
       };
 
@@ -1341,16 +1371,21 @@ export class SecurityActionService implements ISecurityActionService {
         member.joinedAt?.toISOString()
       );
 
-      const reasonText = reason ? `Reason: ${reason}` : 'No reason provided.';
+      const normalizedReason = reason?.trim() || undefined;
+      const reasonText = `Manually flagged by <@${moderator.id}>.${normalizedReason ? ` Reason: ${normalizedReason}` : ''}`;
       const detectionEvent = await this.detectionEventsRepository.create({
         server_id: member.guild.id,
         user_id: member.id,
-        detection_type: DetectionType.GPT_ANALYSIS,
+        detection_type: DetectionType.ADMIN_FLAG,
         confidence: 1.0,
-        reasons: [`Manually flagged by admin ${moderator.id}. ${reasonText}`],
+        reasons: [reasonText],
         detected_at: new Date(),
         metadata: withDetectionTestingMetadata(
-          { type: 'admin_flag', adminId: moderator.id, reason: reason ?? reasonText },
+          {
+            type: 'admin_flag',
+            adminId: moderator.id,
+            reason: normalizedReason ?? 'No reason provided.',
+          },
           'server'
         ),
       });
@@ -1358,9 +1393,9 @@ export class SecurityActionService implements ISecurityActionService {
       const detectionResult: DetectionResult = {
         label: 'SUSPICIOUS',
         confidence: 1.0,
-        reasons: [`Manually flagged by admin ${moderator.id}. ${reasonText}`],
-        triggerSource: DetectionType.GPT_ANALYSIS,
-        triggerContent: reason ?? 'Manual admin flag',
+        reasons: [reasonText],
+        triggerSource: DetectionType.ADMIN_FLAG,
+        triggerContent: `Flagged by <@${moderator.id}>${normalizedReason ? `: ${normalizedReason}` : ''}`,
         detectionEventId: detectionEvent.id,
       };
 

--- a/src/services/ThreadManager.ts
+++ b/src/services/ThreadManager.ts
@@ -305,10 +305,39 @@ export class ThreadManager implements IThreadManager {
     verificationEvent: VerificationEvent,
     threadId: string
   ): Promise<void> {
-    verificationEvent.private_evidence_thread_id = threadId;
-    await this.verificationEventRepository.update(verificationEvent.id, {
+    const updatedEvent = await this.verificationEventRepository.update(verificationEvent.id, {
       private_evidence_thread_id: threadId,
     });
+    if (!updatedEvent) {
+      throw new Error(`Verification event ${verificationEvent.id} was not found`);
+    }
+
+    verificationEvent.private_evidence_thread_id =
+      updatedEvent.private_evidence_thread_id ?? threadId;
+  }
+
+  private getAttachedThreadFromMessage(message: Message): ThreadChannel | null {
+    return (message as Message & { thread?: ThreadChannel | null }).thread ?? null;
+  }
+
+  private async fetchAttachedThreadFromMessage(message: Message): Promise<ThreadChannel | null> {
+    const cachedThread = this.getAttachedThreadFromMessage(message);
+    if (cachedThread) {
+      return cachedThread;
+    }
+
+    const fetchMessage = (message as unknown as { fetch?: () => Promise<Message> }).fetch;
+    if (!fetchMessage) {
+      return null;
+    }
+
+    try {
+      const refreshedMessage = await fetchMessage.call(message);
+      return this.getAttachedThreadFromMessage(refreshedMessage);
+    } catch (error) {
+      console.warn('Failed to fetch admin notification message while recovering thread:', error);
+      return null;
+    }
   }
 
   private async addCaseResponderMembers(
@@ -900,15 +929,26 @@ export class ThreadManager implements IThreadManager {
         member.joinedAt ?? undefined
       );
 
-      setupStage = 'create admin evidence thread from admin notification';
-      // Attached threads keep the admin notification embed visible at the top;
-      // their visibility follows the admin notification channel permissions.
-      const thread = await notificationMessage.startThread({
-        name: `Evidence: ${member.user.username}`,
-        autoArchiveDuration: ThreadAutoArchiveDuration.OneWeek,
-        reason: `Admin evidence thread for user: ${member.user.tag}`,
-      });
-      threadWasCreated = true;
+      setupStage = 'recover existing admin evidence thread from admin notification';
+      let thread = await this.fetchAttachedThreadFromMessage(notificationMessage);
+      if (!thread) {
+        setupStage = 'create admin evidence thread from admin notification';
+        // Attached threads keep the admin notification embed visible at the top;
+        // their visibility follows the admin notification channel permissions.
+        try {
+          thread = await notificationMessage.startThread({
+            name: `Evidence: ${member.user.username}`,
+            autoArchiveDuration: ThreadAutoArchiveDuration.OneWeek,
+            reason: `Admin evidence thread for user: ${member.user.tag}`,
+          });
+          threadWasCreated = true;
+        } catch (error) {
+          thread = await this.fetchAttachedThreadFromMessage(notificationMessage);
+          if (!thread) {
+            throw error;
+          }
+        }
+      }
 
       setupStage = 'store admin evidence thread id';
       await this.storePrivateEvidenceThreadId(verificationEvent, thread.id);

--- a/src/services/ThreadManager.ts
+++ b/src/services/ThreadManager.ts
@@ -73,6 +73,7 @@ export interface IThreadManager {
     member: GuildMember,
     verificationEvent: VerificationEvent,
     detectionResult: DetectionResult,
+    notificationMessage: Message,
     sourceMessage?: Message
   ): Promise<ThreadChannel | null>;
 
@@ -190,6 +191,7 @@ export class ThreadManager implements IThreadManager {
     member: GuildMember,
     verificationEvent: VerificationEvent,
     detectionResult: DetectionResult,
+    roleMentions: string | null,
     sourceMessage?: Message
   ): string {
     const reasonLines = detectionResult.reasons.length
@@ -204,6 +206,7 @@ export class ThreadManager implements IThreadManager {
 
     return enforceDiscordMessageLimit(
       [
+        roleMentions,
         `Private evidence workspace for ${member.user.tag} (${member.id}).`,
         'Admin-only discussion and evidence can be added here. Do not add the user under review to this thread.',
         '',
@@ -217,6 +220,46 @@ export class ThreadManager implements IThreadManager {
         .filter((line): line is string => Boolean(line))
         .join('\n')
     );
+  }
+
+  private async getCaseNotificationRoleIds(guildId: string): Promise<string[]> {
+    const serverConfig = await this.configService.getServerConfig(guildId).catch((error) => {
+      console.warn(`Failed to load case notification roles for guild ${guildId}:`, error);
+      return null;
+    });
+    if (!serverConfig) {
+      return [];
+    }
+
+    const roleIds = new Set<string>();
+    if (serverConfig.admin_notification_role_id) {
+      roleIds.add(serverConfig.admin_notification_role_id);
+    }
+
+    const responderSettings = getCaseResponderSettings(serverConfig.settings);
+    if (responderSettings.routingMode !== 'off') {
+      responderSettings.roleIds.forEach((roleId) => roleIds.add(roleId));
+    }
+
+    return [...roleIds];
+  }
+
+  private formatRoleMentions(roleIds: readonly string[]): string | null {
+    return roleIds.length > 0 ? roleIds.map((roleId) => `<@&${roleId}>`).join(' ') : null;
+  }
+
+  private createAllowedRoleMentions(roleIds: readonly string[]): {
+    parse: [];
+    users: [];
+    roles: string[];
+    repliedUser: false;
+  } {
+    return {
+      parse: [],
+      users: [],
+      roles: [...roleIds],
+      repliedUser: false,
+    };
   }
 
   private buildReportIntakeThreadMessage(reporter: GuildMember): string {
@@ -790,7 +833,6 @@ export class ThreadManager implements IThreadManager {
       // failures do not orphan a thread that was already created.
       setupStage = 'store report review thread id';
       await this.storeThreadId(verificationEvent, thread.id, REPORT_REVIEW_THREAD_TYPE);
-      await this.storePrivateEvidenceThreadId(verificationEvent, thread.id);
 
       try {
         await thread.setInvitable(false, 'Keep report review thread moderator-only');
@@ -836,6 +878,7 @@ export class ThreadManager implements IThreadManager {
     member: GuildMember,
     verificationEvent: VerificationEvent,
     detectionResult: DetectionResult,
+    notificationMessage: Message,
     sourceMessage?: Message
   ): Promise<ThreadChannel | null> {
     if (verificationEvent.private_evidence_thread_id) {
@@ -843,15 +886,6 @@ export class ThreadManager implements IThreadManager {
       if (existing) {
         return existing;
       }
-    }
-
-    const channel =
-      (await this.configService.getVerificationChannel(member.guild.id)) ||
-      (await this.configService.getAdminChannel(member.guild.id));
-
-    if (!channel) {
-      console.error('No verification or admin channel ID configured');
-      return null;
     }
 
     let setupStage = 'prepare private evidence thread records';
@@ -866,44 +900,31 @@ export class ThreadManager implements IThreadManager {
         member.joinedAt ?? undefined
       );
 
-      setupStage = 'create private evidence thread';
-      const thread = await channel.threads.create({
+      setupStage = 'create private evidence thread from admin notification';
+      const thread = await notificationMessage.startThread({
         name: `Evidence: ${member.user.username}`,
         autoArchiveDuration: ThreadAutoArchiveDuration.OneWeek,
         reason: `Private evidence thread for user: ${member.user.tag}`,
-        type: ChannelType.PrivateThread,
       });
       threadWasCreated = true;
 
       setupStage = 'store private evidence thread id';
       await this.storePrivateEvidenceThreadId(verificationEvent, thread.id);
 
-      try {
-        await thread.setInvitable(false, 'Keep private evidence thread moderator-only');
-      } catch (error) {
-        console.warn(
-          `Failed to set invitable=false for private evidence thread ${thread.id} (continuing):`,
-          error
-        );
-      }
-
       setupStage = 'route case responders to private evidence thread';
       await this.addCaseResponderMembers(member.guild, thread, [member.id]);
 
       setupStage = 'send private evidence thread prompt';
+      const roleIds = await this.getCaseNotificationRoleIds(member.guild.id);
       await thread.send({
         content: this.buildPrivateEvidenceThreadMessage(
           member,
           verificationEvent,
           detectionResult,
+          this.formatRoleMentions(roleIds),
           sourceMessage
         ),
-        allowedMentions: {
-          parse: [],
-          users: [],
-          roles: [],
-          repliedUser: false,
-        },
+        allowedMentions: this.createAllowedRoleMentions(roleIds),
       });
 
       return thread;

--- a/src/services/ThreadManager.ts
+++ b/src/services/ThreadManager.ts
@@ -207,8 +207,8 @@ export class ThreadManager implements IThreadManager {
     return enforceDiscordMessageLimit(
       [
         roleMentions,
-        `Private evidence workspace for ${member.user.tag} (${member.id}).`,
-        'Admin-only discussion and evidence can be added here. Do not add the user under review to this thread.',
+        `Admin evidence workspace for ${member.user.tag} (${member.id}).`,
+        'Visibility follows the admin notification channel and thread membership. Do not add the user under review to this thread.',
         '',
         `Case ID: ${verificationEvent.id}`,
         ...links,
@@ -888,7 +888,7 @@ export class ThreadManager implements IThreadManager {
       }
     }
 
-    let setupStage = 'prepare private evidence thread records';
+    let setupStage = 'prepare admin evidence thread records';
     let threadWasCreated = false;
 
     try {
@@ -900,21 +900,23 @@ export class ThreadManager implements IThreadManager {
         member.joinedAt ?? undefined
       );
 
-      setupStage = 'create private evidence thread from admin notification';
+      setupStage = 'create admin evidence thread from admin notification';
+      // Attached threads keep the admin notification embed visible at the top;
+      // their visibility follows the admin notification channel permissions.
       const thread = await notificationMessage.startThread({
         name: `Evidence: ${member.user.username}`,
         autoArchiveDuration: ThreadAutoArchiveDuration.OneWeek,
-        reason: `Private evidence thread for user: ${member.user.tag}`,
+        reason: `Admin evidence thread for user: ${member.user.tag}`,
       });
       threadWasCreated = true;
 
-      setupStage = 'store private evidence thread id';
+      setupStage = 'store admin evidence thread id';
       await this.storePrivateEvidenceThreadId(verificationEvent, thread.id);
 
-      setupStage = 'route case responders to private evidence thread';
+      setupStage = 'route case responders to admin evidence thread';
       await this.addCaseResponderMembers(member.guild, thread, [member.id]);
 
-      setupStage = 'send private evidence thread prompt';
+      setupStage = 'send admin evidence thread prompt';
       const roleIds = await this.getCaseNotificationRoleIds(member.guild.id);
       await thread.send({
         content: this.buildPrivateEvidenceThreadMessage(
@@ -929,7 +931,7 @@ export class ThreadManager implements IThreadManager {
 
       return thread;
     } catch (error) {
-      console.error('Failed to create private evidence thread:', error);
+      console.error('Failed to create admin evidence thread:', error);
       if (threadWasCreated) {
         throw this.buildThreadSetupError(setupStage, error);
       }


### PR DESCRIPTION
## Summary
- Add distinct admin case, admin flag, and role intake detection types.
- Persist short-lived moderation message context with 30-day retention and bounded per-user/server limits.
- Create evidence threads from admin notification messages and surface case thread links prominently.

## Why
This keeps admin/server-originated moderation cases distinct from GPT detections, preserves moderation context across process restarts, and makes evidence review easier from the admin notification.

## Testing
- npm run lint
- npm run format:check
- npm run build
- npm test

## Risk / Rollout
- Requires running the included Prisma migration before production inserts use the new detection enum values or message context table.
- Evidence threads are attached to admin notification messages, so admin-channel permissions remain the privacy boundary.