### PR TITLE
Add drasilbot domain infrastructure

### DIFF
--- a/.github/workflows/iac.yml
+++ b/.github/workflows/iac.yml
@@ -37,6 +37,10 @@ jobs:
         working-directory: infra/aws/prod
         run: terraform init -backend=false && terraform validate
 
+      - name: Terraform validate (domain)
+        working-directory: infra/aws/domain
+        run: terraform init -backend=false && terraform validate
+
       - name: Terraform validate (intel)
         working-directory: infra/aws/intel
         run: terraform init -backend=false && terraform validate

--- a/docs/deploy/aws.md
+++ b/docs/deploy/aws.md
@@ -81,7 +81,7 @@ After first apply, set the Route 53 Domains registration nameservers to the Terr
 ```bash
 terraform output name_servers
 aws route53domains update-domain-nameservers --region us-east-1 --domain-name drasilbot.com \
-  --nameservers Name=NS_1 Name=NS_2 Name=NS_3 Name=NS_4
+  --nameservers Name="<NS_1>" Name="<NS_2>" Name="<NS_3>" Name="<NS_4>"
 ```
 
 The stack creates Vercel DNS defaults by default:

--- a/docs/deploy/aws.md
+++ b/docs/deploy/aws.md
@@ -63,6 +63,35 @@ Terraform creates:
 - GitHub Actions OIDC role for deploys
 - Resource Group filtered by `Project` + `Environment` tags
 
+## 2b) Provision domain DNS
+
+The domain stack manages the public Route 53 hosted zone for `drasilbot.com` separately from the ECS
+production stack.
+
+```bash
+cd infra/aws/domain
+cp backend.hcl.example backend.hcl
+# Edit backend.hcl and replace REPLACE_ME with the shared state bucket name
+terraform init -backend-config=backend.hcl
+terraform apply
+```
+
+After first apply, set the Route 53 Domains registration nameservers to the Terraform output:
+
+```bash
+terraform output name_servers
+aws route53domains update-domain-nameservers --region us-east-1 --domain-name drasilbot.com \
+  --nameservers Name=NS_1 Name=NS_2 Name=NS_3 Name=NS_4
+```
+
+The stack creates Vercel DNS defaults by default:
+
+- `drasilbot.com` A -> `76.76.21.21`
+- `www.drasilbot.com` CNAME -> `cname.vercel-dns.com`
+
+When Vercel is configured for the custom domain, also set `NEXT_PUBLIC_APP_URL=https://drasilbot.com`
+and add `https://drasilbot.com/api/auth/discord/callback` to the Discord OAuth redirect list.
+
 If your AWS account already has the standard GitHub Actions OIDC provider
 (`token.actions.githubusercontent.com`), set `github_oidc_provider_arn` when
 applying `infra/aws/prod` so this stack reuses it.

--- a/infra/aws/README.md
+++ b/infra/aws/README.md
@@ -5,6 +5,7 @@ This directory contains Terraform for deploying Drasil to AWS.
 Layout:
 
 - `infra/aws/bootstrap`: one-time setup for Terraform remote state (S3 + DynamoDB lock table)
+- `infra/aws/domain`: public Route 53 hosted zone and web DNS records for `drasilbot.com`
 - `infra/aws/intel`: lightweight private S3 bucket for scam/spam evidence collection
 - `infra/aws/prod`: production infrastructure (ECR + ECS Fargate + networking + IAM)
 
@@ -38,6 +39,22 @@ terraform apply
 The production stack creates Secrets Manager entries for `DISCORD_TOKEN`,
 `OPENAI_API_KEY`, `DATABASE_URL`, `OBSERVABILITY_HASH_KEY`, and
 `POSTHOG_PROJECT_API_KEY`.
+
+## Domain DNS
+
+Use `infra/aws/domain` to manage the public hosted zone and Vercel DNS records for `drasilbot.com`.
+
+```bash
+cd infra/aws/domain
+cp backend.hcl.example backend.hcl
+# Edit backend.hcl and replace REPLACE_ME with the shared state bucket name
+terraform init -backend-config=backend.hcl
+terraform apply
+```
+
+After the first apply, update the Route 53 Domains registration to use the `name_servers` output.
+The hosted zone state is intentionally separate from `prod` so DNS ownership can be managed without
+touching the ECS service stack.
 
 ## Optional intelligence bucket
 

--- a/infra/aws/domain/.terraform.lock.hcl
+++ b/infra/aws/domain/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:H3mU/7URhP0uCRGK8jeQRKxx2XFzEqLiOq/L2Bbiaxs=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}

--- a/infra/aws/domain/backend.hcl.example
+++ b/infra/aws/domain/backend.hcl.example
@@ -1,0 +1,7 @@
+# Used by: terraform init -backend-config=backend.hcl
+
+bucket         = "REPLACE_ME"
+key            = "drasil/domain/terraform.tfstate"
+region         = "us-east-1"
+dynamodb_table = "drasil-terraform-locks"
+encrypt        = true

--- a/infra/aws/domain/backend.tf
+++ b/infra/aws/domain/backend.tf
@@ -1,0 +1,3 @@
+terraform {
+  backend "s3" {}
+}

--- a/infra/aws/domain/main.tf
+++ b/infra/aws/domain/main.tf
@@ -32,6 +32,7 @@ resource "aws_route53_zone" "primary" {
 
 resource "aws_route53_record" "vercel_apex" {
   #checkov:skip=CKV2_AWS_23:Vercel apex records intentionally point to Vercel's provider-managed global edge IP.
+  # Allow overwrite keeps apply idempotent if these records were pre-created during cutover.
   count = var.enable_vercel_records ? 1 : 0
 
   zone_id         = aws_route53_zone.primary.zone_id
@@ -43,6 +44,7 @@ resource "aws_route53_record" "vercel_apex" {
 }
 
 resource "aws_route53_record" "vercel_www" {
+  # Allow overwrite keeps apply idempotent if this record was pre-created during cutover.
   count = var.enable_vercel_records ? 1 : 0
 
   zone_id         = aws_route53_zone.primary.zone_id

--- a/infra/aws/domain/main.tf
+++ b/infra/aws/domain/main.tf
@@ -1,0 +1,54 @@
+locals {
+  domain_name = trimsuffix(lower(var.domain_name), ".")
+
+  common_tags = merge(
+    var.tags,
+    {
+      Project     = var.project_name
+      Environment = var.environment
+      ManagedBy   = "terraform"
+      Repository  = "basic-bit/drasil"
+      Service     = "web-dashboard"
+      Component   = "domain"
+    }
+  )
+}
+
+resource "aws_route53_zone" "primary" {
+  #checkov:skip=CKV2_AWS_38:DNSSEC requires registrar DS-record coordination and is deferred until the initial domain cutover is stable.
+  #checkov:skip=CKV2_AWS_39:Query logging is deferred; DNS query logs can contain user lookup metadata and need a privacy-aware retention policy.
+  name          = local.domain_name
+  comment       = "Public hosted zone for Drasil Bot."
+  force_destroy = false
+
+  tags = {
+    Name = local.domain_name
+  }
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "aws_route53_record" "vercel_apex" {
+  #checkov:skip=CKV2_AWS_23:Vercel apex records intentionally point to Vercel's provider-managed global edge IP.
+  count = var.enable_vercel_records ? 1 : 0
+
+  zone_id         = aws_route53_zone.primary.zone_id
+  name            = local.domain_name
+  type            = "A"
+  ttl             = var.dns_record_ttl
+  records         = var.vercel_apex_a_records
+  allow_overwrite = true
+}
+
+resource "aws_route53_record" "vercel_www" {
+  count = var.enable_vercel_records ? 1 : 0
+
+  zone_id         = aws_route53_zone.primary.zone_id
+  name            = "www.${local.domain_name}"
+  type            = "CNAME"
+  ttl             = var.dns_record_ttl
+  records         = [var.vercel_cname_target]
+  allow_overwrite = true
+}

--- a/infra/aws/domain/outputs.tf
+++ b/infra/aws/domain/outputs.tf
@@ -1,0 +1,24 @@
+output "domain_name" {
+  value       = local.domain_name
+  description = "Domain name managed by this stack."
+}
+
+output "hosted_zone_id" {
+  value       = aws_route53_zone.primary.zone_id
+  description = "Route 53 hosted zone ID."
+}
+
+output "name_servers" {
+  value       = aws_route53_zone.primary.name_servers
+  description = "Authoritative nameservers to set on the Route 53 Domains registration."
+}
+
+output "apex_record" {
+  value       = try(aws_route53_record.vercel_apex[0].fqdn, null)
+  description = "Apex Vercel DNS record FQDN, or null when Vercel records are disabled."
+}
+
+output "www_record" {
+  value       = try(aws_route53_record.vercel_www[0].fqdn, null)
+  description = "www Vercel DNS record FQDN, or null when Vercel records are disabled."
+}

--- a/infra/aws/domain/variables.tf
+++ b/infra/aws/domain/variables.tf
@@ -1,0 +1,58 @@
+variable "aws_region" {
+  type        = string
+  description = "AWS region for Route 53 API calls. Route 53 is global, but Terraform still needs a provider region."
+  default     = "us-east-1"
+}
+
+variable "domain_name" {
+  type        = string
+  description = "Primary domain name managed by this stack."
+  default     = "drasilbot.com"
+
+  validation {
+    condition     = can(regex("^[A-Za-z0-9][A-Za-z0-9.-]*[A-Za-z0-9]$", trimsuffix(var.domain_name, ".")))
+    error_message = "domain_name must be a valid DNS name without protocol or path."
+  }
+}
+
+variable "project_name" {
+  type        = string
+  description = "Project tag used for naming and tagging."
+  default     = "drasil"
+}
+
+variable "environment" {
+  type        = string
+  description = "Environment tag used for naming and tagging."
+  default     = "prod"
+}
+
+variable "enable_vercel_records" {
+  type        = bool
+  description = "Create apex A and www CNAME records for Vercel-hosted web production."
+  default     = true
+}
+
+variable "vercel_apex_a_records" {
+  type        = list(string)
+  description = "A records Vercel expects for apex domains."
+  default     = ["76.76.21.21"]
+}
+
+variable "vercel_cname_target" {
+  type        = string
+  description = "CNAME target Vercel expects for subdomains."
+  default     = "cname.vercel-dns.com"
+}
+
+variable "dns_record_ttl" {
+  type        = number
+  description = "TTL in seconds for managed DNS records."
+  default     = 300
+}
+
+variable "tags" {
+  type        = map(string)
+  description = "Tags applied to created resources."
+  default     = {}
+}

--- a/infra/aws/domain/variables.tf
+++ b/infra/aws/domain/variables.tf
@@ -10,8 +10,8 @@ variable "domain_name" {
   default     = "drasilbot.com"
 
   validation {
-    condition     = can(regex("^[A-Za-z0-9][A-Za-z0-9.-]*[A-Za-z0-9]$", trimsuffix(var.domain_name, ".")))
-    error_message = "domain_name must be a valid DNS name without protocol or path."
+    condition     = length(trimsuffix(var.domain_name, ".")) <= 253 && can(regex("^([A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?\\.)+[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?$", trimsuffix(var.domain_name, ".")))
+    error_message = "domain_name must be a valid DNS name without protocol, path, consecutive dots, or labels starting/ending with a hyphen."
   }
 }
 

--- a/infra/aws/domain/versions.tf
+++ b/infra/aws/domain/versions.tf
@@ -1,0 +1,18 @@
+terraform {
+  required_version = ">= 1.6.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+
+  default_tags {
+    tags = local.common_tags
+  }
+}


### PR DESCRIPTION
[AGENT]

## What / Why

Add a separate Terraform stack for `drasilbot.com` DNS ownership in Route 53, including the public hosted zone, Vercel apex/www records, backend template, provider lock, outputs, and IaC workflow validation.

## Linked issues

Closes #121.

## How to test

IaC validation passed locally and is covered by the PR IaC workflow. Checkov result: 211 passed, 0 failed, 29 skipped.

## Risk / rollout

No Terraform apply is included in this PR. After merge, apply `infra/aws/domain`, update the Route 53 Domains nameservers from the `name_servers` output, then configure the Vercel custom domain and Discord OAuth redirect.

## AI Review Packet (fresh-context friendly)

- Primary goal: manage `drasilbot.com` DNS through Terraform without mixing DNS ownership into the ECS prod stack.
- Non-goals: DNSSEC, DNS query logging, Terraform apply, Vercel provider automation, Discord/Vercel provider-side mutation.
- Key files changed: `infra/aws/domain/*`, `.github/workflows/iac.yml`, `infra/aws/README.md`, `docs/deploy/aws.md`.
- Invariants this PR must preserve: DNS hosted zone has `prevent_destroy`; domain stack state is isolated from prod; Vercel record defaults remain configurable.
- Manual test notes: `drasilbot.com` Route 53 registration is already successful; nameserver cutover is intentionally deferred until after Terraform apply.
- Questions for reviewers: none.

## Merge checklist

- [x] All PR review threads resolved (or explicitly addressed)