### PR TITLE
Fix PostCSS alert and post-111 follow-ups

### DIFF
--- a/apps/web/next-env.d.ts
+++ b/apps/web/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@drasil/contracts": "file:../../packages/contracts",
-    "next": "^16.2.6",
+    "next": "16.3.0-canary.6",
     "pg": "^8.20.0",
     "react": "^19.2.5",
     "react-dom": "^19.2.5",
@@ -30,10 +30,10 @@
     "@types/pg": "^8.15.6",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
+    "@vitest/coverage-v8": "^4.1.0",
     "eslint": "^9.23.0",
     "typescript": "^5.5.4",
     "typescript-eslint": "^8.28.0",
-    "@vitest/coverage-v8": "^4.1.0",
     "vitest": "^4.1.0"
   }
 }

--- a/docs/dev/maintainability.md
+++ b/docs/dev/maintainability.md
@@ -72,7 +72,7 @@ First metrics slice:
 
 - Include root `src` in `scripts/check-metrics.sh`.
 - Keep `lizard` strict for production code only, but start at a non-noisy ratchet baseline: cyclomatic complexity over `50` and function length over `300`.
-- PR #116 ratchets the cyclomatic complexity gate from `50` to the current non-noisy baseline of `37`; issue #114 remains the tracker for continuing the ratchet toward `25`.
+- PR #116 ratchets the cyclomatic complexity gate from `50` to the documented non-noisy target baseline of `25`.
 - Exclude tests from strict complexity checks for now.
 - Add an advisory largest-file report so growth is visible without failing existing known hotspots.
 
@@ -81,7 +81,7 @@ Ratcheting path:
 - Capture and update this inventory as large-file splits land.
 - Add a baseline or allowlist before any file-length gate becomes blocking.
 - Prefer preventing touched hotspots from growing before enforcing a global max-file-lines rule.
-- Ratchet cyclomatic complexity toward `25` under issue #114 as extracted setup/config handlers are split internally and current production code passes with margin.
+- Continue ratcheting cyclomatic complexity under issue #114 once extracted setup/config handlers are split enough to establish the next non-noisy baseline below `25`.
 
 Coverage strategy:
 
@@ -118,7 +118,7 @@ Lint strategy:
 - Lockdown slice implemented: `/config lockdown` view, disable, allow-list, audit, apply, and lockdown report formatting moved to `src/controllers/LockdownConfigCommandHandler.ts`.
 - Legacy test-command slice implemented: `!test` handling and GPT profile simulation moved to `src/controllers/TestCommandHandler.ts`.
 - `CommandHandler.ts` is now a 403-line command router/coordinator; the next maintainability targets are the newly extracted domain handlers that still appear in the advisory largest-file report, especially `ConfigSubcommandHandler.ts`, `SetupCommandHandler.ts`, and `commandDefinitions.ts`.
-- Setup remains a complexity ratchet target: the first gate used cyclomatic complexity `50` to avoid noisy failures, PR #116 ratchets that gate to the current baseline of `37`, and #114 remains the tracker for continuing toward `25` once setup internals are split further.
+- Setup remains a complexity ratchet target: the first gate used cyclomatic complexity `50` to avoid noisy failures, and PR #116 ratchets that gate to the documented baseline of `25` after splitting setup permission checks and config setup reply/result handling.
 - Command test split implemented: `src/__tests__/unit/CommandHandler.unit.test.ts` was replaced by domain files plus `src/__tests__/unit/commandHandlerTestHarness.ts`; the largest command-handler test slice is now `CommandHandler.setup.unit.test.ts` at 1,470 lines.
 - Metrics advisory report now skips tracked-but-deleted paths so pre-commit splits do not produce stale `wc` errors.
 - Interaction setup modal slice implemented: setup verification modal submission and rollback handling moved from `src/controllers/InteractionHandler.ts` to `src/controllers/SetupVerificationModalHandler.ts`.

--- a/docs/dev/maintainability.md
+++ b/docs/dev/maintainability.md
@@ -72,6 +72,7 @@ First metrics slice:
 
 - Include root `src` in `scripts/check-metrics.sh`.
 - Keep `lizard` strict for production code only, but start at a non-noisy ratchet baseline: cyclomatic complexity over `50` and function length over `300`.
+- PR #116 ratchets the cyclomatic complexity gate from `50` to the current non-noisy baseline of `37`; issue #114 remains the tracker for continuing the ratchet toward `25`.
 - Exclude tests from strict complexity checks for now.
 - Add an advisory largest-file report so growth is visible without failing existing known hotspots.
 
@@ -80,7 +81,7 @@ Ratcheting path:
 - Capture and update this inventory as large-file splits land.
 - Add a baseline or allowlist before any file-length gate becomes blocking.
 - Prefer preventing touched hotspots from growing before enforcing a global max-file-lines rule.
-- Ratchet cyclomatic complexity toward `25` as extracted setup/config handlers are split internally and current production code passes with margin.
+- Ratchet cyclomatic complexity toward `25` under issue #114 as extracted setup/config handlers are split internally and current production code passes with margin.
 
 Coverage strategy:
 
@@ -117,7 +118,7 @@ Lint strategy:
 - Lockdown slice implemented: `/config lockdown` view, disable, allow-list, audit, apply, and lockdown report formatting moved to `src/controllers/LockdownConfigCommandHandler.ts`.
 - Legacy test-command slice implemented: `!test` handling and GPT profile simulation moved to `src/controllers/TestCommandHandler.ts`.
 - `CommandHandler.ts` is now a 403-line command router/coordinator; the next maintainability targets are the newly extracted domain handlers that still appear in the advisory largest-file report, especially `ConfigSubcommandHandler.ts`, `SetupCommandHandler.ts`, and `commandDefinitions.ts`.
-- Setup remains a complexity ratchet target: the first gate uses cyclomatic complexity `50` to avoid noisy failures, with a documented target of `25` once setup internals are split further.
+- Setup remains a complexity ratchet target: the first gate used cyclomatic complexity `50` to avoid noisy failures, PR #116 ratchets that gate to the current baseline of `37`, and #114 remains the tracker for continuing toward `25` once setup internals are split further.
 - Command test split implemented: `src/__tests__/unit/CommandHandler.unit.test.ts` was replaced by domain files plus `src/__tests__/unit/commandHandlerTestHarness.ts`; the largest command-handler test slice is now `CommandHandler.setup.unit.test.ts` at 1,470 lines.
 - Metrics advisory report now skips tracked-but-deleted paths so pre-commit splits do not produce stale `wc` errors.
 - Interaction setup modal slice implemented: setup verification modal submission and rollback handling moved from `src/controllers/InteractionHandler.ts` to `src/controllers/SetupVerificationModalHandler.ts`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -62,7 +62,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@drasil/contracts": "file:../../packages/contracts",
-        "next": "^16.2.6",
+        "next": "16.3.0-canary.6",
         "pg": "^8.20.0",
         "react": "^19.2.5",
         "react-dom": "^19.2.5",
@@ -2555,16 +2555,19 @@
       "license": "MIT"
     },
     "node_modules/@next/env": {
-      "version": "16.2.6",
+      "version": "16.3.0-canary.6",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.3.0-canary.6.tgz",
+      "integrity": "sha512-viQ1MGyeIXc8kcLzAayNp/QOK55+9Zq448Jr4lgBezicapVyZ4mpuYSUL+pbe3zNn4HCIVWPQpELxTpPdCzgtQ==",
       "license": "MIT"
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "16.2.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.6.tgz",
-      "integrity": "sha512-ZJGkkcNfYgrrMkqOdZ7zoLa1TOy0qpcMfk/z4Mh/FKUz40gVO+HNQWqmLxf67Z5WB64DRp0dhEbyHfel+6sJUg==",
+      "version": "16.3.0-canary.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.3.0-canary.6.tgz",
+      "integrity": "sha512-MbXuBOTbr2efeqHixHI8/amWujMVb3dGS2sLfvTNHIXO5+sGILPJleEk9k+VcCG8hq/f4FWz7UjnsgCuXCft/w==",
       "cpu": [
         "arm64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -2574,12 +2577,13 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "16.2.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.6.tgz",
-      "integrity": "sha512-v/YLBHIY132Ced3puBJ7YJKw1lqsCrgcNo2aRJlCEyQrrCeRJlvGlnmxhPxNQI3KE3N1DN5r9TPNPvka3nq5RQ==",
+      "version": "16.3.0-canary.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.3.0-canary.6.tgz",
+      "integrity": "sha512-6oFb0WIz8qaapPFz5h/gS6DBtjAHh3RFjLo2MvIsVS2VnQnlwZluhXtqWm9B7EDQv6VqJTo0ZmBr3tbcIHrnTQ==",
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -2589,12 +2593,16 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "16.2.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.6.tgz",
-      "integrity": "sha512-RPOvqlYBbcQjkz9VQQDZ2T2bARIjXZV1KFlt+V2Mr6SW/e4I9fcKsaA0hdyf2FHoTlsV2xnBd5Y912rP/1Ce6w==",
+      "version": "16.3.0-canary.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.3.0-canary.6.tgz",
+      "integrity": "sha512-W3nI7lhUNIp8eHZ9KWMzGhM/8ZOBBEl6W/VU5X140UrzvMHI41Zr2VgQiNtusKRn2szujpl0AndJrXLgUNRgRA==",
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -2604,12 +2612,16 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "16.2.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.6.tgz",
-      "integrity": "sha512-URUTu1+dMkxJsPFgm+OeEvq9wf5sujw0EvgYy80TDGHTSLTnIHeqb0Eu8A3sC95IRgjejQL+kC4mw+4yPxiAXA==",
+      "version": "16.3.0-canary.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.3.0-canary.6.tgz",
+      "integrity": "sha512-Mp5X/ilMPUlfv67871WLrc6wBCRcpTYWqqSsyQc/KJwbG5bdaftWF3JlGfzMxeUnogydEKHKNn/zgs71QXItmQ==",
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -2619,12 +2631,16 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "16.2.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.6.tgz",
-      "integrity": "sha512-DOj182mPV8G3UkrayLoREM5YEYI+Dk5wv7Ox9xl1fFibAELEsFD0lDPfHIeILlutMMfdyhlzYPELG3peuKaurw==",
+      "version": "16.3.0-canary.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.3.0-canary.6.tgz",
+      "integrity": "sha512-hAaobdR+J/8WQgu6QlP1c+23fF2YRkjiayv2c0zq3KV/fiSEyAxmEj657EmkpBo6q/CWmwaO/QnKSG+z3Qr7fw==",
       "cpu": [
         "x64"
       ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -2634,12 +2650,16 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "16.2.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.6.tgz",
-      "integrity": "sha512-HKQ5SP/V/ub73UvF7n/zeJlxk2kLmtL7Wzrg4WfmkjmNos5onJ2tKu7yZOPdL18A6Svfn3max29ym+ry7NkK4g==",
+      "version": "16.3.0-canary.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.3.0-canary.6.tgz",
+      "integrity": "sha512-n6zJdZ5v9OsrWDVZ1obTjrOcg93LQaXuv6oNJqgPFkWuatCRrVBtqRhvS5258SZhYuKJYIcWG3v0llanrPz5zQ==",
       "cpu": [
         "x64"
       ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -2649,12 +2669,13 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "16.2.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.6.tgz",
-      "integrity": "sha512-LZXpTlPyS5v7HhSmnvsLGP3iIYgYOBnc8r8ArlT55sGHV89bR2HlDdBjWQ+PY6SJMmk8TuVGFuxalnP3k/0Dwg==",
+      "version": "16.3.0-canary.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.3.0-canary.6.tgz",
+      "integrity": "sha512-ZGpz4j7h2ZjFabzSah0/XGFGlAPoQ5keAKNJ2h5gnY3cHHiqa0xORX/SEk0QPV9ZVZTtZaKkt6kynscR3bGmjw==",
       "cpu": [
         "arm64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -2664,7 +2685,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "16.2.6",
+      "version": "16.3.0-canary.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.3.0-canary.6.tgz",
+      "integrity": "sha512-PfskcBjRHaRDWlnh3VdqHvnuadohogOmclSwNTk8hQiMgMr6awTxusrz9izr/jUhDWoZ1n/D738nzQN8vQ/CtA==",
       "cpu": [
         "x64"
       ],
@@ -3411,10 +3434,10 @@
         "x64"
       ],
       "dev": true,
-      "license": "MIT",
       "libc": [
         "glibc"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -3431,10 +3454,10 @@
         "x64"
       ],
       "dev": true,
-      "license": "MIT",
       "libc": [
         "musl"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -7081,14 +7104,16 @@
       "license": "MIT"
     },
     "node_modules/next": {
-      "version": "16.2.6",
+      "version": "16.3.0-canary.6",
+      "resolved": "https://registry.npmjs.org/next/-/next-16.3.0-canary.6.tgz",
+      "integrity": "sha512-DfikOWCKxyccJOQL3TOpIDg1mZgocra1GoHCmiA1eEpr12S/3hIBVISeABLaNbmY6Zz+hEkyCORQB7uws4QxXA==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "16.2.6",
+        "@next/env": "16.3.0-canary.6",
         "@swc/helpers": "0.5.15",
         "baseline-browser-mapping": "^2.9.19",
         "caniuse-lite": "^1.0.30001579",
-        "postcss": "8.4.31",
+        "postcss": "8.5.10",
         "styled-jsx": "5.1.6"
       },
       "bin": {
@@ -7098,14 +7123,14 @@
         "node": ">=20.9.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "16.2.6",
-        "@next/swc-darwin-x64": "16.2.6",
-        "@next/swc-linux-arm64-gnu": "16.2.6",
-        "@next/swc-linux-arm64-musl": "16.2.6",
-        "@next/swc-linux-x64-gnu": "16.2.6",
-        "@next/swc-linux-x64-musl": "16.2.6",
-        "@next/swc-win32-arm64-msvc": "16.2.6",
-        "@next/swc-win32-x64-msvc": "16.2.6",
+        "@next/swc-darwin-arm64": "16.3.0-canary.6",
+        "@next/swc-darwin-x64": "16.3.0-canary.6",
+        "@next/swc-linux-arm64-gnu": "16.3.0-canary.6",
+        "@next/swc-linux-arm64-musl": "16.3.0-canary.6",
+        "@next/swc-linux-x64-gnu": "16.3.0-canary.6",
+        "@next/swc-linux-x64-musl": "16.3.0-canary.6",
+        "@next/swc-win32-arm64-msvc": "16.3.0-canary.6",
+        "@next/swc-win32-x64-msvc": "16.3.0-canary.6",
         "sharp": "^0.34.5"
       },
       "peerDependencies": {
@@ -7554,7 +7579,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.31",
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -7571,9 +7598,9 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.6",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
       },
       "engines": {
         "node": "^10 || ^12 || >=14"

--- a/scripts/check-metrics.sh
+++ b/scripts/check-metrics.sh
@@ -16,9 +16,9 @@ scc \
 
 echo "== lizard (production complexity/function length) =="
 # Keep this separate from METRIC_PATHS: scc reports package size, while lizard
-# gates only production source paths. TODO(#114): continue ratcheting the CCN
-# baseline from 37 back toward 25 as documented in docs/dev/maintainability.md.
-lizard -C 37 -L 300 -w \
+# gates only production source paths. TODO(#114): continue ratcheting from the
+# documented CCN target once the next non-noisy baseline is available.
+lizard -C 25 -L 300 -w \
   -x "*/node_modules/*" \
   -x "*/.next/*" \
   -x "*/coverage/*" \

--- a/scripts/check-metrics.sh
+++ b/scripts/check-metrics.sh
@@ -16,9 +16,9 @@ scc \
 
 echo "== lizard (production complexity/function length) =="
 # Keep this separate from METRIC_PATHS: scc reports package size, while lizard
-# gates only production source paths. TODO(#110): ratchet the CCN baseline from
-# 50 back toward 25 as documented in docs/dev/maintainability.md.
-lizard -C 50 -L 300 -w \
+# gates only production source paths. TODO(#114): continue ratcheting the CCN
+# baseline from 37 back toward 25 as documented in docs/dev/maintainability.md.
+lizard -C 37 -L 300 -w \
   -x "*/node_modules/*" \
   -x "*/.next/*" \
   -x "*/coverage/*" \

--- a/src/__tests__/unit/NotificationPresentationBuilder.unit.test.ts
+++ b/src/__tests__/unit/NotificationPresentationBuilder.unit.test.ts
@@ -1,0 +1,198 @@
+import { EmbedBuilder, Guild, GuildMember, User } from 'discord.js';
+import { NotificationPresentationBuilder } from '../../services/NotificationPresentationBuilder';
+import { DetectionResult } from '../../services/DetectionOrchestrator';
+import {
+  AdminActionType,
+  DetectionEvent,
+  DetectionType,
+  VerificationEvent,
+  VerificationStatus,
+} from '../../repositories/types';
+import { VERIFICATION_ACTION_FAILURES_METADATA_KEY } from '../../utils/verificationActionFailures';
+
+const buildMember = (): GuildMember =>
+  ({
+    id: 'user-1',
+    joinedAt: new Date('2026-01-02T00:00:00Z'),
+    guild: { id: 'guild-1' } as unknown as Guild,
+    user: {
+      id: 'user-1',
+      tag: 'test-user#0001',
+      createdTimestamp: new Date('2026-01-01T00:00:00Z').getTime(),
+      displayAvatarURL: jest.fn().mockReturnValue('https://example.com/avatar.png'),
+    } as unknown as User,
+  }) as unknown as GuildMember;
+
+const buildDetectionResult = (overrides: Partial<DetectionResult> = {}): DetectionResult => ({
+  label: 'SUSPICIOUS',
+  confidence: 0.9,
+  reasons: ['Suspicious content'],
+  triggerSource: DetectionType.ADMIN_CASE,
+  triggerContent: 'Manual review',
+  ...overrides,
+});
+
+const buildDetectionEvent = (overrides: Partial<DetectionEvent> = {}): DetectionEvent => ({
+  id: overrides.id ?? 'event-1',
+  server_id: overrides.server_id ?? 'guild-1',
+  user_id: overrides.user_id ?? 'user-1',
+  thread_id: overrides.thread_id ?? null,
+  message_id: overrides.message_id ?? null,
+  channel_id: overrides.channel_id ?? null,
+  detection_type: overrides.detection_type ?? DetectionType.ADMIN_CASE,
+  confidence: overrides.confidence ?? 0.9,
+  reasons: overrides.reasons ?? ['Suspicious content'],
+  detected_at: overrides.detected_at ?? new Date('2026-01-03T00:00:00Z'),
+  latest_verification_event_id: overrides.latest_verification_event_id ?? null,
+  metadata: overrides.metadata,
+  admin_actions: overrides.admin_actions,
+});
+
+const buildVerificationEvent = (overrides: Partial<VerificationEvent> = {}): VerificationEvent => ({
+  id: overrides.id ?? 'ver-1',
+  server_id: overrides.server_id ?? 'guild-1',
+  user_id: overrides.user_id ?? 'user-1',
+  detection_event_id: overrides.detection_event_id ?? null,
+  thread_id: overrides.thread_id ?? null,
+  private_evidence_thread_id: overrides.private_evidence_thread_id ?? null,
+  notification_message_id: overrides.notification_message_id ?? null,
+  status: overrides.status ?? VerificationStatus.PENDING,
+  created_at: overrides.created_at ?? new Date('2026-01-03T00:00:00Z'),
+  updated_at: overrides.updated_at ?? new Date('2026-01-03T00:00:00Z'),
+  resolved_at: overrides.resolved_at ?? null,
+  resolved_by: overrides.resolved_by ?? null,
+  notes: overrides.notes ?? null,
+  metadata: overrides.metadata ?? null,
+});
+
+const getField = (embed: EmbedBuilder, name: string): string | undefined =>
+  embed.data.fields?.find((field) => field.name === name)?.value;
+
+describe('NotificationPresentationBuilder (unit)', () => {
+  const builder = new NotificationPresentationBuilder();
+
+  it('formats case thread links and newest-first detection history labels', () => {
+    const embed = builder.createSuspiciousUserEmbed(
+      buildMember(),
+      buildDetectionResult({ triggerSource: DetectionType.ADMIN_FLAG, triggerContent: 'triage' }),
+      buildVerificationEvent({
+        thread_id: 'thread-1',
+        private_evidence_thread_id: 'evidence-thread-1',
+        status: VerificationStatus.VERIFIED,
+        resolved_by: 'admin-1',
+      }),
+      [
+        buildDetectionEvent({
+          id: 'older',
+          detection_type: DetectionType.SUSPICIOUS_CONTENT,
+          detected_at: new Date('2026-01-01T00:00:00Z'),
+        }),
+        buildDetectionEvent({
+          id: 'newer',
+          detection_type: DetectionType.ROLE_INTAKE,
+          detected_at: new Date('2026-01-04T00:00:00Z'),
+          message_id: 'message-1',
+          channel_id: 'channel-1',
+        }),
+      ]
+    );
+
+    expect(getField(embed, 'Trigger')).toBe('Admin flag: triage');
+    expect(getField(embed, 'Case Threads')).toBe(
+      'Verification/review: [thread](https://discord.com/channels/guild-1/thread-1) status: verified by <@admin-1>\n' +
+        'Admin evidence: [thread](https://discord.com/channels/guild-1/evidence-thread-1)'
+    );
+    expect(getField(embed, 'Detection History')).toContain('role intake');
+    expect(getField(embed, 'Detection History')?.indexOf('role intake')).toBeLessThan(
+      getField(embed, 'Detection History')?.indexOf('suspicious content') ?? Number.MAX_VALUE
+    );
+    expect(getField(embed, 'Detection History')).toContain(
+      '[View Message](https://discord.com/channels/guild-1/channel-1/message-1)'
+    );
+  });
+
+  it('updates latest admin action and appends action log entries', () => {
+    const embed = new EmbedBuilder().addFields({
+      name: 'Detection Confidence',
+      value: 'High',
+      inline: true,
+    });
+
+    builder.upsertAdminActionLog(
+      embed,
+      AdminActionType.VERIFY,
+      'admin-1',
+      1_800_000_000,
+      undefined,
+      true
+    );
+    builder.upsertAdminActionLog(
+      embed,
+      AdminActionType.BAN,
+      'admin-2',
+      1_800_000_100,
+      undefined,
+      true
+    );
+
+    expect(embed.data.color).toBe(0x000000);
+    expect(embed.data.fields?.map((field) => field.name)).toEqual([
+      'Detection Confidence',
+      'Latest Admin Action',
+      'Action Log',
+    ]);
+    expect(getField(embed, 'Latest Admin Action')).toBe('Banned by <@admin-2> at <t:1800000100:F>');
+    expect(getField(embed, 'Action Log')).toBe(
+      '• Verified by <@admin-1> at <t:1800000000:F>\n' +
+        '• Banned by <@admin-2> at <t:1800000100:F>'
+    );
+  });
+
+  it('adds and removes moderation action failure warnings', () => {
+    const embed = new EmbedBuilder();
+
+    builder.upsertVerificationActionFailureField(
+      embed,
+      buildVerificationEvent({
+        metadata: {
+          [VERIFICATION_ACTION_FAILURES_METADATA_KEY]: [
+            {
+              action: 'private_evidence_thread',
+              at: '2026-01-01T00:00:00Z',
+              message: 'Missing thread permissions',
+            },
+          ],
+        },
+      })
+    );
+
+    expect(getField(embed, 'Moderation Action Warning')).toContain(
+      'Warning: Create admin evidence thread failed'
+    );
+
+    builder.upsertVerificationActionFailureField(embed, buildVerificationEvent({ metadata: {} }));
+
+    expect(getField(embed, 'Moderation Action Warning')).toBeUndefined();
+  });
+
+  it('formats observed admin and role-intake triggers', () => {
+    const adminCaseEmbed = builder.createObservedDetectionEmbed(
+      buildMember(),
+      buildDetectionResult({ triggerSource: DetectionType.ADMIN_CASE, triggerContent: '' }),
+      []
+    );
+    const roleIntakeEmbed = builder.createObservedDetectionEmbed(
+      buildMember(),
+      buildDetectionResult({
+        triggerSource: DetectionType.ROLE_INTAKE,
+        triggerContent: 'new role',
+      }),
+      []
+    );
+
+    expect(getField(adminCaseEmbed, 'Trigger')).toBe(
+      'Observed via admin-opened case: Manual review'
+    );
+    expect(getField(roleIntakeEmbed, 'Trigger')).toBe('Observed via role intake: new role');
+  });
+});

--- a/src/controllers/SetupCommandHandler.ts
+++ b/src/controllers/SetupCommandHandler.ts
@@ -19,6 +19,7 @@ import { truncatePreview } from '../utils/textPreview';
 import { ReportInstructionsManager } from './ReportInstructionsManager';
 
 const DEFAULT_RESTRICTED_ROLE_NAME = 'Drasil Restricted';
+const DEFAULT_SETUP_FAILURE_DETAIL = 'Please check permissions and try again.';
 const VERIFICATION_CHANNEL_NAME = 'verification';
 
 type ReplyGuildInstallRequired = (interaction: ChatInputCommandInteraction) => Promise<void>;
@@ -77,7 +78,7 @@ export class SetupCommandHandler {
       return;
     }
 
-    let setupFailureDetail = 'Please check permissions and try again.';
+    let setupFailureDetail = DEFAULT_SETUP_FAILURE_DETAIL;
 
     try {
       const restrictedRole = interaction.options.getRole('restricted-role', true);
@@ -144,9 +145,7 @@ export class SetupCommandHandler {
       if (setupResult.status === 'final_validation_failed') {
         setupFailureDetail = setupResult.setupFailureDetail;
         const rollbackNote =
-          setupFailureDetail !== 'Please check permissions and try again.'
-            ? `\n\n${setupFailureDetail}`
-            : '';
+          setupFailureDetail !== DEFAULT_SETUP_FAILURE_DETAIL ? `\n\n${setupFailureDetail}` : '';
         await interaction.editReply({
           content: `Setup not saved. Fix the errors below and rerun setup.${rollbackNote}\n\n${this.formatSetupDiagnosticsReport(setupResult.report)}`,
           allowedMentions: { parse: [] },
@@ -486,7 +485,7 @@ export class SetupCommandHandler {
       await interaction.editReply({
         content: setupFailureDetail
           ? `Failed to complete setup. ${setupFailureDetail}`
-          : 'Failed to complete setup. Please check permissions and try again.',
+          : `Failed to complete setup. ${DEFAULT_SETUP_FAILURE_DETAIL}`,
         allowedMentions: { parse: [] },
       });
     }
@@ -596,7 +595,10 @@ export class SetupCommandHandler {
         });
         return { setupFailureDetail: null };
       case 'final_validation_failed': {
-        const rollbackNote = `\n\n${setupResult.setupFailureDetail}`;
+        const rollbackNote =
+          setupResult.setupFailureDetail !== DEFAULT_SETUP_FAILURE_DETAIL
+            ? `\n\n${setupResult.setupFailureDetail}`
+            : '';
         await interaction.editReply({
           content: `Setup not saved. Fix the errors below and rerun /config setup.${rollbackNote}\n\n${this.formatSetupDiagnosticsReport(setupResult.report)}`,
           allowedMentions: { parse: [] },

--- a/src/controllers/SetupCommandHandler.ts
+++ b/src/controllers/SetupCommandHandler.ts
@@ -14,7 +14,7 @@ import {
   SetupDiagnosticIssue,
   SetupDiagnosticReport,
 } from '../services/SetupDiagnosticsService';
-import { SetupWorkflowService } from '../services/SetupWorkflowService';
+import { SetupWorkflowService, type SetupWorkflowResult } from '../services/SetupWorkflowService';
 import { truncatePreview } from '../utils/textPreview';
 import { ReportInstructionsManager } from './ReportInstructionsManager';
 
@@ -22,6 +22,11 @@ const DEFAULT_RESTRICTED_ROLE_NAME = 'Drasil Restricted';
 const VERIFICATION_CHANNEL_NAME = 'verification';
 
 type ReplyGuildInstallRequired = (interaction: ChatInputCommandInteraction) => Promise<void>;
+type CompletedSetupWorkflowResult = Extract<SetupWorkflowResult, { status: 'completed' }>;
+type ConfigSetupReportInstructionsStatus = {
+  line: string | null;
+  warningLine: string | null;
+};
 
 export class SetupCommandHandler {
   private readonly setupWorkflowService?: SetupWorkflowService;
@@ -53,20 +58,7 @@ export class SetupCommandHandler {
       return;
     }
 
-    let hasAdminPermission = interaction.memberPermissions?.has(PermissionFlagsBits.Administrator);
-
-    if (hasAdminPermission === undefined) {
-      const invokingMember = await guild.members.fetch(interaction.user.id).catch(() => null);
-      if (!invokingMember) {
-        hasAdminPermission = false;
-      } else if (interaction.channelId) {
-        hasAdminPermission = invokingMember
-          .permissionsIn(interaction.channelId)
-          .has(PermissionFlagsBits.Administrator);
-      } else {
-        hasAdminPermission = invokingMember.permissions.has(PermissionFlagsBits.Administrator);
-      }
-    }
+    const hasAdminPermission = await this.hasSetupAdminPermission(interaction, guild);
 
     if (!hasAdminPermission) {
       await interaction.reply({
@@ -206,6 +198,29 @@ export class SetupCommandHandler {
         await interaction.reply({ ...errorResponse, flags: MessageFlags.Ephemeral });
       }
     }
+  }
+
+  private async hasSetupAdminPermission(
+    interaction: ChatInputCommandInteraction,
+    guild: NonNullable<ChatInputCommandInteraction['guild']>
+  ): Promise<boolean> {
+    const memberPermission = interaction.memberPermissions?.has(PermissionFlagsBits.Administrator);
+    if (memberPermission !== undefined) {
+      return memberPermission;
+    }
+
+    const invokingMember = await guild.members.fetch(interaction.user.id).catch(() => null);
+    if (!invokingMember) {
+      return false;
+    }
+
+    if (interaction.channelId) {
+      return invokingMember
+        .permissionsIn(interaction.channelId)
+        .has(PermissionFlagsBits.Administrator);
+    }
+
+    return invokingMember.permissions.has(PermissionFlagsBits.Administrator);
   }
 
   private async resolveVerificationChannelCandidate(
@@ -360,35 +375,15 @@ export class SetupCommandHandler {
     const verificationChannel = interaction.options.getChannel('verification-channel');
     const reportChannel = interaction.options.getChannel('report-channel');
 
-    if (adminChannel.type !== ChannelType.GuildText) {
-      await interaction.reply({
-        content: 'Admin channel must be a text channel.',
-        flags: MessageFlags.Ephemeral,
-      });
-      return;
-    }
-
-    if (verificationChannel && verificationChannel.type !== ChannelType.GuildText) {
-      await interaction.reply({
-        content: 'Verification channel must be a text channel.',
-        flags: MessageFlags.Ephemeral,
-      });
-      return;
-    }
-
-    if (reportChannel && reportChannel.type !== ChannelType.GuildText) {
-      await interaction.reply({
-        content: 'Report channel must be a text channel.',
-        flags: MessageFlags.Ephemeral,
-      });
-      return;
-    }
-
-    if (existingRestrictedRole && requestedRoleName) {
-      await interaction.reply({
-        content: '`restricted-role-name` cannot be combined with `restricted-role`.',
-        flags: MessageFlags.Ephemeral,
-      });
+    if (
+      await this.replyIfInvalidConfigSetupOptions(interaction, {
+        adminChannel,
+        verificationChannel,
+        reportChannel,
+        hasExplicitRestrictedRole: Boolean(existingRestrictedRole),
+        requestedRoleName,
+      })
+    ) {
       return;
     }
 
@@ -407,27 +402,13 @@ export class SetupCommandHandler {
         requestedRoleName
       );
 
-      if (restrictedRoleCandidate.ambiguousRoleIds.length > 0) {
-        await interaction.editReply({
-          content:
-            `Setup not saved. Multiple roles named \`${restrictedRoleCandidate.roleName}\` already exist: ` +
-            restrictedRoleCandidate.ambiguousRoleIds.map((roleId) => `<@&${roleId}>`).join(', ') +
-            '. Choose one with `restricted-role` before rerunning /config setup.',
-          allowedMentions: { parse: [] },
-        });
-        return;
-      }
-
-      if (verificationChannelCandidate.ambiguousChannelIds.length > 0) {
-        await interaction.editReply({
-          content:
-            `Setup not saved. Multiple #${VERIFICATION_CHANNEL_NAME} channels already exist: ` +
-            verificationChannelCandidate.ambiguousChannelIds
-              .map((channelId) => `<#${channelId}>`)
-              .join(', ') +
-            '. Choose one with `verification-channel` before rerunning /config setup.',
-          allowedMentions: { parse: [] },
-        });
+      if (
+        await this.replyIfAmbiguousConfigSetupCandidates(
+          interaction,
+          restrictedRoleCandidate,
+          verificationChannelCandidate
+        )
+      ) {
         return;
       }
 
@@ -443,11 +424,7 @@ export class SetupCommandHandler {
         reportInstructionsChannelId: reportChannel?.id ?? null,
       });
 
-      if (candidateReport.errorCount > 0) {
-        await interaction.editReply({
-          content: `Setup not saved. Fix the errors below and rerun /config setup.\n\n${this.formatSetupDiagnosticsReport(candidateReport)}`,
-          allowedMentions: { parse: [] },
-        });
+      if (await this.replyIfConfigSetupCandidateHasErrors(interaction, candidateReport)) {
         return;
       }
 
@@ -476,69 +453,29 @@ export class SetupCommandHandler {
         createdRestrictedRole,
       });
 
-      if (setupResult.status === 'candidate_validation_failed') {
-        await interaction.editReply({
-          content: `Setup not saved. Fix the errors below and rerun /config setup.\n\n${this.formatSetupDiagnosticsReport(setupResult.report)}`,
-          allowedMentions: { parse: [] },
-        });
-        return;
-      }
-
-      if (setupResult.status === 'final_validation_failed') {
-        setupFailureDetail = setupResult.setupFailureDetail;
-        const rollbackNote = `\n\n${setupFailureDetail}`;
-        await interaction.editReply({
-          content: `Setup not saved. Fix the errors below and rerun /config setup.${rollbackNote}\n\n${this.formatSetupDiagnosticsReport(setupResult.report)}`,
-          allowedMentions: { parse: [] },
-        });
-        return;
-      }
-
-      if (setupResult.status === 'verification_channel_failed') {
-        setupFailureDetail = setupResult.setupFailureDetail;
-        throw setupResult.error;
-      }
-
-      if (setupResult.status === 'config_save_failed') {
-        setupFailureDetail = setupResult.setupFailureDetail;
-        throw setupResult.error;
-      }
-
-      let reportInstructionsLine: string | null = null;
-      let reportInstructionsWarningLine: string | null = null;
-      if (reportChannel) {
-        try {
-          const result = await this.reportInstructionsManager.upsertReportInstructionsMessage(
-            guild.id,
-            reportChannel as TextChannel
-          );
-          reportInstructionsLine = `Report instructions ${result.action}: <#${reportChannel.id}>`;
-        } catch (error) {
-          console.error(`Failed to upsert report instructions for guild ${guild.id}:`, error);
-          reportInstructionsWarningLine =
-            `[WARNING] Core setup was saved, but report instructions were not updated in <#${reportChannel.id}>. ` +
-            'Check Drasil can send messages and embeds there, then rerun setup.';
+      if (setupResult.status !== 'completed') {
+        const incompleteResult = await this.resolveIncompleteConfigSetupResult(
+          interaction,
+          setupResult
+        );
+        if (incompleteResult.setupFailureDetail) {
+          setupFailureDetail = incompleteResult.setupFailureDetail;
         }
+        if (incompleteResult.error) {
+          throw incompleteResult.error;
+        }
+        return;
       }
 
-      const lines = [
-        'Setup complete.',
-        `${setupResult.restrictedRoleWasCreated ? 'Created restricted role' : 'Restricted role'}: <@&${setupResult.restrictedRoleId}>`,
-        `Admin channel: <#${adminChannel.id}>`,
-        `${setupResult.verificationChannelAction === 'created' ? 'Created verification channel' : setupResult.verificationChannelAction === 'synced' ? 'Synced verification channel permissions' : 'Verification channel'}: <#${setupResult.verificationChannelId}>`,
-      ];
-
-      if (reportInstructionsLine) {
-        lines.push(reportInstructionsLine);
-      }
-
-      if (reportInstructionsWarningLine) {
-        lines.push(reportInstructionsWarningLine);
-      }
-
-      if (setupResult.candidateReport.warningCount > 0) {
-        this.appendSetupDiagnosticsReport(lines, setupResult.candidateReport);
-      }
+      const reportInstructionsStatus = await this.upsertReportInstructionsStatus(
+        guild.id,
+        reportChannel as TextChannel | null
+      );
+      const lines = this.buildConfigSetupSuccessLines(
+        setupResult,
+        adminChannel.id,
+        reportInstructionsStatus
+      );
 
       await interaction.editReply({
         content: truncatePreview(lines.join('\n'), 1900),
@@ -553,6 +490,184 @@ export class SetupCommandHandler {
         allowedMentions: { parse: [] },
       });
     }
+  }
+
+  private async replyIfInvalidConfigSetupOptions(
+    interaction: ChatInputCommandInteraction,
+    options: {
+      adminChannel: { type: ChannelType };
+      verificationChannel: { type: ChannelType } | null;
+      reportChannel: { type: ChannelType } | null;
+      hasExplicitRestrictedRole: boolean;
+      requestedRoleName: string | null;
+    }
+  ): Promise<boolean> {
+    if (options.adminChannel.type !== ChannelType.GuildText) {
+      await interaction.reply({
+        content: 'Admin channel must be a text channel.',
+        flags: MessageFlags.Ephemeral,
+      });
+      return true;
+    }
+
+    if (options.verificationChannel && options.verificationChannel.type !== ChannelType.GuildText) {
+      await interaction.reply({
+        content: 'Verification channel must be a text channel.',
+        flags: MessageFlags.Ephemeral,
+      });
+      return true;
+    }
+
+    if (options.reportChannel && options.reportChannel.type !== ChannelType.GuildText) {
+      await interaction.reply({
+        content: 'Report channel must be a text channel.',
+        flags: MessageFlags.Ephemeral,
+      });
+      return true;
+    }
+
+    if (options.hasExplicitRestrictedRole && options.requestedRoleName) {
+      await interaction.reply({
+        content: '`restricted-role-name` cannot be combined with `restricted-role`.',
+        flags: MessageFlags.Ephemeral,
+      });
+      return true;
+    }
+
+    return false;
+  }
+
+  private async replyIfAmbiguousConfigSetupCandidates(
+    interaction: ChatInputCommandInteraction,
+    restrictedRoleCandidate: { roleName: string; ambiguousRoleIds: readonly string[] },
+    verificationChannelCandidate: { ambiguousChannelIds: readonly string[] }
+  ): Promise<boolean> {
+    if (restrictedRoleCandidate.ambiguousRoleIds.length > 0) {
+      await interaction.editReply({
+        content:
+          `Setup not saved. Multiple roles named \`${restrictedRoleCandidate.roleName}\` already exist: ` +
+          restrictedRoleCandidate.ambiguousRoleIds.map((roleId) => `<@&${roleId}>`).join(', ') +
+          '. Choose one with `restricted-role` before rerunning /config setup.',
+        allowedMentions: { parse: [] },
+      });
+      return true;
+    }
+
+    if (verificationChannelCandidate.ambiguousChannelIds.length > 0) {
+      await interaction.editReply({
+        content:
+          `Setup not saved. Multiple #${VERIFICATION_CHANNEL_NAME} channels already exist: ` +
+          verificationChannelCandidate.ambiguousChannelIds
+            .map((channelId) => `<#${channelId}>`)
+            .join(', ') +
+          '. Choose one with `verification-channel` before rerunning /config setup.',
+        allowedMentions: { parse: [] },
+      });
+      return true;
+    }
+
+    return false;
+  }
+
+  private async replyIfConfigSetupCandidateHasErrors(
+    interaction: ChatInputCommandInteraction,
+    candidateReport: SetupDiagnosticReport
+  ): Promise<boolean> {
+    if (candidateReport.errorCount === 0) {
+      return false;
+    }
+
+    await interaction.editReply({
+      content: `Setup not saved. Fix the errors below and rerun /config setup.\n\n${this.formatSetupDiagnosticsReport(candidateReport)}`,
+      allowedMentions: { parse: [] },
+    });
+    return true;
+  }
+
+  private async resolveIncompleteConfigSetupResult(
+    interaction: ChatInputCommandInteraction,
+    setupResult: Exclude<SetupWorkflowResult, { status: 'completed' }>
+  ): Promise<{ setupFailureDetail: string | null; error?: unknown }> {
+    switch (setupResult.status) {
+      case 'candidate_validation_failed':
+        await interaction.editReply({
+          content: `Setup not saved. Fix the errors below and rerun /config setup.\n\n${this.formatSetupDiagnosticsReport(setupResult.report)}`,
+          allowedMentions: { parse: [] },
+        });
+        return { setupFailureDetail: null };
+      case 'final_validation_failed': {
+        const rollbackNote = `\n\n${setupResult.setupFailureDetail}`;
+        await interaction.editReply({
+          content: `Setup not saved. Fix the errors below and rerun /config setup.${rollbackNote}\n\n${this.formatSetupDiagnosticsReport(setupResult.report)}`,
+          allowedMentions: { parse: [] },
+        });
+        return { setupFailureDetail: setupResult.setupFailureDetail };
+      }
+      case 'verification_channel_failed':
+      case 'config_save_failed':
+        return { setupFailureDetail: setupResult.setupFailureDetail, error: setupResult.error };
+    }
+  }
+
+  private async upsertReportInstructionsStatus(
+    guildId: string,
+    reportChannel: TextChannel | null
+  ): Promise<ConfigSetupReportInstructionsStatus> {
+    if (!reportChannel) {
+      return { line: null, warningLine: null };
+    }
+
+    try {
+      const result = await this.reportInstructionsManager.upsertReportInstructionsMessage(
+        guildId,
+        reportChannel
+      );
+      return {
+        line: `Report instructions ${result.action}: <#${reportChannel.id}>`,
+        warningLine: null,
+      };
+    } catch (error) {
+      console.error(`Failed to upsert report instructions for guild ${guildId}:`, error);
+      return {
+        line: null,
+        warningLine:
+          `[WARNING] Core setup was saved, but report instructions were not updated in <#${reportChannel.id}>. ` +
+          'Check Drasil can send messages and embeds there, then rerun setup.',
+      };
+    }
+  }
+
+  private buildConfigSetupSuccessLines(
+    setupResult: CompletedSetupWorkflowResult,
+    adminChannelId: string,
+    reportInstructionsStatus: ConfigSetupReportInstructionsStatus
+  ): string[] {
+    const verificationChannelAction =
+      setupResult.verificationChannelAction === 'created'
+        ? 'Created verification channel'
+        : setupResult.verificationChannelAction === 'synced'
+          ? 'Synced verification channel permissions'
+          : 'Verification channel';
+    const lines = [
+      'Setup complete.',
+      `${setupResult.restrictedRoleWasCreated ? 'Created restricted role' : 'Restricted role'}: <@&${setupResult.restrictedRoleId}>`,
+      `Admin channel: <#${adminChannelId}>`,
+      `${verificationChannelAction}: <#${setupResult.verificationChannelId}>`,
+    ];
+
+    if (reportInstructionsStatus.line) {
+      lines.push(reportInstructionsStatus.line);
+    }
+
+    if (reportInstructionsStatus.warningLine) {
+      lines.push(reportInstructionsStatus.warningLine);
+    }
+
+    if (setupResult.candidateReport.warningCount > 0) {
+      this.appendSetupDiagnosticsReport(lines, setupResult.candidateReport);
+    }
+
+    return lines;
   }
 
   public async handleConfigValidateCommand(

--- a/src/services/NotificationManager.ts
+++ b/src/services/NotificationManager.ts
@@ -1,10 +1,7 @@
 import { injectable, inject } from 'inversify';
 import {
-  ActionRowBuilder,
-  ButtonStyle,
   Client,
   EmbedBuilder,
-  ButtonBuilder,
   GuildMember,
   Message,
   User,
@@ -25,31 +22,16 @@ import { DetectionResult } from './DetectionOrchestrator';
 import { IDetectionEventsRepository } from '../repositories/DetectionEventsRepository';
 import {
   DetectionEvent,
-  Server,
   VerificationStatus,
   AdminActionType,
   VerificationEvent,
-  DetectionType,
 } from '../repositories/types';
 import { DetectionHistoryFormatter } from '../utils/DetectionHistoryFormatter';
-import type { ReportAIAnalysis, VerificationThreadAnalysisResult } from './GPTService';
+import type { VerificationThreadAnalysisResult } from './GPTService';
 import { getDetectionResponseSettings } from '../utils/detectionResponseSettings';
-import { getVerificationActionFailures } from '../utils/verificationActionFailures';
-import { getCaseResponderSettings } from '../utils/caseResponderSettings';
-import { CASE_STAFF_ROUTING_METADATA_KEY } from './ThreadManager';
-import { isDetectionEventExcludedFromAccounting } from '../utils/detectionEventAccounting';
-import {
-  buildCaseAdminActionsCustomId,
-  buildObservedAdminActionsCustomId,
-} from '../utils/adminActionCustomIds';
+import { NotificationPresentationBuilder } from './NotificationPresentationBuilder';
 
 const VERIFICATION_CHANNEL_NAME = 'verification';
-
-export interface NotificationButton {
-  id: string;
-  label: string;
-  style: ButtonStyle;
-}
 
 /**
  * Interface for NotificationManager service
@@ -136,21 +118,6 @@ export interface INotificationManager {
   ): Promise<boolean>;
 }
 
-interface ThreadAnalysisMetadata {
-  analyzedMessageIds?: unknown;
-  latestAnalysis?: {
-    result: 'likely_legitimate' | 'needs_review' | 'likely_suspicious';
-    confidence: number;
-    summary: string;
-    reasonCodes?: string[];
-    legitimacySignals?: string[];
-    suspicionSignals?: string[];
-    recommendedNextQuestion?: string;
-    recommendedAction?: 'none' | 'ask_followup' | 'manual_review' | 'restrict';
-    analyzedMessageCount: number;
-  };
-}
-
 interface ObservedDetectionMetadata {
   observed_notification_message_id?: string;
   observed_notification_last_notified_at?: string;
@@ -167,9 +134,7 @@ export class NotificationManager implements INotificationManager {
   private client: Client;
   private configService: IConfigService;
   private detectionEventsRepository: IDetectionEventsRepository;
-  private static readonly THREAD_ANALYSIS_FIELD_NAME = 'AI Thread Analysis';
-  private static readonly LATEST_ADMIN_ACTION_FIELD_NAME = 'Latest Admin Action';
-  private static readonly MODERATION_ACTION_WARNING_FIELD_NAME = 'Moderation Action Warning';
+  private presentationBuilder = new NotificationPresentationBuilder();
 
   constructor(
     @inject(TYPES.DiscordClient) client: Client,
@@ -202,15 +167,19 @@ export class NotificationManager implements INotificationManager {
     }
 
     try {
-      // Create the base embed
-      const embed = await this.createSuspiciousUserEmbed(
+      const detectionEvents = await this.detectionEventsRepository.findByServerAndUser(
+        member.guild.id,
+        member.id
+      );
+      const embed = this.presentationBuilder.createSuspiciousUserEmbed(
         member,
         detectionResult,
         verificationEvent,
+        detectionEvents,
         sourceMessage
       );
       const serverConfig = await this.configService.getServerConfig(member.guild.id);
-      const actionRow = this.createActionRow(member.id);
+      const actionRow = this.presentationBuilder.createActionRow(member.id);
 
       // If we have an existing message, update it, otherwise create new
       if (verificationEvent.notification_message_id) {
@@ -225,10 +194,10 @@ export class NotificationManager implements INotificationManager {
       }
 
       // Create a new message
-      const notificationRoleIds = this.getCaseNotificationRoleIds(serverConfig);
+      const notificationRoleIds = this.presentationBuilder.getCaseNotificationRoleIds(serverConfig);
       return await adminChannel.send({
-        content: this.formatRoleMentions(notificationRoleIds),
-        allowedMentions: this.createAdminAllowedMentions(notificationRoleIds),
+        content: this.presentationBuilder.formatRoleMentions(notificationRoleIds),
+        allowedMentions: this.presentationBuilder.createAdminAllowedMentions(notificationRoleIds),
         embeds: [embed],
         components: [actionRow],
       });
@@ -264,7 +233,7 @@ export class NotificationManager implements INotificationManager {
         detectionEvents,
         responseSettings.observedNotificationWindowMinutes
       );
-      const embed = this.createObservedDetectionEmbed(
+      const embed = this.presentationBuilder.createObservedDetectionEmbed(
         member,
         detectionResult,
         detectionEvents,
@@ -272,7 +241,7 @@ export class NotificationManager implements INotificationManager {
       );
       const actionDetectionEventId = detectionResult.detectionEventId ?? detectionEvents[0]?.id;
       const components = actionDetectionEventId
-        ? this.createObservedActionRows(member.id, actionDetectionEventId)
+        ? this.presentationBuilder.createObservedActionRows(member.id, actionDetectionEventId)
         : [];
 
       let notificationMessage: Message | null = null;
@@ -282,7 +251,7 @@ export class NotificationManager implements INotificationManager {
           .catch(() => null);
         if (existingMessage) {
           notificationMessage = await existingMessage.edit({
-            allowedMentions: this.createAdminAllowedMentions(),
+            allowedMentions: this.presentationBuilder.createAdminAllowedMentions(),
             embeds: [embed],
             components,
           });
@@ -290,10 +259,11 @@ export class NotificationManager implements INotificationManager {
       }
 
       if (!notificationMessage) {
-        const notificationRoleIds = this.getCaseNotificationRoleIds(serverConfig);
+        const notificationRoleIds =
+          this.presentationBuilder.getCaseNotificationRoleIds(serverConfig);
         notificationMessage = await notificationChannel.send({
-          content: this.formatRoleMentions(notificationRoleIds),
-          allowedMentions: this.createAdminAllowedMentions(notificationRoleIds),
+          content: this.presentationBuilder.formatRoleMentions(notificationRoleIds),
+          allowedMentions: this.presentationBuilder.createAdminAllowedMentions(notificationRoleIds),
           embeds: [embed],
           components,
         });
@@ -358,19 +328,17 @@ export class NotificationManager implements INotificationManager {
 
       const updatedEmbed = EmbedBuilder.from(message.embeds[0]);
       const timestamp = Math.floor(Date.now() / 1000);
-      const field = {
-        name: 'Action Taken',
-        value: `<@${admin.id}> ${actionDescription} <t:${timestamp}:R>`,
-        inline: false,
-      };
-      const existingFields =
-        updatedEmbed.data.fields?.filter(
-          (existingField) =>
-            existingField.name !== field.name && existingField.name !== 'Action Reverted'
-        ) ?? [];
-      updatedEmbed.setFields(...existingFields, field);
+      this.presentationBuilder.addObservedActionTakenField(
+        updatedEmbed,
+        actionDescription,
+        admin.id,
+        timestamp
+      );
 
-      const components = this.createObservedActionRows(detectionEvent.user_id, detectionEvent.id);
+      const components = this.presentationBuilder.createObservedActionRows(
+        detectionEvent.user_id,
+        detectionEvent.id
+      );
 
       await message.edit({
         allowedMentions: { parse: [] },
@@ -417,7 +385,10 @@ export class NotificationManager implements INotificationManager {
         return false;
       }
 
-      const components = this.createObservedActionRows(detectionEvent.user_id, detectionEvent.id);
+      const components = this.presentationBuilder.createObservedActionRows(
+        detectionEvent.user_id,
+        detectionEvent.id
+      );
       if (!message.embeds.length) {
         await message.edit({ allowedMentions: { parse: [] }, components });
         return true;
@@ -425,17 +396,12 @@ export class NotificationManager implements INotificationManager {
 
       const updatedEmbed = EmbedBuilder.from(message.embeds[0]);
       const timestamp = Math.floor(Date.now() / 1000);
-      const field = {
-        name: 'Action Reverted',
-        value: `<@${admin.id}> ${actionDescription} <t:${timestamp}:R>`,
-        inline: false,
-      };
-      const existingFields =
-        updatedEmbed.data.fields?.filter(
-          (existingField) =>
-            existingField.name !== 'Action Taken' && existingField.name !== field.name
-        ) ?? [];
-      updatedEmbed.setFields(...existingFields, field);
+      this.presentationBuilder.addObservedActionRevertedField(
+        updatedEmbed,
+        actionDescription,
+        admin.id,
+        timestamp
+      );
 
       await message.edit({
         allowedMentions: { parse: [] },
@@ -475,56 +441,14 @@ export class NotificationManager implements INotificationManager {
       // Create a new embed based on the existing one
       const updatedEmbed = EmbedBuilder.from(existingEmbed);
 
-      const timestamp = Math.floor(Date.now() / 1000);
-      const actionLogField = updatedEmbed.data.fields?.find((field) => field.name === 'Action Log');
-      this.upsertLatestAdminActionField(updatedEmbed, actionTaken, admin.id, timestamp);
-
-      let actionLogContent = `• ${this.formatAdminActionEvent(actionTaken, admin.id, timestamp)}`;
-
-      // If a thread was created, add/update a dedicated thread link field
-      if (thread && actionTaken === AdminActionType.CREATE_THREAD) {
-        const threadField = {
-          name: 'Verification Thread',
-          value: `[Click here to view the thread](${thread.url})`,
-          inline: false,
-        };
-        // Check if thread field already exists
-        const existingThreadFieldIndex = updatedEmbed.data.fields?.findIndex(
-          (field) => field.name === 'Verification Thread'
-        );
-        if (existingThreadFieldIndex !== undefined && existingThreadFieldIndex > -1) {
-          // Update existing field
-          updatedEmbed.spliceFields(existingThreadFieldIndex, 1, threadField);
-        } else {
-          // Add new field
-          updatedEmbed.addFields(threadField);
-        }
-      }
-
-      // Update the thread status if it's a verification or ban action
-      if (message.guildId && actionTaken === AdminActionType.VERIFY) {
-        // Update embed color based on resolution
-        updatedEmbed.setColor(0x00ff00);
-      }
-
-      // Update the thread status if it's a verification or ban action
-      if (message.guildId && actionTaken === AdminActionType.BAN) {
-        // Update embed color based on resolution
-        updatedEmbed.setColor(0x000000);
-      }
-
-      if (actionLogField) {
-        // Append to existing log
-        actionLogContent = `${actionLogField.value}\n${actionLogContent}`;
-      }
-
-      if (actionLogField) {
-        // Update existing field
-        actionLogField.value = actionLogContent;
-      } else {
-        // Add new field
-        updatedEmbed.addFields({ name: 'Action Log', value: actionLogContent, inline: false });
-      }
+      this.presentationBuilder.upsertAdminActionLog(
+        updatedEmbed,
+        actionTaken,
+        admin.id,
+        Math.floor(Date.now() / 1000),
+        thread?.url,
+        Boolean(message.guildId)
+      );
 
       // Update the message embed. Let button updates be handled separately.
       await message.edit({ allowedMentions: { parse: [] }, embeds: [updatedEmbed] });
@@ -545,26 +469,11 @@ export class NotificationManager implements INotificationManager {
       const existingEmbed = message.embeds[0];
       const updatedEmbed = EmbedBuilder.from(existingEmbed);
 
-      const value = this.formatThreadAnalysisFieldValue({
-        ...analysis,
-        analyzedMessageCount,
-      });
-
-      const field = {
-        name: NotificationManager.THREAD_ANALYSIS_FIELD_NAME,
-        value,
-        inline: false,
-      };
-
-      const existingFieldIndex = updatedEmbed.data.fields?.findIndex(
-        (embedField) => embedField.name === field.name
+      this.presentationBuilder.upsertThreadAnalysisField(
+        updatedEmbed,
+        analysis,
+        analyzedMessageCount
       );
-
-      if (existingFieldIndex !== undefined && existingFieldIndex > -1) {
-        updatedEmbed.spliceFields(existingFieldIndex, 1, field);
-      } else {
-        updatedEmbed.addFields(field);
-      }
 
       await message.edit({ allowedMentions: { parse: [] }, embeds: [updatedEmbed] });
       return true;
@@ -574,146 +483,12 @@ export class NotificationManager implements INotificationManager {
     }
   }
 
-  private truncateEmbedFieldValue(value: string): string {
-    const maxLength = 1024;
-    if (value.length <= maxLength) {
-      return value;
-    }
-
-    return `${value.slice(0, maxLength - 3)}...`;
-  }
-
-  private formatAdminActionLabel(actionTaken: AdminActionType): string {
-    switch (actionTaken) {
-      case AdminActionType.BAN:
-        return 'Banned';
-      case AdminActionType.VERIFY:
-        return 'Verified';
-      case AdminActionType.CREATE_THREAD:
-        return 'Created verification thread';
-      case AdminActionType.REOPEN:
-        return 'Reopened verification';
-      case AdminActionType.RESTRICT:
-        return 'Restricted';
-      case AdminActionType.OPEN_CASE:
-        return 'Opened case';
-      case AdminActionType.DISMISS:
-        return 'Dismissed alert';
-      case AdminActionType.FALSE_POSITIVE:
-        return 'Marked false positive';
-      case AdminActionType.UNDO_OBSERVED_ACTION:
-        return 'Undid observed action';
-      case AdminActionType.REJECT:
-        return 'Rejected';
-      default:
-        return actionTaken;
-    }
-  }
-
-  private formatAdminActionEvent(
-    actionTaken: AdminActionType,
-    adminId: string,
-    timestamp: number
-  ): string {
-    return `${this.formatAdminActionLabel(actionTaken)} by <@${adminId}> at <t:${timestamp}:F>`;
-  }
-
-  private upsertLatestAdminActionField(
-    embed: EmbedBuilder,
-    actionTaken: AdminActionType,
-    adminId: string,
-    timestamp: number
-  ): void {
-    const field = {
-      name: NotificationManager.LATEST_ADMIN_ACTION_FIELD_NAME,
-      value: this.formatAdminActionEvent(actionTaken, adminId, timestamp),
-      inline: false,
-    };
-    const fields = (embed.data.fields ?? []).filter(
-      (existingField) => existingField.name !== field.name
-    );
-    const confidenceIndex = fields.findIndex(
-      (existingField) => existingField.name === 'Detection Confidence'
-    );
-    const insertIndex = confidenceIndex >= 0 ? confidenceIndex + 1 : 0;
-    fields.splice(insertIndex, 0, field);
-    embed.setFields(...fields);
-  }
-
-  private upsertLatestResolutionField(
-    embed: EmbedBuilder,
-    verificationEvent: VerificationEvent
-  ): void {
-    if (!verificationEvent.resolved_by || !verificationEvent.resolved_at) {
-      return;
-    }
-
-    const actionTaken =
-      verificationEvent.status === VerificationStatus.BANNED
-        ? AdminActionType.BAN
-        : verificationEvent.status === VerificationStatus.VERIFIED
-          ? AdminActionType.VERIFY
-          : null;
-    if (!actionTaken) {
-      return;
-    }
-
-    this.upsertLatestAdminActionField(
-      embed,
-      actionTaken,
-      verificationEvent.resolved_by,
-      Math.floor(verificationEvent.resolved_at.getTime() / 1000)
-    );
-  }
-
   private metadataToRecord(metadata: DetectionEvent['metadata']): Record<string, unknown> {
     if (!metadata || typeof metadata !== 'object' || Array.isArray(metadata)) {
       return {};
     }
 
     return { ...metadata } as Record<string, unknown>;
-  }
-
-  private createAdminAllowedMentions(roleIds?: string[] | string | null): {
-    parse: [];
-    roles: string[];
-    users: [];
-    repliedUser: false;
-  } {
-    const roles = Array.isArray(roleIds)
-      ? roleIds
-      : typeof roleIds === 'string' && roleIds
-        ? [roleIds]
-        : [];
-
-    return {
-      parse: [],
-      roles,
-      users: [],
-      repliedUser: false,
-    };
-  }
-
-  private getCaseNotificationRoleIds(serverConfig: Server): string[] {
-    const roleIds = new Set<string>();
-    if (serverConfig.admin_notification_role_id) {
-      roleIds.add(serverConfig.admin_notification_role_id);
-    }
-
-    const responderSettings = getCaseResponderSettings(serverConfig.settings);
-    if (responderSettings.routingMode !== 'off') {
-      responderSettings.roleIds.forEach((roleId) => roleIds.add(roleId));
-    }
-
-    return [...roleIds];
-  }
-
-  private formatRoleMentions(roleIds: readonly string[]): string | undefined {
-    if (roleIds.length === 0) {
-      return undefined;
-    }
-
-    return roleIds.map((roleId) => `<@&${roleId}>`).join(' ');
   }
 
   private findRecentObservedDetectionNotification(
@@ -765,122 +540,6 @@ export class NotificationManager implements INotificationManager {
     return (await this.configService.getAdminChannel(guildId)) ?? null;
   }
 
-  private formatDetectionTrigger(
-    detectionResult: DetectionResult,
-    sourceMessage?: Message
-  ): string {
-    if (detectionResult.triggerSource === DetectionType.SUSPICIOUS_CONTENT) {
-      const safeContent = detectionResult.triggerContent
-        ? `\`${detectionResult.triggerContent}\``
-        : '`Message content unavailable`';
-      return sourceMessage
-        ? `[Observed message](${sourceMessage.url}): ${safeContent}`
-        : `Observed message: ${safeContent}`;
-    }
-
-    if (detectionResult.triggerSource === DetectionType.NEW_ACCOUNT) {
-      return 'Observed upon joining server';
-    }
-
-    if (detectionResult.triggerSource === DetectionType.USER_REPORT) {
-      return `Observed via user report: \`${detectionResult.triggerContent || 'No reason provided'}\``;
-    }
-
-    if (detectionResult.triggerSource === DetectionType.GPT_ANALYSIS) {
-      return `Observed via manual review: \`${detectionResult.triggerContent || 'Manual flag'}\``;
-    }
-
-    return 'Observed suspicious activity';
-  }
-
-  private createObservedDetectionEmbed(
-    member: GuildMember,
-    detectionResult: DetectionResult,
-    detectionEvents: DetectionEvent[],
-    sourceMessage?: Message
-  ): EmbedBuilder {
-    const accountCreatedAt = new Date(member.user.createdTimestamp);
-    const accountCreatedTimestamp = Math.floor(accountCreatedAt.getTime() / 1000);
-    const joinedServerTimestamp = member.joinedAt
-      ? Math.floor(member.joinedAt.getTime() / 1000)
-      : null;
-    const confidencePercent = Math.round(detectionResult.confidence * 100);
-    const reasonsFormatted = detectionResult.reasons.map((reason) => `• ${reason}`).join('\n');
-    const recentEvents = detectionEvents.slice(0, 5);
-    const detectionHistory = recentEvents
-      .map((event) => {
-        const timestamp = Math.floor(new Date(event.detected_at).getTime() / 1000);
-        return `• <t:${timestamp}:R>: ${event.detection_type} (${Math.round(event.confidence * 100)}% confidence)${this.formatAccountingSuffix(event)}`;
-      })
-      .join('\n');
-
-    const embed = new EmbedBuilder()
-      .setColor(0xffc107)
-      .setTitle('Suspicious Activity Observed')
-      .setDescription(
-        `Drasil observed suspicious activity from <@${member.id}>. No automatic restriction was applied.`
-      )
-      .setThumbnail(member.user.displayAvatarURL())
-      .addFields(
-        { name: 'Username', value: member.user.tag, inline: true },
-        { name: 'User ID', value: member.id, inline: true },
-        {
-          name: 'Account Created',
-          value: `<t:${accountCreatedTimestamp}:F> (<t:${accountCreatedTimestamp}:R>)`,
-          inline: false,
-        },
-        {
-          name: 'Joined Server',
-          value: joinedServerTimestamp
-            ? `<t:${joinedServerTimestamp}:F> (<t:${joinedServerTimestamp}:R>)`
-            : 'Unknown',
-          inline: false,
-        },
-        { name: 'Detection Confidence', value: `${confidencePercent}%`, inline: true },
-        {
-          name: 'Trigger',
-          value: this.truncateEmbedFieldValue(
-            this.formatDetectionTrigger(detectionResult, sourceMessage)
-          ),
-        },
-        {
-          name: 'Reasons',
-          value: this.truncateEmbedFieldValue(reasonsFormatted || 'No specific reason provided'),
-        }
-      )
-      .setTimestamp();
-
-    const aiDiagnosticFieldValue = this.formatGptDiagnosticFieldValue(detectionResult);
-    if (aiDiagnosticFieldValue) {
-      embed.addFields({
-        name: 'AI Analysis',
-        value: aiDiagnosticFieldValue,
-        inline: false,
-      });
-    }
-
-    const reportAiFieldValue = this.formatReportAiFieldValue(
-      detectionResult.reportAiAnalysis ??
-        this.findReportAiAnalysis(detectionEvents, detectionResult.detectionEventId)
-    );
-    if (reportAiFieldValue) {
-      embed.addFields({
-        name: 'AI Report Triage',
-        value: reportAiFieldValue,
-        inline: false,
-      });
-    }
-
-    if (detectionHistory) {
-      embed.addFields({
-        name: 'Recent Detection History',
-        value: this.truncateEmbedFieldValue(detectionHistory),
-      });
-    }
-
-    return embed;
-  }
-
   private async getMessageForVerificationEvent(
     verificationEvent: VerificationEvent
   ): Promise<Message> {
@@ -895,516 +554,6 @@ export class NotificationManager implements INotificationManager {
     }
 
     return await adminChannel.messages.fetch(verificationEvent.notification_message_id);
-  }
-
-  /**
-   * Creates an embed for displaying suspicious user information
-   * @param member The guild member
-   * @param detectionResult The detection result
-   * @param sourceMessage Optional message that triggered the detection
-   * @returns An EmbedBuilder with user information
-   */
-  private async createSuspiciousUserEmbed(
-    member: GuildMember,
-    detectionResult: DetectionResult,
-    verificationEvent: VerificationEvent,
-    sourceMessage?: Message
-  ): Promise<EmbedBuilder> {
-    const accountCreatedAt = new Date(member.user.createdTimestamp);
-    const joinedServerAt = member.joinedAt;
-
-    // Get unix timestamps for Discord timestamp formatting
-    const accountCreatedTimestamp = Math.floor(accountCreatedAt.getTime() / 1000);
-    const joinedServerTimestamp = joinedServerAt ? Math.floor(joinedServerAt.getTime() / 1000) : 0;
-
-    // Format the account timestamps with both absolute and relative format
-    const accountCreatedFormatted = `<t:${accountCreatedTimestamp}:F> (<t:${accountCreatedTimestamp}:R>)`;
-    const joinedServerFormatted = joinedServerAt
-      ? `<t:${joinedServerTimestamp}:F> (<t:${joinedServerTimestamp}:R>)`
-      : 'Unknown';
-
-    // Convert confidence to Low/Medium/High
-    const confidencePercent = detectionResult.confidence * 100;
-    let confidenceLevel: string;
-    let embedColor: number = 0xff0000; // Default red for suspicious/unverified users
-
-    if (confidencePercent <= 40) {
-      confidenceLevel = '🟢 Low';
-    } else if (confidencePercent <= 70) {
-      confidenceLevel = '🟡 Medium';
-    } else {
-      confidenceLevel = '🔴 High';
-    }
-
-    // Format reasons as bullet points
-    const reasonsFormatted = detectionResult.reasons.map((reason) => `• ${reason}`).join('\n');
-
-    // Create trigger information
-    let triggerInfo: string;
-    if (detectionResult.triggerSource === DetectionType.SUSPICIOUS_CONTENT) {
-      const safeContent = detectionResult.triggerContent
-        ? `\`${detectionResult.triggerContent}\``
-        : '`Message content unavailable`';
-
-      if (sourceMessage) {
-        triggerInfo = `[Flagged for message](${sourceMessage.url}): ${safeContent}`;
-      } else {
-        triggerInfo = `Flagged for message: ${safeContent}`;
-      }
-    } else if (detectionResult.triggerSource === DetectionType.USER_REPORT) {
-      const safeContent = detectionResult.triggerContent
-        ? `\`${detectionResult.triggerContent}\``
-        : '`No report reason provided`';
-      triggerInfo = `Flagged via user report: ${safeContent}`;
-    } else if (detectionResult.triggerSource === DetectionType.GPT_ANALYSIS) {
-      const safeContent = detectionResult.triggerContent
-        ? `\`${detectionResult.triggerContent}\``
-        : '`Manual flag`';
-      triggerInfo = `Flagged via manual review: ${safeContent}`;
-    } else if (detectionResult.triggerSource === DetectionType.NEW_ACCOUNT) {
-      triggerInfo = 'Flagged upon joining server';
-    } else {
-      triggerInfo = 'Flagged for suspicious activity';
-    }
-
-    // Get all detection events for this user in this server
-    const detectionEvents = await this.detectionEventsRepository.findByServerAndUser(
-      member.guild.id,
-      member.id
-    );
-    const countedDetectionEvents = detectionEvents.filter(
-      (event) => !isDetectionEventExcludedFromAccounting(event)
-    );
-
-    // Format detection history
-    let detectionHistory = '';
-    if (detectionEvents.length > 0) {
-      // Sort events by date, most recent first
-      const sortedEvents = detectionEvents.sort(
-        (a, b) => new Date(b.detected_at).getTime() - new Date(a.detected_at).getTime()
-      );
-
-      // Take the 5 most recent events
-      const recentEvents = sortedEvents.slice(0, 5);
-
-      // Format the recent events
-      detectionHistory = recentEvents
-        .map((event) => {
-          const timestamp = Math.floor(new Date(event.detected_at).getTime() / 1000);
-          let entry = `• <t:${timestamp}:R>: ${event.detection_type}`;
-          if (event.message_id) {
-            entry += ` - [View Message](https://discord.com/channels/${member.guild.id}/${event.channel_id}/${event.message_id})`;
-          }
-          entry += ` (${(event.confidence * 100).toFixed(0)}% confidence)`;
-          entry += this.formatAccountingSuffix(event);
-          return entry;
-        })
-        .join('\n');
-
-      // If there are more events, add a count
-      if (sortedEvents.length > 5) {
-        detectionHistory += `\n\n*${sortedEvents.length - 5} more events not shown*`;
-      }
-    }
-
-    // Update embed color based on verification status if thread exists
-    if (verificationEvent.status === VerificationStatus.VERIFIED) {
-      embedColor = 0x00ff00; // Green for verified users
-    } else if (verificationEvent.status === VerificationStatus.BANNED) {
-      embedColor = 0x000000; // Black for banned users
-    }
-
-    // Create the embed
-    const embed = new EmbedBuilder()
-      .setColor(embedColor)
-      .setTitle('Suspicious User Detected')
-      .setDescription(
-        countedDetectionEvents.length > 1
-          ? `<@${member.id}> has been flagged as suspicious ${countedDetectionEvents.length} times.`
-          : `<@${member.id}> has been flagged as suspicious.`
-      )
-      .setThumbnail(member.user.displayAvatarURL())
-      .addFields(
-        { name: 'Username', value: member.user.tag, inline: true },
-        { name: 'User ID', value: member.id, inline: true },
-        { name: 'Account Created', value: accountCreatedFormatted, inline: false },
-        { name: 'Joined Server', value: joinedServerFormatted, inline: false },
-        { name: 'Detection Confidence', value: confidenceLevel, inline: true },
-        { name: 'Trigger', value: triggerInfo, inline: false },
-        { name: 'Reasons', value: reasonsFormatted || 'No specific reason provided', inline: false }
-      )
-      .setTimestamp();
-
-    this.upsertLatestResolutionField(embed, verificationEvent);
-
-    const aiDiagnosticFieldValue = this.formatGptDiagnosticFieldValue(detectionResult);
-    if (aiDiagnosticFieldValue) {
-      embed.addFields({
-        name: 'AI Analysis',
-        value: aiDiagnosticFieldValue,
-        inline: false,
-      });
-    }
-
-    const reportAiFieldValue = this.formatReportAiFieldValue(
-      detectionResult.reportAiAnalysis ??
-        this.findReportAiAnalysis(detectionEvents, detectionResult.detectionEventId)
-    );
-    if (reportAiFieldValue) {
-      embed.addFields({
-        name: 'AI Report Triage',
-        value: reportAiFieldValue,
-        inline: false,
-      });
-    }
-
-    const actionFailureFieldValue = this.formatVerificationActionFailureFieldValue(
-      verificationEvent.metadata
-    );
-    if (actionFailureFieldValue) {
-      embed.addFields({
-        name: NotificationManager.MODERATION_ACTION_WARNING_FIELD_NAME,
-        value: actionFailureFieldValue,
-        inline: false,
-      });
-    }
-
-    const caseStaffWarningFieldValue = this.formatCaseStaffRoutingWarningFieldValue(
-      verificationEvent.metadata
-    );
-    if (caseStaffWarningFieldValue) {
-      embed.addFields({
-        name: 'Case Staff Routing Warning',
-        value: caseStaffWarningFieldValue,
-        inline: false,
-      });
-    }
-
-    // Add detection history if we have any
-    if (detectionHistory) {
-      embed.addFields({
-        name: 'Detection History',
-        value: detectionHistory,
-        inline: false,
-      });
-    }
-
-    // Add verification thread status if it exists
-    if (verificationEvent.thread_id) {
-      const threadStatus =
-        verificationEvent.status === VerificationStatus.VERIFIED ||
-        verificationEvent.status === VerificationStatus.BANNED
-          ? `${verificationEvent.status} by <@${verificationEvent.resolved_by}>`
-          : 'pending'; // Use 'pending' for unresolved states
-      embed.addFields({
-        name: 'Verification Status',
-        value: `[Thread](https://discord.com/channels/${member.guild.id}/${verificationEvent.thread_id}) status: ${threadStatus}`,
-        inline: false,
-      });
-    }
-
-    const persistedThreadAnalysis = this.getThreadAnalysisMetadata(verificationEvent.metadata);
-    if (persistedThreadAnalysis?.latestAnalysis) {
-      embed.addFields({
-        name: NotificationManager.THREAD_ANALYSIS_FIELD_NAME,
-        value: this.formatThreadAnalysisFieldValue(persistedThreadAnalysis.latestAnalysis),
-        inline: false,
-      });
-    }
-
-    return embed;
-  }
-
-  private formatVerificationActionFailureFieldValue(metadata: unknown): string | null {
-    const failures = getVerificationActionFailures(metadata);
-    if (failures.length === 0) {
-      return null;
-    }
-
-    const value = failures
-      .slice(-3)
-      .map((failure) => {
-        const timestamp = Math.floor(new Date(failure.at).getTime() / 1000);
-        const action =
-          failure.action === 'restrict'
-            ? 'Apply restricted role'
-            : failure.action === 'private_evidence_thread'
-              ? 'Create private evidence thread'
-              : 'Create case thread';
-        const when = Number.isFinite(timestamp) ? ` <t:${timestamp}:R>` : '';
-        return `Warning: ${action} failed${when}: ${failure.message}`;
-      })
-      .join('\n');
-
-    return this.truncateEmbedFieldValue(
-      `${value}\nCase record was still created so moderators can review and fix permissions.`
-    );
-  }
-
-  private upsertVerificationActionFailureField(
-    embed: EmbedBuilder,
-    verificationEvent: VerificationEvent
-  ): void {
-    const actionFailureFieldValue = this.formatVerificationActionFailureFieldValue(
-      verificationEvent.metadata
-    );
-    const fieldIndex = embed.data.fields?.findIndex(
-      (field) => field.name === NotificationManager.MODERATION_ACTION_WARNING_FIELD_NAME
-    );
-
-    if (actionFailureFieldValue) {
-      const field = {
-        name: NotificationManager.MODERATION_ACTION_WARNING_FIELD_NAME,
-        value: actionFailureFieldValue,
-        inline: false,
-      };
-      if (fieldIndex !== undefined && fieldIndex >= 0) {
-        embed.spliceFields(fieldIndex, 1, field);
-      } else {
-        embed.addFields(field);
-      }
-      return;
-    }
-
-    if (fieldIndex !== undefined && fieldIndex >= 0) {
-      embed.spliceFields(fieldIndex, 1);
-    }
-  }
-
-  private formatCaseStaffRoutingWarningFieldValue(metadata: unknown): string | null {
-    if (!metadata || typeof metadata !== 'object' || Array.isArray(metadata)) {
-      return null;
-    }
-
-    const routing = (metadata as Record<string, unknown>)[CASE_STAFF_ROUTING_METADATA_KEY];
-    if (!routing || typeof routing !== 'object' || Array.isArray(routing)) {
-      return null;
-    }
-
-    const warnings = (routing as { warnings?: unknown }).warnings;
-    if (!Array.isArray(warnings) || warnings.length === 0) {
-      return null;
-    }
-
-    return this.truncateEmbedFieldValue(
-      warnings
-        .filter((warning): warning is string => typeof warning === 'string' && warning.length > 0)
-        .slice(-3)
-        .map((warning) => `Warning: ${warning}`)
-        .join('\n')
-    );
-  }
-
-  private formatThreadAnalysisFieldValue(analysis: {
-    result: 'likely_legitimate' | 'needs_review' | 'likely_suspicious';
-    confidence: number;
-    summary: string;
-    reasonCodes?: string[];
-    legitimacySignals?: string[];
-    suspicionSignals?: string[];
-    recommendedNextQuestion?: string;
-    recommendedAction?: 'none' | 'ask_followup' | 'manual_review' | 'restrict';
-    analyzedMessageCount: number;
-  }): string {
-    const confidencePercent = Math.round(analysis.confidence * 100);
-    const lines = [
-      `Result: **${analysis.result}** (${confidencePercent}% confidence)`,
-      `Analyzed responses: ${analysis.analyzedMessageCount}`,
-      `Summary: ${analysis.summary}`,
-    ];
-    if (analysis.reasonCodes?.length) {
-      lines.push(`Reason codes: ${analysis.reasonCodes.join(', ')}`);
-    }
-    if (analysis.legitimacySignals?.length) {
-      lines.push(`Legitimacy signals: ${analysis.legitimacySignals.join('; ')}`);
-    }
-    if (analysis.suspicionSignals?.length) {
-      lines.push(`Suspicion signals: ${analysis.suspicionSignals.join('; ')}`);
-    }
-    if (analysis.recommendedNextQuestion) {
-      lines.push(`Next question: ${analysis.recommendedNextQuestion}`);
-    }
-    if (analysis.recommendedAction) {
-      lines.push(`Recommended action: ${analysis.recommendedAction}`);
-    }
-
-    return this.truncateEmbedFieldValue(lines.join('\n'));
-  }
-
-  private findReportAiAnalysis(
-    detectionEvents: DetectionEvent[],
-    detectionEventId?: string
-  ): ReportAIAnalysis | null {
-    const candidates = detectionEventId
-      ? detectionEvents.filter((event) => event.id === detectionEventId)
-      : detectionEvents;
-
-    for (const event of candidates) {
-      const metadata = this.metadataToRecord(event.metadata);
-      const reportAi = metadata.report_ai;
-      if (reportAi && typeof reportAi === 'object' && !Array.isArray(reportAi)) {
-        return reportAi as ReportAIAnalysis;
-      }
-    }
-
-    return null;
-  }
-
-  private formatReportAiFieldValue(analysis: ReportAIAnalysis | null): string | null {
-    if (!analysis) {
-      return null;
-    }
-
-    const confidencePercent = Math.round(analysis.confidence * 100);
-    const lines = [
-      `Result: **${analysis.result}** (${confidencePercent}% confidence)`,
-      `Summary: ${analysis.summary}`,
-      `Recommended action: ${analysis.recommendedAction}`,
-      `Images analyzed: ${analysis.analyzedImageCount}`,
-    ];
-    if (analysis.reasonCodes.length) {
-      lines.push(`Reason codes: ${analysis.reasonCodes.join(', ')}`);
-    }
-    if (analysis.evidenceCategories.length) {
-      lines.push(`Evidence: ${analysis.evidenceCategories.join(', ')}`);
-    }
-    if (analysis.concerns.length) {
-      lines.push(`Concerns: ${analysis.concerns.join('; ')}`);
-    }
-
-    return this.truncateEmbedFieldValue(lines.join('\n'));
-  }
-
-  private formatGptDiagnosticFieldValue(detectionResult: DetectionResult): string | null {
-    const analysis = detectionResult.gptAnalysis;
-    if (!analysis) {
-      return null;
-    }
-
-    const confidencePercent = Math.round(analysis.confidence * 100);
-    const reasonCodes = analysis.reasonCodes.length ? analysis.reasonCodes.join(', ') : 'none';
-    const resultLine = analysis.isFallback
-      ? 'Result: **Unavailable**'
-      : `Result: **${analysis.result}** (${confidencePercent}% confidence)`;
-    return this.truncateEmbedFieldValue(
-      [
-        resultLine,
-        `Primary signal: ${analysis.primarySignal}`,
-        `Reason codes: ${reasonCodes}`,
-        `Summary: ${analysis.summary}`,
-      ].join('\n')
-    );
-  }
-
-  private formatAccountingSuffix(event: DetectionEvent): string {
-    return isDetectionEventExcludedFromAccounting(event) ? ' - ignored for future accounting' : '';
-  }
-
-  private getThreadAnalysisMetadata(
-    metadata: VerificationEvent['metadata']
-  ): ThreadAnalysisMetadata | null {
-    if (!metadata || typeof metadata !== 'object' || Array.isArray(metadata)) {
-      return null;
-    }
-
-    const threadAnalysis = (metadata as { thread_analysis?: unknown }).thread_analysis;
-    if (!threadAnalysis || typeof threadAnalysis !== 'object' || Array.isArray(threadAnalysis)) {
-      return null;
-    }
-
-    const metadataRecord = threadAnalysis as ThreadAnalysisMetadata;
-    const latestAnalysis =
-      metadataRecord.latestAnalysis &&
-      typeof metadataRecord.latestAnalysis === 'object' &&
-      !Array.isArray(metadataRecord.latestAnalysis)
-        ? (metadataRecord.latestAnalysis as Record<string, unknown>)
-        : null;
-    if (!latestAnalysis) {
-      return metadataRecord;
-    }
-
-    const rawResult = latestAnalysis.result;
-    const result =
-      rawResult === 'likely_legitimate' ||
-      rawResult === 'needs_review' ||
-      rawResult === 'likely_suspicious'
-        ? rawResult
-        : rawResult === 'OK'
-          ? 'likely_legitimate'
-          : rawResult === 'SUSPICIOUS'
-            ? 'likely_suspicious'
-            : null;
-
-    if (
-      !result ||
-      typeof latestAnalysis.confidence !== 'number' ||
-      typeof latestAnalysis.summary !== 'string' ||
-      typeof latestAnalysis.analyzedMessageCount !== 'number'
-    ) {
-      return metadataRecord;
-    }
-
-    return {
-      ...metadataRecord,
-      latestAnalysis: {
-        result,
-        confidence: latestAnalysis.confidence,
-        summary: latestAnalysis.summary,
-        reasonCodes: Array.isArray(latestAnalysis.reasonCodes)
-          ? latestAnalysis.reasonCodes.filter((value): value is string => typeof value === 'string')
-          : [],
-        legitimacySignals: Array.isArray(latestAnalysis.legitimacySignals)
-          ? latestAnalysis.legitimacySignals.filter(
-              (value): value is string => typeof value === 'string'
-            )
-          : [],
-        suspicionSignals: Array.isArray(latestAnalysis.suspicionSignals)
-          ? latestAnalysis.suspicionSignals.filter(
-              (value): value is string => typeof value === 'string'
-            )
-          : [],
-        recommendedNextQuestion:
-          typeof latestAnalysis.recommendedNextQuestion === 'string'
-            ? latestAnalysis.recommendedNextQuestion
-            : undefined,
-        recommendedAction:
-          latestAnalysis.recommendedAction === 'none' ||
-          latestAnalysis.recommendedAction === 'ask_followup' ||
-          latestAnalysis.recommendedAction === 'manual_review' ||
-          latestAnalysis.recommendedAction === 'restrict'
-            ? latestAnalysis.recommendedAction
-            : 'manual_review',
-        analyzedMessageCount: latestAnalysis.analyzedMessageCount,
-      },
-    };
-  }
-
-  /**
-   * Creates an action row with admin action buttons
-   * @param userId The ID of the user the actions apply to
-   * @returns An ActionRowBuilder with buttons
-   */
-  private createActionRow(userId: string): ActionRowBuilder<ButtonBuilder> {
-    return new ActionRowBuilder<ButtonBuilder>().addComponents(
-      new ButtonBuilder()
-        .setCustomId(buildCaseAdminActionsCustomId(userId))
-        .setLabel('Admin Actions')
-        .setStyle(ButtonStyle.Primary)
-    );
-  }
-
-  private createObservedActionRows(
-    userId: string,
-    detectionEventId: string
-  ): ActionRowBuilder<ButtonBuilder>[] {
-    return [
-      new ActionRowBuilder<ButtonBuilder>().addComponents(
-        new ButtonBuilder()
-          .setCustomId(buildObservedAdminActionsCustomId(userId, detectionEventId))
-          .setLabel('Admin Actions')
-          .setStyle(ButtonStyle.Primary)
-      ),
-    ];
   }
 
   /**
@@ -1710,12 +859,15 @@ export class NotificationManager implements INotificationManager {
     const updatedEmbed = messageEmbeds.length > 0 ? EmbedBuilder.from(messageEmbeds[0]) : null;
 
     if (updatedEmbed) {
-      this.upsertVerificationActionFailureField(updatedEmbed, verificationEvent);
+      this.presentationBuilder.upsertVerificationActionFailureField(
+        updatedEmbed,
+        verificationEvent
+      );
     }
 
     await message.edit({
       allowedMentions: { parse: [] },
-      components: [this.createActionRow(verificationEvent.user_id)],
+      components: [this.presentationBuilder.createActionRow(verificationEvent.user_id)],
       ...(updatedEmbed ? { embeds: [updatedEmbed] } : {}),
     });
   }

--- a/src/services/NotificationManager.ts
+++ b/src/services/NotificationManager.ts
@@ -1,4 +1,4 @@
-import { injectable, inject } from 'inversify';
+import { injectable, inject, unmanaged } from 'inversify';
 import {
   Client,
   EmbedBuilder,
@@ -134,16 +134,19 @@ export class NotificationManager implements INotificationManager {
   private client: Client;
   private configService: IConfigService;
   private detectionEventsRepository: IDetectionEventsRepository;
-  private presentationBuilder = new NotificationPresentationBuilder();
+  private presentationBuilder: NotificationPresentationBuilder;
 
   constructor(
     @inject(TYPES.DiscordClient) client: Client,
     @inject(TYPES.ConfigService) configService: IConfigService,
-    @inject(TYPES.DetectionEventsRepository) detectionEventsRepository: IDetectionEventsRepository
+    @inject(TYPES.DetectionEventsRepository) detectionEventsRepository: IDetectionEventsRepository,
+    @unmanaged()
+    presentationBuilder: NotificationPresentationBuilder = new NotificationPresentationBuilder()
   ) {
     this.client = client;
     this.configService = configService;
     this.detectionEventsRepository = detectionEventsRepository;
+    this.presentationBuilder = presentationBuilder;
   }
 
   /**

--- a/src/services/NotificationPresentationBuilder.ts
+++ b/src/services/NotificationPresentationBuilder.ts
@@ -1,0 +1,859 @@
+import {
+  ActionRowBuilder,
+  ButtonBuilder,
+  ButtonStyle,
+  EmbedBuilder,
+  GuildMember,
+  Message,
+} from 'discord.js';
+import { DetectionResult } from './DetectionOrchestrator';
+import type { ReportAIAnalysis, VerificationThreadAnalysisResult } from './GPTService';
+import { CASE_STAFF_ROUTING_METADATA_KEY } from './ThreadManager';
+import {
+  AdminActionType,
+  DetectionEvent,
+  DetectionType,
+  Server,
+  VerificationEvent,
+  VerificationStatus,
+} from '../repositories/types';
+import {
+  buildCaseAdminActionsCustomId,
+  buildObservedAdminActionsCustomId,
+} from '../utils/adminActionCustomIds';
+import { getCaseResponderSettings } from '../utils/caseResponderSettings';
+import { isDetectionEventExcludedFromAccounting } from '../utils/detectionEventAccounting';
+import { getVerificationActionFailures } from '../utils/verificationActionFailures';
+
+interface ThreadAnalysisMetadata {
+  analyzedMessageIds?: unknown;
+  latestAnalysis?: {
+    result: 'likely_legitimate' | 'needs_review' | 'likely_suspicious';
+    confidence: number;
+    summary: string;
+    reasonCodes?: string[];
+    legitimacySignals?: string[];
+    suspicionSignals?: string[];
+    recommendedNextQuestion?: string;
+    recommendedAction?: 'none' | 'ask_followup' | 'manual_review' | 'restrict';
+    analyzedMessageCount: number;
+  };
+}
+
+export class NotificationPresentationBuilder {
+  public static readonly THREAD_ANALYSIS_FIELD_NAME = 'AI Thread Analysis';
+  public static readonly LATEST_ADMIN_ACTION_FIELD_NAME = 'Latest Admin Action';
+  public static readonly MODERATION_ACTION_WARNING_FIELD_NAME = 'Moderation Action Warning';
+
+  public createSuspiciousUserEmbed(
+    member: GuildMember,
+    detectionResult: DetectionResult,
+    verificationEvent: VerificationEvent,
+    detectionEvents: DetectionEvent[],
+    sourceMessage?: Message
+  ): EmbedBuilder {
+    const accountCreatedAt = new Date(member.user.createdTimestamp);
+    const joinedServerAt = member.joinedAt;
+    const accountCreatedTimestamp = Math.floor(accountCreatedAt.getTime() / 1000);
+    const joinedServerTimestamp = joinedServerAt ? Math.floor(joinedServerAt.getTime() / 1000) : 0;
+    const accountCreatedFormatted = `<t:${accountCreatedTimestamp}:F> (<t:${accountCreatedTimestamp}:R>)`;
+    const joinedServerFormatted = joinedServerAt
+      ? `<t:${joinedServerTimestamp}:F> (<t:${joinedServerTimestamp}:R>)`
+      : 'Unknown';
+
+    const confidencePercent = detectionResult.confidence * 100;
+    let confidenceLevel: string;
+    let embedColor = 0xff0000;
+    if (confidencePercent <= 40) {
+      confidenceLevel = '🟢 Low';
+    } else if (confidencePercent <= 70) {
+      confidenceLevel = '🟡 Medium';
+    } else {
+      confidenceLevel = '🔴 High';
+    }
+
+    const reasonsFormatted = detectionResult.reasons.map((reason) => `• ${reason}`).join('\n');
+    const countedDetectionEvents = detectionEvents.filter(
+      (event) => !isDetectionEventExcludedFromAccounting(event)
+    );
+    const detectionEventsNewestFirst = [...detectionEvents].sort(
+      (a, b) => new Date(b.detected_at).getTime() - new Date(a.detected_at).getTime()
+    );
+    const detectionHistory = this.formatSuspiciousDetectionHistory(
+      detectionEventsNewestFirst,
+      member.guild.id
+    );
+
+    if (verificationEvent.status === VerificationStatus.VERIFIED) {
+      embedColor = 0x00ff00;
+    } else if (verificationEvent.status === VerificationStatus.BANNED) {
+      embedColor = 0x000000;
+    }
+
+    const embed = new EmbedBuilder()
+      .setColor(embedColor)
+      .setTitle('Suspicious User Detected')
+      .setDescription(
+        countedDetectionEvents.length > 1
+          ? `<@${member.id}> has been flagged as suspicious ${countedDetectionEvents.length} times.`
+          : `<@${member.id}> has been flagged as suspicious.`
+      )
+      .setThumbnail(member.user.displayAvatarURL())
+      .addFields(
+        { name: 'Username', value: member.user.tag, inline: true },
+        { name: 'User ID', value: member.id, inline: true },
+        { name: 'Account Created', value: accountCreatedFormatted, inline: false },
+        { name: 'Joined Server', value: joinedServerFormatted, inline: false },
+        { name: 'Detection Confidence', value: confidenceLevel, inline: true },
+        {
+          name: 'Trigger',
+          value: this.formatSuspiciousDetectionTrigger(detectionResult, sourceMessage),
+          inline: false,
+        },
+        { name: 'Reasons', value: reasonsFormatted || 'No specific reason provided', inline: false }
+      )
+      .setTimestamp();
+
+    this.upsertLatestResolutionField(embed, verificationEvent);
+    this.addOptionalAnalysisFields(embed, detectionResult, detectionEventsNewestFirst);
+
+    const actionFailureFieldValue = this.formatVerificationActionFailureFieldValue(
+      verificationEvent.metadata
+    );
+    if (actionFailureFieldValue) {
+      embed.addFields({
+        name: NotificationPresentationBuilder.MODERATION_ACTION_WARNING_FIELD_NAME,
+        value: actionFailureFieldValue,
+        inline: false,
+      });
+    }
+
+    const caseStaffWarningFieldValue = this.formatCaseStaffRoutingWarningFieldValue(
+      verificationEvent.metadata
+    );
+    if (caseStaffWarningFieldValue) {
+      embed.addFields({
+        name: 'Case Staff Routing Warning',
+        value: caseStaffWarningFieldValue,
+        inline: false,
+      });
+    }
+
+    if (detectionHistory) {
+      embed.addFields({ name: 'Detection History', value: detectionHistory, inline: false });
+    }
+
+    if (verificationEvent.thread_id) {
+      const threadStatus =
+        verificationEvent.status === VerificationStatus.VERIFIED ||
+        verificationEvent.status === VerificationStatus.BANNED
+          ? `${verificationEvent.status} by <@${verificationEvent.resolved_by}>`
+          : 'pending';
+      embed.addFields({
+        name: 'Verification Status',
+        value: `[Thread](https://discord.com/channels/${member.guild.id}/${verificationEvent.thread_id}) status: ${threadStatus}`,
+        inline: false,
+      });
+    }
+
+    const persistedThreadAnalysis = this.getThreadAnalysisMetadata(verificationEvent.metadata);
+    if (persistedThreadAnalysis?.latestAnalysis) {
+      embed.addFields({
+        name: NotificationPresentationBuilder.THREAD_ANALYSIS_FIELD_NAME,
+        value: this.formatThreadAnalysisFieldValue(persistedThreadAnalysis.latestAnalysis),
+        inline: false,
+      });
+    }
+
+    return embed;
+  }
+
+  public createObservedDetectionEmbed(
+    member: GuildMember,
+    detectionResult: DetectionResult,
+    detectionEvents: DetectionEvent[],
+    sourceMessage?: Message
+  ): EmbedBuilder {
+    const accountCreatedAt = new Date(member.user.createdTimestamp);
+    const accountCreatedTimestamp = Math.floor(accountCreatedAt.getTime() / 1000);
+    const joinedServerTimestamp = member.joinedAt
+      ? Math.floor(member.joinedAt.getTime() / 1000)
+      : null;
+    const confidencePercent = Math.round(detectionResult.confidence * 100);
+    const reasonsFormatted = detectionResult.reasons.map((reason) => `• ${reason}`).join('\n');
+    const recentEvents = detectionEvents.slice(0, 5);
+    const detectionHistory = recentEvents
+      .map((event) => {
+        const timestamp = Math.floor(new Date(event.detected_at).getTime() / 1000);
+        return `• <t:${timestamp}:R>: ${event.detection_type} (${Math.round(event.confidence * 100)}% confidence)${this.formatAccountingSuffix(event)}`;
+      })
+      .join('\n');
+
+    const embed = new EmbedBuilder()
+      .setColor(0xffc107)
+      .setTitle('Suspicious Activity Observed')
+      .setDescription(
+        `Drasil observed suspicious activity from <@${member.id}>. No automatic restriction was applied.`
+      )
+      .setThumbnail(member.user.displayAvatarURL())
+      .addFields(
+        { name: 'Username', value: member.user.tag, inline: true },
+        { name: 'User ID', value: member.id, inline: true },
+        {
+          name: 'Account Created',
+          value: `<t:${accountCreatedTimestamp}:F> (<t:${accountCreatedTimestamp}:R>)`,
+          inline: false,
+        },
+        {
+          name: 'Joined Server',
+          value: joinedServerTimestamp
+            ? `<t:${joinedServerTimestamp}:F> (<t:${joinedServerTimestamp}:R>)`
+            : 'Unknown',
+          inline: false,
+        },
+        { name: 'Detection Confidence', value: `${confidencePercent}%`, inline: true },
+        {
+          name: 'Trigger',
+          value: this.truncateEmbedFieldValue(
+            this.formatObservedDetectionTrigger(detectionResult, sourceMessage)
+          ),
+        },
+        {
+          name: 'Reasons',
+          value: this.truncateEmbedFieldValue(reasonsFormatted || 'No specific reason provided'),
+        }
+      )
+      .setTimestamp();
+
+    this.addOptionalAnalysisFields(embed, detectionResult, detectionEvents);
+
+    if (detectionHistory) {
+      embed.addFields({
+        name: 'Recent Detection History',
+        value: this.truncateEmbedFieldValue(detectionHistory),
+      });
+    }
+
+    return embed;
+  }
+
+  public createActionRow(userId: string): ActionRowBuilder<ButtonBuilder> {
+    return new ActionRowBuilder<ButtonBuilder>().addComponents(
+      new ButtonBuilder()
+        .setCustomId(buildCaseAdminActionsCustomId(userId))
+        .setLabel('Admin Actions')
+        .setStyle(ButtonStyle.Primary)
+    );
+  }
+
+  public createObservedActionRows(
+    userId: string,
+    detectionEventId: string
+  ): ActionRowBuilder<ButtonBuilder>[] {
+    return [
+      new ActionRowBuilder<ButtonBuilder>().addComponents(
+        new ButtonBuilder()
+          .setCustomId(buildObservedAdminActionsCustomId(userId, detectionEventId))
+          .setLabel('Admin Actions')
+          .setStyle(ButtonStyle.Primary)
+      ),
+    ];
+  }
+
+  public createAdminAllowedMentions(roleIds?: string[] | string | null): {
+    parse: [];
+    roles: string[];
+    users: [];
+    repliedUser: false;
+  } {
+    const roles = Array.isArray(roleIds)
+      ? roleIds
+      : typeof roleIds === 'string' && roleIds
+        ? [roleIds]
+        : [];
+
+    return { parse: [], roles, users: [], repliedUser: false };
+  }
+
+  public getCaseNotificationRoleIds(serverConfig: Server): string[] {
+    const roleIds = new Set<string>();
+    if (serverConfig.admin_notification_role_id) {
+      roleIds.add(serverConfig.admin_notification_role_id);
+    }
+
+    const responderSettings = getCaseResponderSettings(serverConfig.settings);
+    if (responderSettings.routingMode !== 'off') {
+      responderSettings.roleIds.forEach((roleId) => roleIds.add(roleId));
+    }
+
+    return [...roleIds];
+  }
+
+  public formatRoleMentions(roleIds: readonly string[]): string | undefined {
+    return roleIds.length > 0 ? roleIds.map((roleId) => `<@&${roleId}>`).join(' ') : undefined;
+  }
+
+  public addObservedActionTakenField(
+    embed: EmbedBuilder,
+    actionDescription: string,
+    adminId: string,
+    timestamp: number
+  ): void {
+    const field = {
+      name: 'Action Taken',
+      value: `<@${adminId}> ${actionDescription} <t:${timestamp}:R>`,
+      inline: false,
+    };
+    const existingFields =
+      embed.data.fields?.filter(
+        (existingField) =>
+          existingField.name !== field.name && existingField.name !== 'Action Reverted'
+      ) ?? [];
+    embed.setFields(...existingFields, field);
+  }
+
+  public addObservedActionRevertedField(
+    embed: EmbedBuilder,
+    actionDescription: string,
+    adminId: string,
+    timestamp: number
+  ): void {
+    const field = {
+      name: 'Action Reverted',
+      value: `<@${adminId}> ${actionDescription} <t:${timestamp}:R>`,
+      inline: false,
+    };
+    const existingFields =
+      embed.data.fields?.filter(
+        (existingField) =>
+          existingField.name !== 'Action Taken' && existingField.name !== field.name
+      ) ?? [];
+    embed.setFields(...existingFields, field);
+  }
+
+  public upsertAdminActionLog(
+    embed: EmbedBuilder,
+    actionTaken: AdminActionType,
+    adminId: string,
+    timestamp: number,
+    threadUrl?: string,
+    hasGuild?: boolean
+  ): void {
+    const actionLogField = embed.data.fields?.find((field) => field.name === 'Action Log');
+    this.upsertLatestAdminActionField(embed, actionTaken, adminId, timestamp);
+
+    if (threadUrl && actionTaken === AdminActionType.CREATE_THREAD) {
+      this.upsertField(embed, {
+        name: 'Verification Thread',
+        value: `[Click here to view the thread](${threadUrl})`,
+        inline: false,
+      });
+    }
+
+    if (hasGuild && actionTaken === AdminActionType.VERIFY) {
+      embed.setColor(0x00ff00);
+    }
+    if (hasGuild && actionTaken === AdminActionType.BAN) {
+      embed.setColor(0x000000);
+    }
+
+    const actionLogContent = `• ${this.formatAdminActionEvent(actionTaken, adminId, timestamp)}`;
+    if (actionLogField) {
+      actionLogField.value = `${actionLogField.value}\n${actionLogContent}`;
+    } else {
+      embed.addFields({ name: 'Action Log', value: actionLogContent, inline: false });
+    }
+  }
+
+  public upsertThreadAnalysisField(
+    embed: EmbedBuilder,
+    analysis: VerificationThreadAnalysisResult,
+    analyzedMessageCount: number
+  ): void {
+    this.upsertField(embed, {
+      name: NotificationPresentationBuilder.THREAD_ANALYSIS_FIELD_NAME,
+      value: this.formatThreadAnalysisFieldValue({ ...analysis, analyzedMessageCount }),
+      inline: false,
+    });
+  }
+
+  public upsertVerificationActionFailureField(
+    embed: EmbedBuilder,
+    verificationEvent: VerificationEvent
+  ): void {
+    const actionFailureFieldValue = this.formatVerificationActionFailureFieldValue(
+      verificationEvent.metadata
+    );
+    const fieldIndex = embed.data.fields?.findIndex(
+      (field) => field.name === NotificationPresentationBuilder.MODERATION_ACTION_WARNING_FIELD_NAME
+    );
+
+    if (actionFailureFieldValue) {
+      const field = {
+        name: NotificationPresentationBuilder.MODERATION_ACTION_WARNING_FIELD_NAME,
+        value: actionFailureFieldValue,
+        inline: false,
+      };
+      if (fieldIndex !== undefined && fieldIndex >= 0) {
+        embed.spliceFields(fieldIndex, 1, field);
+      } else {
+        embed.addFields(field);
+      }
+      return;
+    }
+
+    if (fieldIndex !== undefined && fieldIndex >= 0) {
+      embed.spliceFields(fieldIndex, 1);
+    }
+  }
+
+  private addOptionalAnalysisFields(
+    embed: EmbedBuilder,
+    detectionResult: DetectionResult,
+    detectionEvents: DetectionEvent[]
+  ): void {
+    const aiDiagnosticFieldValue = this.formatGptDiagnosticFieldValue(detectionResult);
+    if (aiDiagnosticFieldValue) {
+      embed.addFields({ name: 'AI Analysis', value: aiDiagnosticFieldValue, inline: false });
+    }
+
+    const reportAiFieldValue = this.formatReportAiFieldValue(
+      detectionResult.reportAiAnalysis ??
+        this.findReportAiAnalysis(detectionEvents, detectionResult.detectionEventId)
+    );
+    if (reportAiFieldValue) {
+      embed.addFields({ name: 'AI Report Triage', value: reportAiFieldValue, inline: false });
+    }
+  }
+
+  private formatSuspiciousDetectionHistory(
+    detectionEvents: DetectionEvent[],
+    guildId: string
+  ): string {
+    if (detectionEvents.length === 0) {
+      return '';
+    }
+
+    const sortedEvents = [...detectionEvents].sort(
+      (a, b) => new Date(b.detected_at).getTime() - new Date(a.detected_at).getTime()
+    );
+    const detectionHistory = sortedEvents
+      .slice(0, 5)
+      .map((event) => {
+        const timestamp = Math.floor(new Date(event.detected_at).getTime() / 1000);
+        let entry = `• <t:${timestamp}:R>: ${event.detection_type}`;
+        if (event.message_id) {
+          entry += ` - [View Message](https://discord.com/channels/${guildId}/${event.channel_id}/${event.message_id})`;
+        }
+        entry += ` (${(event.confidence * 100).toFixed(0)}% confidence)`;
+        entry += this.formatAccountingSuffix(event);
+        return entry;
+      })
+      .join('\n');
+
+    return sortedEvents.length > 5
+      ? `${detectionHistory}\n\n*${sortedEvents.length - 5} more events not shown*`
+      : detectionHistory;
+  }
+
+  private formatObservedDetectionTrigger(
+    detectionResult: DetectionResult,
+    sourceMessage?: Message
+  ): string {
+    if (detectionResult.triggerSource === DetectionType.SUSPICIOUS_CONTENT) {
+      const safeContent = detectionResult.triggerContent
+        ? `\`${detectionResult.triggerContent}\``
+        : '`Message content unavailable`';
+      return sourceMessage
+        ? `[Observed message](${sourceMessage.url}): ${safeContent}`
+        : `Observed message: ${safeContent}`;
+    }
+
+    if (detectionResult.triggerSource === DetectionType.NEW_ACCOUNT) {
+      return 'Observed upon joining server';
+    }
+    if (detectionResult.triggerSource === DetectionType.USER_REPORT) {
+      return `Observed via user report: \`${detectionResult.triggerContent || 'No reason provided'}\``;
+    }
+    if (detectionResult.triggerSource === DetectionType.GPT_ANALYSIS) {
+      return `Observed via manual review: \`${detectionResult.triggerContent || 'Manual flag'}\``;
+    }
+
+    return 'Observed suspicious activity';
+  }
+
+  private formatSuspiciousDetectionTrigger(
+    detectionResult: DetectionResult,
+    sourceMessage?: Message
+  ): string {
+    if (detectionResult.triggerSource === DetectionType.SUSPICIOUS_CONTENT) {
+      const safeContent = detectionResult.triggerContent
+        ? `\`${detectionResult.triggerContent}\``
+        : '`Message content unavailable`';
+      return sourceMessage
+        ? `[Flagged for message](${sourceMessage.url}): ${safeContent}`
+        : `Flagged for message: ${safeContent}`;
+    }
+    if (detectionResult.triggerSource === DetectionType.USER_REPORT) {
+      const safeContent = detectionResult.triggerContent
+        ? `\`${detectionResult.triggerContent}\``
+        : '`No report reason provided`';
+      return `Flagged via user report: ${safeContent}`;
+    }
+    if (detectionResult.triggerSource === DetectionType.GPT_ANALYSIS) {
+      const safeContent = detectionResult.triggerContent
+        ? `\`${detectionResult.triggerContent}\``
+        : '`Manual flag`';
+      return `Flagged via manual review: ${safeContent}`;
+    }
+    if (detectionResult.triggerSource === DetectionType.NEW_ACCOUNT) {
+      return 'Flagged upon joining server';
+    }
+
+    return 'Flagged for suspicious activity';
+  }
+
+  private truncateEmbedFieldValue(value: string): string {
+    const maxLength = 1024;
+    return value.length <= maxLength ? value : `${value.slice(0, maxLength - 3)}...`;
+  }
+
+  private formatAdminActionLabel(actionTaken: AdminActionType): string {
+    switch (actionTaken) {
+      case AdminActionType.BAN:
+        return 'Banned';
+      case AdminActionType.VERIFY:
+        return 'Verified';
+      case AdminActionType.CREATE_THREAD:
+        return 'Created verification thread';
+      case AdminActionType.REOPEN:
+        return 'Reopened verification';
+      case AdminActionType.RESTRICT:
+        return 'Restricted';
+      case AdminActionType.OPEN_CASE:
+        return 'Opened case';
+      case AdminActionType.DISMISS:
+        return 'Dismissed alert';
+      case AdminActionType.FALSE_POSITIVE:
+        return 'Marked false positive';
+      case AdminActionType.UNDO_OBSERVED_ACTION:
+        return 'Undid observed action';
+      case AdminActionType.REJECT:
+        return 'Rejected';
+      default:
+        return actionTaken;
+    }
+  }
+
+  private formatAdminActionEvent(
+    actionTaken: AdminActionType,
+    adminId: string,
+    timestamp: number
+  ): string {
+    return `${this.formatAdminActionLabel(actionTaken)} by <@${adminId}> at <t:${timestamp}:F>`;
+  }
+
+  private upsertLatestAdminActionField(
+    embed: EmbedBuilder,
+    actionTaken: AdminActionType,
+    adminId: string,
+    timestamp: number
+  ): void {
+    const field = {
+      name: NotificationPresentationBuilder.LATEST_ADMIN_ACTION_FIELD_NAME,
+      value: this.formatAdminActionEvent(actionTaken, adminId, timestamp),
+      inline: false,
+    };
+    const fields = (embed.data.fields ?? []).filter(
+      (existingField) => existingField.name !== field.name
+    );
+    const confidenceIndex = fields.findIndex(
+      (existingField) => existingField.name === 'Detection Confidence'
+    );
+    const insertIndex = confidenceIndex >= 0 ? confidenceIndex + 1 : 0;
+    fields.splice(insertIndex, 0, field);
+    embed.setFields(...fields);
+  }
+
+  private upsertLatestResolutionField(
+    embed: EmbedBuilder,
+    verificationEvent: VerificationEvent
+  ): void {
+    if (!verificationEvent.resolved_by || !verificationEvent.resolved_at) {
+      return;
+    }
+
+    const actionTaken =
+      verificationEvent.status === VerificationStatus.BANNED
+        ? AdminActionType.BAN
+        : verificationEvent.status === VerificationStatus.VERIFIED
+          ? AdminActionType.VERIFY
+          : null;
+    if (!actionTaken) {
+      return;
+    }
+
+    this.upsertLatestAdminActionField(
+      embed,
+      actionTaken,
+      verificationEvent.resolved_by,
+      Math.floor(verificationEvent.resolved_at.getTime() / 1000)
+    );
+  }
+
+  private upsertField(
+    embed: EmbedBuilder,
+    field: { name: string; value: string; inline: boolean }
+  ): void {
+    const existingFieldIndex = embed.data.fields?.findIndex(
+      (embedField) => embedField.name === field.name
+    );
+    if (existingFieldIndex !== undefined && existingFieldIndex > -1) {
+      embed.spliceFields(existingFieldIndex, 1, field);
+    } else {
+      embed.addFields(field);
+    }
+  }
+
+  private metadataToRecord(metadata: DetectionEvent['metadata']): Record<string, unknown> {
+    if (!metadata || typeof metadata !== 'object' || Array.isArray(metadata)) {
+      return {};
+    }
+
+    return { ...metadata } as Record<string, unknown>;
+  }
+
+  private formatVerificationActionFailureFieldValue(metadata: unknown): string | null {
+    const failures = getVerificationActionFailures(metadata);
+    if (failures.length === 0) {
+      return null;
+    }
+
+    const value = failures
+      .slice(-3)
+      .map((failure) => {
+        const timestamp = Math.floor(new Date(failure.at).getTime() / 1000);
+        const action =
+          failure.action === 'restrict'
+            ? 'Apply restricted role'
+            : failure.action === 'private_evidence_thread'
+              ? 'Create private evidence thread'
+              : 'Create case thread';
+        const when = Number.isFinite(timestamp) ? ` <t:${timestamp}:R>` : '';
+        return `Warning: ${action} failed${when}: ${failure.message}`;
+      })
+      .join('\n');
+
+    return this.truncateEmbedFieldValue(
+      `${value}\nCase record was still created so moderators can review and fix permissions.`
+    );
+  }
+
+  private formatCaseStaffRoutingWarningFieldValue(metadata: unknown): string | null {
+    if (!metadata || typeof metadata !== 'object' || Array.isArray(metadata)) {
+      return null;
+    }
+
+    const routing = (metadata as Record<string, unknown>)[CASE_STAFF_ROUTING_METADATA_KEY];
+    if (!routing || typeof routing !== 'object' || Array.isArray(routing)) {
+      return null;
+    }
+
+    const warnings = (routing as { warnings?: unknown }).warnings;
+    if (!Array.isArray(warnings) || warnings.length === 0) {
+      return null;
+    }
+
+    return this.truncateEmbedFieldValue(
+      warnings
+        .filter((warning): warning is string => typeof warning === 'string' && warning.length > 0)
+        .slice(-3)
+        .map((warning) => `Warning: ${warning}`)
+        .join('\n')
+    );
+  }
+
+  private formatThreadAnalysisFieldValue(analysis: {
+    result: 'likely_legitimate' | 'needs_review' | 'likely_suspicious';
+    confidence: number;
+    summary: string;
+    reasonCodes?: string[];
+    legitimacySignals?: string[];
+    suspicionSignals?: string[];
+    recommendedNextQuestion?: string;
+    recommendedAction?: 'none' | 'ask_followup' | 'manual_review' | 'restrict';
+    analyzedMessageCount: number;
+  }): string {
+    const confidencePercent = Math.round(analysis.confidence * 100);
+    const lines = [
+      `Result: **${analysis.result}** (${confidencePercent}% confidence)`,
+      `Analyzed responses: ${analysis.analyzedMessageCount}`,
+      `Summary: ${analysis.summary}`,
+    ];
+    if (analysis.reasonCodes?.length) {
+      lines.push(`Reason codes: ${analysis.reasonCodes.join(', ')}`);
+    }
+    if (analysis.legitimacySignals?.length) {
+      lines.push(`Legitimacy signals: ${analysis.legitimacySignals.join('; ')}`);
+    }
+    if (analysis.suspicionSignals?.length) {
+      lines.push(`Suspicion signals: ${analysis.suspicionSignals.join('; ')}`);
+    }
+    if (analysis.recommendedNextQuestion) {
+      lines.push(`Next question: ${analysis.recommendedNextQuestion}`);
+    }
+    if (analysis.recommendedAction) {
+      lines.push(`Recommended action: ${analysis.recommendedAction}`);
+    }
+
+    return this.truncateEmbedFieldValue(lines.join('\n'));
+  }
+
+  private findReportAiAnalysis(
+    detectionEvents: DetectionEvent[],
+    detectionEventId?: string
+  ): ReportAIAnalysis | null {
+    const candidates = detectionEventId
+      ? detectionEvents.filter((event) => event.id === detectionEventId)
+      : detectionEvents;
+
+    for (const event of candidates) {
+      const metadata = this.metadataToRecord(event.metadata);
+      const reportAi = metadata.report_ai;
+      if (reportAi && typeof reportAi === 'object' && !Array.isArray(reportAi)) {
+        return reportAi as ReportAIAnalysis;
+      }
+    }
+
+    return null;
+  }
+
+  private formatReportAiFieldValue(analysis: ReportAIAnalysis | null): string | null {
+    if (!analysis) {
+      return null;
+    }
+
+    const confidencePercent = Math.round(analysis.confidence * 100);
+    const lines = [
+      `Result: **${analysis.result}** (${confidencePercent}% confidence)`,
+      `Summary: ${analysis.summary}`,
+      `Recommended action: ${analysis.recommendedAction}`,
+      `Images analyzed: ${analysis.analyzedImageCount}`,
+    ];
+    if (analysis.reasonCodes.length) {
+      lines.push(`Reason codes: ${analysis.reasonCodes.join(', ')}`);
+    }
+    if (analysis.evidenceCategories.length) {
+      lines.push(`Evidence: ${analysis.evidenceCategories.join(', ')}`);
+    }
+    if (analysis.concerns.length) {
+      lines.push(`Concerns: ${analysis.concerns.join('; ')}`);
+    }
+
+    return this.truncateEmbedFieldValue(lines.join('\n'));
+  }
+
+  private formatGptDiagnosticFieldValue(detectionResult: DetectionResult): string | null {
+    const analysis = detectionResult.gptAnalysis;
+    if (!analysis) {
+      return null;
+    }
+
+    const confidencePercent = Math.round(analysis.confidence * 100);
+    const reasonCodes = analysis.reasonCodes.length ? analysis.reasonCodes.join(', ') : 'none';
+    const resultLine = analysis.isFallback
+      ? 'Result: **Unavailable**'
+      : `Result: **${analysis.result}** (${confidencePercent}% confidence)`;
+    return this.truncateEmbedFieldValue(
+      [
+        resultLine,
+        `Primary signal: ${analysis.primarySignal}`,
+        `Reason codes: ${reasonCodes}`,
+        `Summary: ${analysis.summary}`,
+      ].join('\n')
+    );
+  }
+
+  private formatAccountingSuffix(event: DetectionEvent): string {
+    return isDetectionEventExcludedFromAccounting(event) ? ' - ignored for future accounting' : '';
+  }
+
+  private getThreadAnalysisMetadata(
+    metadata: VerificationEvent['metadata']
+  ): ThreadAnalysisMetadata | null {
+    if (!metadata || typeof metadata !== 'object' || Array.isArray(metadata)) {
+      return null;
+    }
+
+    const threadAnalysis = (metadata as { thread_analysis?: unknown }).thread_analysis;
+    if (!threadAnalysis || typeof threadAnalysis !== 'object' || Array.isArray(threadAnalysis)) {
+      return null;
+    }
+
+    const metadataRecord = threadAnalysis as ThreadAnalysisMetadata;
+    const latestAnalysis =
+      metadataRecord.latestAnalysis &&
+      typeof metadataRecord.latestAnalysis === 'object' &&
+      !Array.isArray(metadataRecord.latestAnalysis)
+        ? (metadataRecord.latestAnalysis as Record<string, unknown>)
+        : null;
+    if (!latestAnalysis) {
+      return metadataRecord;
+    }
+
+    const rawResult = latestAnalysis.result;
+    const result =
+      rawResult === 'likely_legitimate' ||
+      rawResult === 'needs_review' ||
+      rawResult === 'likely_suspicious'
+        ? rawResult
+        : rawResult === 'OK'
+          ? 'likely_legitimate'
+          : rawResult === 'SUSPICIOUS'
+            ? 'likely_suspicious'
+            : null;
+
+    if (
+      !result ||
+      typeof latestAnalysis.confidence !== 'number' ||
+      typeof latestAnalysis.summary !== 'string' ||
+      typeof latestAnalysis.analyzedMessageCount !== 'number'
+    ) {
+      return metadataRecord;
+    }
+
+    return {
+      ...metadataRecord,
+      latestAnalysis: {
+        result,
+        confidence: latestAnalysis.confidence,
+        summary: latestAnalysis.summary,
+        reasonCodes: Array.isArray(latestAnalysis.reasonCodes)
+          ? latestAnalysis.reasonCodes.filter((value): value is string => typeof value === 'string')
+          : [],
+        legitimacySignals: Array.isArray(latestAnalysis.legitimacySignals)
+          ? latestAnalysis.legitimacySignals.filter(
+              (value): value is string => typeof value === 'string'
+            )
+          : [],
+        suspicionSignals: Array.isArray(latestAnalysis.suspicionSignals)
+          ? latestAnalysis.suspicionSignals.filter(
+              (value): value is string => typeof value === 'string'
+            )
+          : [],
+        recommendedNextQuestion:
+          typeof latestAnalysis.recommendedNextQuestion === 'string'
+            ? latestAnalysis.recommendedNextQuestion
+            : undefined,
+        recommendedAction:
+          latestAnalysis.recommendedAction === 'none' ||
+          latestAnalysis.recommendedAction === 'ask_followup' ||
+          latestAnalysis.recommendedAction === 'manual_review' ||
+          latestAnalysis.recommendedAction === 'restrict'
+            ? latestAnalysis.recommendedAction
+            : 'manual_review',
+        analyzedMessageCount: latestAnalysis.analyzedMessageCount,
+      },
+    };
+  }
+}

--- a/src/services/NotificationPresentationBuilder.ts
+++ b/src/services/NotificationPresentationBuilder.ts
@@ -80,7 +80,7 @@ export class NotificationPresentationBuilder {
       (a, b) => new Date(b.detected_at).getTime() - new Date(a.detected_at).getTime()
     );
     const detectionHistory = this.formatSuspiciousDetectionHistory(
-      detectionEventsNewestFirst,
+      detectionEvents,
       member.guild.id
     );
 


### PR DESCRIPTION
## Summary
- Updates the web workspace to Next `16.3.0-canary.6` so the lockfile resolves `postcss@8.5.10` for Dependabot alert #46 / GHSA-qx2v-qp2m-jg93.
- Merges current `main` into the branch, including the admin evidence thread/message-context changes from #112.
- Ratchets the production `lizard` CCN gate from `50` to `25` after extracting setup permission checks and `/config setup` reply/result handling.
- Extracts notification embed/component/field presentation into `NotificationPresentationBuilder`, leaving `NotificationManager` focused on Discord/config/repository coordination.

## Why
This consolidates the small post-#111 follow-ups into one draft PR: security alert remediation, a metrics ratchet, and the #115 notification presentation split while staying current with `main`.

## Testing
- `npm audit --audit-level=moderate`
- `npm run build`
- `npm run lint`
- `npm run format:check`
- `npm run code:metrics`
- `npm test`
- `npm run web:lint`
- `npm run web:typecheck`
- `npm run web:test`
- `npm run web:build`
- `git diff --check`

## Risk Notes
- This uses a Next canary because the latest stable Next still pins vulnerable PostCSS; keep draft until CI confirms and decide whether the security fix justifies canary adoption or should wait for a stable patch.
- The presentation split is intended to preserve behavior; the report-AI fallback ordering was kept newest-first during extraction, and #112's new admin evidence thread presentation was applied in the builder during merge resolution.
- Not run locally: `npm run test:integration`, because the local Supabase/Postgres dependency is not available and previously fails with `ECONNREFUSED 127.0.0.1:54322`.

Refs #114. Closes #115.