### PR TITLE
Fix verification thread repair warnings

### DIFF
--- a/src/__tests__/unit/NotificationManager.unit.test.ts
+++ b/src/__tests__/unit/NotificationManager.unit.test.ts
@@ -754,6 +754,49 @@ describe('NotificationManager (unit)', () => {
     expect(labels).toEqual(['Admin Actions']);
   });
 
+  it('removes repaired action warnings without dropping action log fields', async () => {
+    const embed = new EmbedBuilder().setTitle('Suspicious User').addFields(
+      {
+        name: 'Moderation Action Warning',
+        value: 'Warning: Create case thread failed: Missing Access',
+        inline: false,
+      },
+      {
+        name: 'Latest Admin Action',
+        value: 'Reopened verification by <@admin-1> at <t:123:F>',
+        inline: false,
+      },
+      {
+        name: 'Action Log',
+        value: 'Reopened verification by <@admin-1> at <t:123:F>',
+        inline: false,
+      }
+    );
+    const message: MockMessage = {
+      embeds: [embed],
+      edit: jest.fn().mockResolvedValue(undefined),
+    };
+    adminChannel.messages.fetch.mockResolvedValue(message as unknown as Message<true>);
+
+    const manager = new NotificationManager({} as any, configService, detectionRepository);
+    const verificationEvent = buildVerificationEvent({
+      notification_message_id: 'message-repair',
+      metadata: {},
+    });
+
+    await manager.updateNotificationButtons(verificationEvent, VerificationStatus.PENDING);
+
+    const editArgs = message.edit.mock.calls[0][0] as { embeds: EmbedBuilder[] };
+    const fields = editArgs.embeds[0].data.fields ?? [];
+    expect(fields.find((field) => field.name === 'Moderation Action Warning')).toBeUndefined();
+    expect(fields.find((field) => field.name === 'Latest Admin Action')?.value).toContain(
+      'Reopened verification'
+    );
+    expect(fields.find((field) => field.name === 'Action Log')?.value).toContain(
+      'Reopened verification'
+    );
+  });
+
   it('updates notification buttons for verified status', async () => {
     const message: MockMessage = { edit: jest.fn().mockResolvedValue(undefined) };
     adminChannel.messages.fetch.mockResolvedValue(message as unknown as Message<true>);

--- a/src/__tests__/unit/SecurityActionService.unit.test.ts
+++ b/src/__tests__/unit/SecurityActionService.unit.test.ts
@@ -579,9 +579,7 @@ describe('SecurityActionService (unit)', () => {
     expect(getVerificationActionFailures(updatedCase?.metadata)).toEqual([
       expect.objectContaining({ action: 'restrict', message: 'Role hierarchy issue' }),
     ]);
-    expect(notificationManager.upsertSuspiciousUserNotification).toHaveBeenCalledWith(
-      member,
-      expect.objectContaining({ detectionEventId: detectionEvent.id }),
+    expect(notificationManager.updateNotificationButtons).toHaveBeenCalledWith(
       expect.objectContaining({
         id: verificationEvent.id,
         metadata: expect.objectContaining({
@@ -590,9 +588,9 @@ describe('SecurityActionService (unit)', () => {
           ],
         }),
       }),
-      undefined
+      VerificationStatus.PENDING
     );
-    expect(notificationManager.updateNotificationButtons).not.toHaveBeenCalled();
+    expect(notificationManager.upsertSuspiciousUserNotification).not.toHaveBeenCalled();
   });
 
   it('reports thread repair success when notification button update fails', async () => {

--- a/src/__tests__/unit/SecurityActionService.unit.test.ts
+++ b/src/__tests__/unit/SecurityActionService.unit.test.ts
@@ -18,7 +18,10 @@ import {
 import { IUserModerationService } from '../../services/UserModerationService';
 import { IAdminActionService } from '../../services/AdminActionService';
 import { USER_REPORT_EXTERNAL_RESPONSE_MODE_SETTING_KEY } from '../../utils/userReportSettings';
-import { getVerificationActionFailures } from '../../utils/verificationActionFailures';
+import {
+  getVerificationActionFailures,
+  VERIFICATION_ACTION_FAILURES_METADATA_KEY,
+} from '../../utils/verificationActionFailures';
 
 const buildMember = (guildId: string, userId: string): GuildMember =>
   ({
@@ -529,6 +532,69 @@ describe('SecurityActionService (unit)', () => {
     });
   });
 
+  it('clears repaired thread warnings and rebuilds the notification embed', async () => {
+    const guildId = 'guild-case-repair-warning-clear';
+    const userId = 'user-case-repair-warning-clear';
+    const member = buildMember(guildId, userId);
+    const detectionEvent = await detectionEventsRepository.create({
+      server_id: guildId,
+      user_id: userId,
+      detection_type: DetectionType.NEW_ACCOUNT,
+      confidence: 1,
+      reasons: ['New Discord account'],
+      detected_at: new Date(),
+    });
+    const verificationEvent = await verificationEventRepository.createFromDetection(
+      detectionEvent.id,
+      guildId,
+      userId,
+      VerificationStatus.PENDING
+    );
+    verificationEvent.thread_id = 'thread-1';
+    verificationEvent.notification_message_id = 'notif-1';
+    verificationEvent.metadata = {
+      [VERIFICATION_ACTION_FAILURES_METADATA_KEY]: [
+        {
+          action: 'thread',
+          message: 'Failed to add flagged user to verification thread: Missing Access',
+          at: new Date().toISOString(),
+        },
+        {
+          action: 'restrict',
+          message: 'Role hierarchy issue',
+          at: new Date().toISOString(),
+        },
+      ],
+    };
+    await verificationEventRepository.update(verificationEvent.id, verificationEvent);
+    await serverMemberRepository.upsertMember(guildId, userId, {
+      is_restricted: true,
+      verification_status: VerificationStatus.PENDING,
+    });
+
+    const result = await buildService().repairActiveCase(member);
+    const updatedCase = await verificationEventRepository.findById(verificationEvent.id);
+
+    expect(result.repaired).toBe(true);
+    expect(getVerificationActionFailures(updatedCase?.metadata)).toEqual([
+      expect.objectContaining({ action: 'restrict', message: 'Role hierarchy issue' }),
+    ]);
+    expect(notificationManager.upsertSuspiciousUserNotification).toHaveBeenCalledWith(
+      member,
+      expect.objectContaining({ detectionEventId: detectionEvent.id }),
+      expect.objectContaining({
+        id: verificationEvent.id,
+        metadata: expect.objectContaining({
+          [VERIFICATION_ACTION_FAILURES_METADATA_KEY]: [
+            expect.objectContaining({ action: 'restrict' }),
+          ],
+        }),
+      }),
+      undefined
+    );
+    expect(notificationManager.updateNotificationButtons).not.toHaveBeenCalled();
+  });
+
   it('reports thread repair success when notification button update fails', async () => {
     const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
     const guildId = 'guild-case-repair-notification-fails';
@@ -566,7 +632,7 @@ describe('SecurityActionService (unit)', () => {
       });
       expect(result.message).toContain('Notification buttons could not be updated automatically');
       expect(errorSpy).toHaveBeenCalledWith(
-        expect.stringContaining('Failed to update notification buttons for repaired case'),
+        expect.stringContaining('Failed to update notification for repaired case'),
         expect.any(Error)
       );
     } finally {

--- a/src/__tests__/unit/ThreadManager.unit.test.ts
+++ b/src/__tests__/unit/ThreadManager.unit.test.ts
@@ -57,10 +57,13 @@ describe('ThreadManager (unit)', () => {
   let serverMemberRepository: InMemoryServerMemberRepository;
 
   type ThreadParentChannel = {
+    id?: string;
     threads: {
       create: jest.Mock;
       fetch?: jest.Mock;
     };
+    permissionsFor?: jest.Mock;
+    fetch?: jest.Mock;
   };
 
   let channel: ThreadParentChannel;
@@ -84,6 +87,7 @@ describe('ThreadManager (unit)', () => {
     } as unknown as jest.Mocked<ThreadChannel>;
 
     channel = {
+      id: 'verification-channel',
       threads: {
         create: jest.fn().mockResolvedValue(thread),
         fetch: jest.fn().mockResolvedValue(thread),
@@ -184,6 +188,79 @@ describe('ThreadManager (unit)', () => {
         expect.objectContaining({ content: expect.stringContaining(`<@${member.id}>`) })
       );
     } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it('explains parent-channel access when Discord denies adding the flagged user', async () => {
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+    channel.permissionsFor = jest.fn().mockReturnValue({
+      has: jest.fn().mockReturnValue(false),
+    });
+    (thread.members.add as jest.Mock).mockRejectedValue(
+      Object.assign(new Error('Missing Access'), { code: 50001 })
+    );
+    const manager = new ThreadManager(
+      {} as any,
+      configService,
+      verificationEventRepository,
+      userRepository,
+      serverRepository,
+      serverMemberRepository
+    );
+    (manager as any).wait = jest.fn().mockResolvedValue(undefined);
+    const member = buildMember('guild-1', 'user-1');
+    const event = await verificationEventRepository.createFromDetection(
+      null,
+      'guild-1',
+      'user-1',
+      VerificationStatus.PENDING
+    );
+
+    try {
+      await expect(manager.createVerificationThread(member, event)).rejects.toThrow(
+        'cannot currently view parent channel verification-channel'
+      );
+      expect(thread.members.add).toHaveBeenCalledTimes(4);
+    } finally {
+      errorSpy.mockRestore();
+      warnSpy.mockRestore();
+    }
+  });
+
+  it('describes missing access after parent access is visible as propagation', async () => {
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+    channel.permissionsFor = jest.fn().mockReturnValue({
+      has: jest.fn().mockReturnValue(true),
+    });
+    (thread.members.add as jest.Mock).mockRejectedValue(
+      Object.assign(new Error('Missing Access'), { code: 50001 })
+    );
+    const manager = new ThreadManager(
+      {} as any,
+      configService,
+      verificationEventRepository,
+      userRepository,
+      serverRepository,
+      serverMemberRepository
+    );
+    (manager as any).wait = jest.fn().mockResolvedValue(undefined);
+    const member = buildMember('guild-1', 'user-1');
+    const event = await verificationEventRepository.createFromDetection(
+      null,
+      'guild-1',
+      'user-1',
+      VerificationStatus.PENDING
+    );
+
+    try {
+      await expect(manager.createVerificationThread(member, event)).rejects.toThrow(
+        'not that the bot lost access'
+      );
+    } finally {
+      errorSpy.mockRestore();
       warnSpy.mockRestore();
     }
   });

--- a/src/__tests__/unit/ThreadManager.unit.test.ts
+++ b/src/__tests__/unit/ThreadManager.unit.test.ts
@@ -265,6 +265,39 @@ describe('ThreadManager (unit)', () => {
     }
   });
 
+  it('does not claim propagation when parent-channel access cannot be checked', async () => {
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+    (thread.members.add as jest.Mock).mockRejectedValue(
+      Object.assign(new Error('Missing Access'), { code: 50001 })
+    );
+    const manager = new ThreadManager(
+      {} as any,
+      configService,
+      verificationEventRepository,
+      userRepository,
+      serverRepository,
+      serverMemberRepository
+    );
+    (manager as any).wait = jest.fn().mockResolvedValue(undefined);
+    const member = buildMember('guild-1', 'user-1');
+    const event = await verificationEventRepository.createFromDetection(
+      null,
+      'guild-1',
+      'user-1',
+      VerificationStatus.PENDING
+    );
+
+    try {
+      await expect(manager.createVerificationThread(member, event)).rejects.toThrow(
+        'parent-channel access could not be verified'
+      );
+    } finally {
+      errorSpy.mockRestore();
+      warnSpy.mockRestore();
+    }
+  });
+
   it('keeps a created verification thread linked when prompt send fails', async () => {
     const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
     thread.send.mockRejectedValueOnce(new Error('Missing Send Messages permission'));

--- a/src/services/NotificationManager.ts
+++ b/src/services/NotificationManager.ts
@@ -169,6 +169,7 @@ export class NotificationManager implements INotificationManager {
   private detectionEventsRepository: IDetectionEventsRepository;
   private static readonly THREAD_ANALYSIS_FIELD_NAME = 'AI Thread Analysis';
   private static readonly LATEST_ADMIN_ACTION_FIELD_NAME = 'Latest Admin Action';
+  private static readonly MODERATION_ACTION_WARNING_FIELD_NAME = 'Moderation Action Warning';
 
   constructor(
     @inject(TYPES.DiscordClient) client: Client,
@@ -1062,7 +1063,7 @@ export class NotificationManager implements INotificationManager {
     );
     if (actionFailureFieldValue) {
       embed.addFields({
-        name: 'Moderation Action Warning',
+        name: NotificationManager.MODERATION_ACTION_WARNING_FIELD_NAME,
         value: actionFailureFieldValue,
         inline: false,
       });
@@ -1138,6 +1139,36 @@ export class NotificationManager implements INotificationManager {
     return this.truncateEmbedFieldValue(
       `${value}\nCase record was still created so moderators can review and fix permissions.`
     );
+  }
+
+  private upsertVerificationActionFailureField(
+    embed: EmbedBuilder,
+    verificationEvent: VerificationEvent
+  ): void {
+    const actionFailureFieldValue = this.formatVerificationActionFailureFieldValue(
+      verificationEvent.metadata
+    );
+    const fieldIndex = embed.data.fields?.findIndex(
+      (field) => field.name === NotificationManager.MODERATION_ACTION_WARNING_FIELD_NAME
+    );
+
+    if (actionFailureFieldValue) {
+      const field = {
+        name: NotificationManager.MODERATION_ACTION_WARNING_FIELD_NAME,
+        value: actionFailureFieldValue,
+        inline: false,
+      };
+      if (fieldIndex !== undefined && fieldIndex >= 0) {
+        embed.spliceFields(fieldIndex, 1, field);
+      } else {
+        embed.addFields(field);
+      }
+      return;
+    }
+
+    if (fieldIndex !== undefined && fieldIndex >= 0) {
+      embed.spliceFields(fieldIndex, 1);
+    }
   }
 
   private formatCaseStaffRoutingWarningFieldValue(metadata: unknown): string | null {
@@ -1675,10 +1706,17 @@ export class NotificationManager implements INotificationManager {
     }
 
     const message = await adminChannel.messages.fetch(verificationEvent.notification_message_id);
+    const messageEmbeds = (message as { embeds?: Message['embeds'] }).embeds ?? [];
+    const updatedEmbed = messageEmbeds.length > 0 ? EmbedBuilder.from(messageEmbeds[0]) : null;
+
+    if (updatedEmbed) {
+      this.upsertVerificationActionFailureField(updatedEmbed, verificationEvent);
+    }
 
     await message.edit({
       allowedMentions: { parse: [] },
       components: [this.createActionRow(verificationEvent.user_id)],
+      ...(updatedEmbed ? { embeds: [updatedEmbed] } : {}),
     });
   }
 }

--- a/src/services/SecurityActionService.ts
+++ b/src/services/SecurityActionService.ts
@@ -36,6 +36,8 @@ import type { IGPTService } from './GPTService';
 import { ReportAttachmentMetadata } from '../utils/reportAiSettings';
 import {
   appendVerificationActionFailure,
+  clearVerificationActionFailures,
+  getVerificationActionFailures,
   type VerificationActionFailureKind,
 } from '../utils/verificationActionFailures';
 import {
@@ -586,6 +588,51 @@ export class SecurityActionService implements ISecurityActionService {
       );
       return fallbackEvent;
     }
+  }
+
+  private async clearResolvedVerificationActionFailures(
+    verificationEvent: VerificationEvent,
+    actions: readonly VerificationActionFailureKind[]
+  ): Promise<VerificationEvent> {
+    const hasFailuresToClear = getVerificationActionFailures(verificationEvent.metadata).some(
+      (failure) => actions.includes(failure.action)
+    );
+    if (!hasFailuresToClear) {
+      return verificationEvent;
+    }
+
+    const updatedMetadata = clearVerificationActionFailures(verificationEvent.metadata, actions);
+    const fallbackEvent = {
+      ...verificationEvent,
+      metadata: updatedMetadata as VerificationEvent['metadata'],
+    };
+
+    try {
+      const updatedEvent = await this.verificationEventRepository.update(verificationEvent.id, {
+        metadata: updatedMetadata as VerificationEvent['metadata'],
+      });
+
+      return updatedEvent ?? fallbackEvent;
+    } catch (error) {
+      console.error(
+        `Failed to clear resolved action failures for verification event ${verificationEvent.id}; continuing repair flow:`,
+        error
+      );
+      return fallbackEvent;
+    }
+  }
+
+  private async getNotificationDetectionResult(
+    verificationEvent: VerificationEvent
+  ): Promise<DetectionResult | null> {
+    if (!verificationEvent.detection_event_id) {
+      return null;
+    }
+
+    const detectionEvent = await this.detectionEventsRepository.findById(
+      verificationEvent.detection_event_id
+    );
+    return detectionEvent ? this.createDetectionResultFromEvent(detectionEvent) : null;
   }
 
   private async tryRestrictUser(
@@ -1271,16 +1318,23 @@ export class SecurityActionService implements ISecurityActionService {
       };
     }
 
+    repairCase = await this.clearResolvedVerificationActionFailures(repairCase, ['thread']);
+
     let notificationUpdateMessage = '';
     try {
-      await this.notificationManager.updateNotificationButtons(
-        repairCase,
-        VerificationStatus.PENDING
-      );
+      const detectionResult = await this.getNotificationDetectionResult(repairCase);
+      if (detectionResult) {
+        await this.upsertNotification(member, detectionResult, repairCase);
+      } else {
+        await this.notificationManager.updateNotificationButtons(
+          repairCase,
+          VerificationStatus.PENDING
+        );
+      }
     } catch (error) {
       notificationUpdateMessage = ' Notification buttons could not be updated automatically.';
       console.error(
-        `Failed to update notification buttons for repaired case ${repairCase.id}; continuing repair flow:`,
+        `Failed to update notification for repaired case ${repairCase.id}; continuing repair flow:`,
         error
       );
     }

--- a/src/services/SecurityActionService.ts
+++ b/src/services/SecurityActionService.ts
@@ -622,19 +622,6 @@ export class SecurityActionService implements ISecurityActionService {
     }
   }
 
-  private async getNotificationDetectionResult(
-    verificationEvent: VerificationEvent
-  ): Promise<DetectionResult | null> {
-    if (!verificationEvent.detection_event_id) {
-      return null;
-    }
-
-    const detectionEvent = await this.detectionEventsRepository.findById(
-      verificationEvent.detection_event_id
-    );
-    return detectionEvent ? this.createDetectionResultFromEvent(detectionEvent) : null;
-  }
-
   private async tryRestrictUser(
     member: GuildMember,
     verificationEvent: VerificationEvent
@@ -1322,15 +1309,10 @@ export class SecurityActionService implements ISecurityActionService {
 
     let notificationUpdateMessage = '';
     try {
-      const detectionResult = await this.getNotificationDetectionResult(repairCase);
-      if (detectionResult) {
-        await this.upsertNotification(member, detectionResult, repairCase);
-      } else {
-        await this.notificationManager.updateNotificationButtons(
-          repairCase,
-          VerificationStatus.PENDING
-        );
-      }
+      await this.notificationManager.updateNotificationButtons(
+        repairCase,
+        VerificationStatus.PENDING
+      );
     } catch (error) {
       notificationUpdateMessage = ' Notification buttons could not be updated automatically.';
       console.error(

--- a/src/services/ThreadManager.ts
+++ b/src/services/ThreadManager.ts
@@ -428,6 +428,12 @@ export class ThreadManager implements IThreadManager {
       );
     }
 
+    if (canViewParentChannel === null) {
+      return new Error(
+        `Discord denied adding ${member.id} to the private verification thread, and parent-channel access could not be verified for parent channel ${parentId}. Check both bot and target-user View Channel access on the parent channel before assuming Discord propagation delay. Original Discord error: ${originalError}`
+      );
+    }
+
     return new Error(
       `Discord denied adding ${member.id} to the private verification thread after role and channel access refreshes. This usually means Discord has not propagated the user's parent-channel access yet, not that the bot lost access. Run case repair after propagation. Original Discord error: ${originalError}`
     );

--- a/src/services/ThreadManager.ts
+++ b/src/services/ThreadManager.ts
@@ -8,6 +8,7 @@ import {
   ThreadChannel,
   ThreadAutoArchiveDuration,
   ChannelType,
+  PermissionFlagsBits,
 } from 'discord.js';
 import { IConfigService } from '../config/ConfigService';
 import { TYPES } from '../di/symbols';
@@ -362,22 +363,123 @@ export class ThreadManager implements IThreadManager {
     await new Promise<void>((resolve) => setTimeout(resolve, delayMs));
   }
 
-  private async refreshMember(member: GuildMember): Promise<void> {
-    const fetchMember = (member as { fetch?: (force?: boolean) => Promise<GuildMember> }).fetch;
-    if (!fetchMember) {
-      return;
+  private getErrorMessage(error: unknown): string {
+    if (error instanceof Error && error.message) {
+      return error.message;
     }
 
-    await fetchMember.call(member, true).catch((error) => {
+    return String(error || 'Unknown error');
+  }
+
+  private isMissingAccessError(error: unknown): boolean {
+    const errorCode = (error as { code?: unknown } | null)?.code;
+    return (
+      errorCode === 50001 ||
+      errorCode === '50001' ||
+      this.getErrorMessage(error).toLowerCase().includes('missing access')
+    );
+  }
+
+  private getThreadParentId(thread: ThreadChannel): string | null {
+    return (thread as { parentId?: string | null }).parentId ?? null;
+  }
+
+  private getThreadParentChannel(thread: ThreadChannel): TextChannel | null {
+    const parent = (thread as { parent?: unknown }).parent;
+    if (
+      parent &&
+      typeof parent === 'object' &&
+      typeof (parent as { permissionsFor?: unknown }).permissionsFor === 'function'
+    ) {
+      return parent as TextChannel;
+    }
+
+    return null;
+  }
+
+  private canMemberViewParentChannel(
+    member: GuildMember,
+    parentChannel: TextChannel | null
+  ): boolean | null {
+    const permissionsFor = (parentChannel as { permissionsFor?: unknown } | null)?.permissionsFor;
+    if (!parentChannel || typeof permissionsFor !== 'function') {
+      return null;
+    }
+
+    return parentChannel.permissionsFor(member).has(PermissionFlagsBits.ViewChannel);
+  }
+
+  private buildFlaggedUserThreadAddError(
+    member: GuildMember,
+    thread: ThreadChannel,
+    error: unknown,
+    parentChannel: TextChannel | null,
+    canViewParentChannel: boolean | null
+  ): Error {
+    if (!this.isMissingAccessError(error)) {
+      return error instanceof Error ? error : new Error(this.getErrorMessage(error));
+    }
+
+    const parentId = parentChannel?.id ?? this.getThreadParentId(thread) ?? 'unknown';
+    const originalError = this.getErrorMessage(error);
+    if (canViewParentChannel === false) {
+      return new Error(
+        `Discord denied adding ${member.id} to the private verification thread because the user cannot currently view parent channel ${parentId}. Private thread membership requires parent View Channel; check restricted-role/channel overwrites. Original Discord error: ${originalError}`
+      );
+    }
+
+    return new Error(
+      `Discord denied adding ${member.id} to the private verification thread after role and channel access refreshes. This usually means Discord has not propagated the user's parent-channel access yet, not that the bot lost access. Run case repair after propagation. Original Discord error: ${originalError}`
+    );
+  }
+
+  private async refreshMember(member: GuildMember): Promise<GuildMember> {
+    const fetchMember = (member as { fetch?: (force?: boolean) => Promise<GuildMember> }).fetch;
+    if (!fetchMember) {
+      return member;
+    }
+
+    const refreshedMember = await fetchMember.call(member, true).catch((error) => {
       console.warn(`Failed to refresh member ${member.id} before thread add retry:`, error);
+      return null;
     });
+
+    return refreshedMember ?? member;
+  }
+
+  private async refreshParentChannel(
+    parentChannel: TextChannel | null
+  ): Promise<TextChannel | null> {
+    if (!parentChannel) {
+      return null;
+    }
+
+    const fetchChannel = (parentChannel as { fetch?: (force?: boolean) => Promise<TextChannel> })
+      .fetch;
+    if (!fetchChannel) {
+      return parentChannel;
+    }
+
+    const refreshedChannel = await fetchChannel.call(parentChannel, true).catch((error) => {
+      console.warn(
+        `Failed to refresh parent channel ${parentChannel.id} before thread add retry:`,
+        error
+      );
+      return null;
+    });
+
+    return refreshedChannel ?? parentChannel;
   }
 
   private async addFlaggedUserToVerificationThread(
     member: GuildMember,
-    thread: ThreadChannel
+    thread: ThreadChannel,
+    parentChannel?: TextChannel | null
   ): Promise<void> {
     let lastError: unknown;
+    let latestMember = member;
+    let latestParentChannel = parentChannel ?? this.getThreadParentChannel(thread);
+    let latestCanViewParent = this.canMemberViewParentChannel(latestMember, latestParentChannel);
 
     try {
       await thread.members.add(member.id);
@@ -392,7 +494,9 @@ export class ThreadManager implements IThreadManager {
         lastError
       );
       await this.wait(retryDelay);
-      await this.refreshMember(member);
+      latestMember = await this.refreshMember(latestMember);
+      latestParentChannel = await this.refreshParentChannel(latestParentChannel);
+      latestCanViewParent = this.canMemberViewParentChannel(latestMember, latestParentChannel);
 
       try {
         await thread.members.add(member.id);
@@ -402,7 +506,13 @@ export class ThreadManager implements IThreadManager {
       }
     }
 
-    throw lastError;
+    throw this.buildFlaggedUserThreadAddError(
+      member,
+      thread,
+      lastError,
+      latestParentChannel,
+      latestCanViewParent
+    );
   }
 
   private async fetchStoredThread(
@@ -554,7 +664,7 @@ export class ThreadManager implements IThreadManager {
 
       // Add the member to the private thread so they can see it
       setupStage = 'add flagged user to verification thread';
-      await this.addFlaggedUserToVerificationThread(member, thread);
+      await this.addFlaggedUserToVerificationThread(member, thread, channel);
 
       // Lock invites after the flagged user has been added.
       // Some server permission setups allow creating private threads but not managing them;

--- a/src/utils/verificationActionFailures.ts
+++ b/src/utils/verificationActionFailures.ts
@@ -57,3 +57,24 @@ export function appendVerificationActionFailure(
     [VERIFICATION_ACTION_FAILURES_METADATA_KEY]: failures,
   };
 }
+
+export function clearVerificationActionFailures(
+  metadata: unknown,
+  actions: readonly VerificationActionFailureKind[]
+): Record<string, unknown> {
+  const record = metadataToRecord(metadata);
+  const actionsToClear = new Set(actions);
+  const failures = getVerificationActionFailures(metadata).filter(
+    (failure) => !actionsToClear.has(failure.action)
+  );
+
+  if (failures.length === 0) {
+    delete record[VERIFICATION_ACTION_FAILURES_METADATA_KEY];
+    return record;
+  }
+
+  return {
+    ...record,
+    [VERIFICATION_ACTION_FAILURES_METADATA_KEY]: failures,
+  };
+}


### PR DESCRIPTION
[AGENT]

## Summary
- Diagnose Discord `Missing Access` when adding flagged users to private verification threads as target parent-channel access, unknown parent access, or propagation, instead of implying the bot lost access.
- Refresh member and parent channel state during retries before producing the final thread-add error.
- Clear resolved thread-action warning metadata after successful case repair and update the existing notification embed in place so stale warnings disappear without dropping action-log fields.

## Why
Discord requires private-thread members to have `VIEW_CHANNEL` on the parent channel. The observed repair success means the original failure can be parent-channel access propagation after restriction, not a bot permission failure.

## Testing
- `npm run lint`
- `npm run build`
- `npm run format:check`
- `npm test -- --runTestsByPath src/__tests__/unit/ThreadManager.unit.test.ts src/__tests__/unit/SecurityActionService.unit.test.ts src/__tests__/unit/NotificationManager.unit.test.ts`
- `git diff --check`

## Risk Notes
- No schema or config changes.
- Repair only clears `thread` action failures after thread repair succeeds; unrelated failures remain visible.
- Notification repair now preserves existing dynamic embed fields such as `Latest Admin Action` and `Action Log`.