### PR TITLE
Add gated domain Terraform deploy workflow

### DIFF
--- a/.github/workflows/deploy-domain.yml
+++ b/.github/workflows/deploy-domain.yml
@@ -1,0 +1,125 @@
+name: Deploy Domain DNS (prod)
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Git ref (branch, tag, or commit SHA) to use'
+        required: false
+        default: 'main'
+      mode:
+        description: 'Run a Terraform plan only, or apply the generated plan'
+        required: true
+        type: choice
+        default: plan
+        options:
+          - plan
+          - apply
+      domain_name:
+        description: 'Domain name managed by infra/aws/domain'
+        required: true
+        default: 'drasilbot.com'
+
+concurrency:
+  group: deploy-domain-prod
+  cancel-in-progress: false
+
+env:
+  GIT_CONFIG_COUNT: 1
+  GIT_CONFIG_KEY_0: init.defaultBranch
+  GIT_CONFIG_VALUE_0: main
+
+jobs:
+  terraform-domain:
+    runs-on: ubuntu-latest
+    environment: Deploy - web-prod
+    permissions:
+      id-token: write
+      contents: read
+    env:
+      TF_VAR_domain_name: ${{ inputs.domain_name }}
+    defaults:
+      run:
+        shell: bash
+        working-directory: infra/aws/domain
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref || github.sha }}
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v4.0.1
+        with:
+          terraform_version: 1.6.6
+          terraform_wrapper: false
+
+      - name: Validate required variables
+        env:
+          AWS_REGION: ${{ vars.AWS_REGION }}
+          AWS_ROLE_TO_ASSUME: ${{ vars.AWS_TERRAFORM_ROLE_TO_ASSUME || vars.AWS_ROLE_TO_ASSUME }}
+          DOMAIN_HOSTED_ZONE_ID: ${{ vars.DRASIL_DOMAIN_HOSTED_ZONE_ID }}
+          TERRAFORM_STATE_BUCKET: ${{ vars.TERRAFORM_STATE_BUCKET }}
+        run: |
+          set -euo pipefail
+          : "${AWS_REGION:?Set repository variable AWS_REGION}"
+          : "${AWS_ROLE_TO_ASSUME:?Set repository variable AWS_TERRAFORM_ROLE_TO_ASSUME or AWS_ROLE_TO_ASSUME}"
+          : "${DOMAIN_HOSTED_ZONE_ID:?Set repository variable DRASIL_DOMAIN_HOSTED_ZONE_ID}"
+          : "${TERRAFORM_STATE_BUCKET:?Set repository variable TERRAFORM_STATE_BUCKET}"
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          aws-region: ${{ vars.AWS_REGION }}
+          role-to-assume: ${{ vars.AWS_TERRAFORM_ROLE_TO_ASSUME || vars.AWS_ROLE_TO_ASSUME }}
+
+      - name: Write backend config
+        env:
+          TERRAFORM_STATE_BUCKET: ${{ vars.TERRAFORM_STATE_BUCKET }}
+        run: |
+          set -euo pipefail
+          cat > backend.ci.hcl <<EOF
+          bucket         = "${TERRAFORM_STATE_BUCKET}"
+          key            = "drasil/domain/terraform.tfstate"
+          region         = "us-east-1"
+          dynamodb_table = "drasil-terraform-locks"
+          encrypt        = true
+          EOF
+
+      - name: Terraform init
+        run: terraform init -backend-config=backend.ci.hcl
+
+      - name: Adopt existing hosted zone
+        env:
+          DOMAIN_HOSTED_ZONE_ID: ${{ vars.DRASIL_DOMAIN_HOSTED_ZONE_ID }}
+        run: |
+          set -euo pipefail
+          if terraform state show aws_route53_zone.primary >/dev/null 2>&1; then
+            echo "aws_route53_zone.primary is already tracked in Terraform state."
+            exit 0
+          fi
+
+          terraform import -input=false aws_route53_zone.primary "$DOMAIN_HOSTED_ZONE_ID"
+
+      - name: Terraform plan
+        run: terraform plan -input=false -out=tfplan
+
+      - name: Terraform apply
+        if: inputs.mode == 'apply'
+        run: terraform apply -input=false -auto-approve tfplan
+
+      - name: Deployment summary
+        if: always()
+        env:
+          DOMAIN_HOSTED_ZONE_ID: ${{ vars.DRASIL_DOMAIN_HOSTED_ZONE_ID }}
+          DOMAIN_NAME: ${{ inputs.domain_name }}
+          MODE: ${{ inputs.mode }}
+        run: |
+          {
+            echo "## Domain DNS Terraform"
+            echo "- Mode: ${MODE}"
+            echo "- Commit SHA: $(git rev-parse --short HEAD)"
+            echo "- Domain: ${DOMAIN_NAME}"
+            echo "- Hosted zone ID: ${DOMAIN_HOSTED_ZONE_ID}"
+            echo "- State key: drasil/domain/terraform.tfstate"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/deploy-domain.yml
+++ b/.github/workflows/deploy-domain.yml
@@ -59,12 +59,14 @@ jobs:
           AWS_REGION: ${{ vars.AWS_REGION }}
           AWS_ROLE_TO_ASSUME: ${{ vars.AWS_TERRAFORM_ROLE_TO_ASSUME || vars.AWS_ROLE_TO_ASSUME }}
           DOMAIN_HOSTED_ZONE_ID: ${{ vars.DRASIL_DOMAIN_HOSTED_ZONE_ID }}
+          TERRAFORM_LOCK_TABLE: ${{ vars.TERRAFORM_LOCK_TABLE || 'drasil-terraform-locks' }}
           TERRAFORM_STATE_BUCKET: ${{ vars.TERRAFORM_STATE_BUCKET }}
         run: |
           set -euo pipefail
           : "${AWS_REGION:?Set repository variable AWS_REGION}"
           : "${AWS_ROLE_TO_ASSUME:?Set repository variable AWS_TERRAFORM_ROLE_TO_ASSUME or AWS_ROLE_TO_ASSUME}"
           : "${DOMAIN_HOSTED_ZONE_ID:?Set repository variable DRASIL_DOMAIN_HOSTED_ZONE_ID}"
+          : "${TERRAFORM_LOCK_TABLE:?Set repository variable TERRAFORM_LOCK_TABLE}"
           : "${TERRAFORM_STATE_BUCKET:?Set repository variable TERRAFORM_STATE_BUCKET}"
 
       - name: Configure AWS credentials (OIDC)
@@ -75,6 +77,7 @@ jobs:
 
       - name: Write backend config
         env:
+          TERRAFORM_LOCK_TABLE: ${{ vars.TERRAFORM_LOCK_TABLE || 'drasil-terraform-locks' }}
           TERRAFORM_STATE_BUCKET: ${{ vars.TERRAFORM_STATE_BUCKET }}
         run: |
           set -euo pipefail
@@ -82,7 +85,7 @@ jobs:
           bucket         = "${TERRAFORM_STATE_BUCKET}"
           key            = "drasil/domain/terraform.tfstate"
           region         = "us-east-1"
-          dynamodb_table = "drasil-terraform-locks"
+          dynamodb_table = "${TERRAFORM_LOCK_TABLE}"
           encrypt        = true
           EOF
 

--- a/.github/workflows/deploy-domain.yml
+++ b/.github/workflows/deploy-domain.yml
@@ -77,6 +77,7 @@ jobs:
 
       - name: Write backend config
         env:
+          AWS_REGION: ${{ vars.AWS_REGION }}
           TERRAFORM_LOCK_TABLE: ${{ vars.TERRAFORM_LOCK_TABLE || 'drasil-terraform-locks' }}
           TERRAFORM_STATE_BUCKET: ${{ vars.TERRAFORM_STATE_BUCKET }}
         run: |
@@ -84,7 +85,7 @@ jobs:
           cat > backend.ci.hcl <<EOF
           bucket         = "${TERRAFORM_STATE_BUCKET}"
           key            = "drasil/domain/terraform.tfstate"
-          region         = "us-east-1"
+          region         = "${AWS_REGION}"
           dynamodb_table = "${TERRAFORM_LOCK_TABLE}"
           encrypt        = true
           EOF

--- a/docs/deploy/aws.md
+++ b/docs/deploy/aws.md
@@ -111,6 +111,7 @@ Repository variables for the workflow:
 - `AWS_REGION`: AWS region for OIDC sessions, usually `us-east-1`.
 - `AWS_ROLE_TO_ASSUME`: existing deploy role, or set `AWS_TERRAFORM_ROLE_TO_ASSUME` to a separate Terraform role.
 - `TERRAFORM_STATE_BUCKET`: S3 bucket created by `infra/aws/bootstrap`.
+- `TERRAFORM_LOCK_TABLE`: DynamoDB lock table created by `infra/aws/bootstrap`; defaults to `drasil-terraform-locks`.
 - `DRASIL_DOMAIN_HOSTED_ZONE_ID`: existing public hosted zone ID, for example `Z07359592T4F9RD06WHWA`.
 
 If reusing the existing deploy role, apply `infra/aws/prod` with these variables so the role can read
@@ -118,6 +119,7 @@ the domain Terraform state and manage only the Drasil hosted zone:
 
 ```hcl
 github_actions_terraform_state_bucket_name = "drasil-terraform-state-079358094174"
+github_actions_terraform_backend_kms_key_arn = "arn:aws:kms:us-east-1:079358094174:key/0a0d24a7-db40-4a5f-871a-5147c5eb2041"
 github_actions_domain_hosted_zone_id       = "Z07359592T4F9RD06WHWA"
 ```
 

--- a/docs/deploy/aws.md
+++ b/docs/deploy/aws.md
@@ -92,6 +92,35 @@ The stack creates Vercel DNS defaults by default:
 When Vercel is configured for the custom domain, also set `NEXT_PUBLIC_APP_URL=https://drasilbot.com`
 and add `https://drasilbot.com/api/auth/discord/callback` to the Discord OAuth redirect list.
 
+If Route 53 already created the hosted zone during domain registration, adopt it into Terraform state
+before the first local apply:
+
+```bash
+terraform import aws_route53_zone.primary Z07359592T4F9RD06WHWA
+terraform plan
+terraform apply
+```
+
+For GitHub-hosted operation, use the manual `Deploy Domain DNS (prod)` workflow. It is
+`workflow_dispatch` only, uses the protected `Deploy - web-prod` approval gate, and imports the
+existing hosted zone into the remote domain state when it is missing. Merging the workflow is a no-op;
+DNS changes happen only when the workflow is explicitly run in `apply` mode.
+
+Repository variables for the workflow:
+
+- `AWS_REGION`: AWS region for OIDC sessions, usually `us-east-1`.
+- `AWS_ROLE_TO_ASSUME`: existing deploy role, or set `AWS_TERRAFORM_ROLE_TO_ASSUME` to a separate Terraform role.
+- `TERRAFORM_STATE_BUCKET`: S3 bucket created by `infra/aws/bootstrap`.
+- `DRASIL_DOMAIN_HOSTED_ZONE_ID`: existing public hosted zone ID, for example `Z07359592T4F9RD06WHWA`.
+
+If reusing the existing deploy role, apply `infra/aws/prod` with these variables so the role can read
+the domain Terraform state and manage only the Drasil hosted zone:
+
+```hcl
+github_actions_terraform_state_bucket_name = "drasil-terraform-state-079358094174"
+github_actions_domain_hosted_zone_id       = "Z07359592T4F9RD06WHWA"
+```
+
 If your AWS account already has the standard GitHub Actions OIDC provider
 (`token.actions.githubusercontent.com`), set `github_oidc_provider_arn` when
 applying `infra/aws/prod` so this stack reuses it.

--- a/docs/deploy/aws.md
+++ b/docs/deploy/aws.md
@@ -112,15 +112,15 @@ Repository variables for the workflow:
 - `AWS_ROLE_TO_ASSUME`: existing deploy role, or set `AWS_TERRAFORM_ROLE_TO_ASSUME` to a separate Terraform role.
 - `TERRAFORM_STATE_BUCKET`: S3 bucket created by `infra/aws/bootstrap`.
 - `TERRAFORM_LOCK_TABLE`: DynamoDB lock table created by `infra/aws/bootstrap`; defaults to `drasil-terraform-locks`.
-- `DRASIL_DOMAIN_HOSTED_ZONE_ID`: existing public hosted zone ID, for example `Z07359592T4F9RD06WHWA`.
+- `DRASIL_DOMAIN_HOSTED_ZONE_ID`: existing public hosted zone ID, for example `Z1234567890EXAMPLE`.
 
 If reusing the existing deploy role, apply `infra/aws/prod` with these variables so the role can read
 the domain Terraform state and manage only the Drasil hosted zone:
 
 ```hcl
-github_actions_terraform_state_bucket_name = "drasil-terraform-state-079358094174"
-github_actions_terraform_backend_kms_key_arn = "arn:aws:kms:us-east-1:079358094174:key/0a0d24a7-db40-4a5f-871a-5147c5eb2041"
-github_actions_domain_hosted_zone_id       = "Z07359592T4F9RD06WHWA"
+github_actions_terraform_state_bucket_name = "drasil-terraform-state-<account-id>"
+github_actions_terraform_backend_kms_key_arn = "arn:aws:kms:<region>:<account-id>:key/<key-id>"
+github_actions_domain_hosted_zone_id       = "<hosted-zone-id>"
 ```
 
 If your AWS account already has the standard GitHub Actions OIDC provider

--- a/infra/aws/README.md
+++ b/infra/aws/README.md
@@ -49,12 +49,18 @@ cd infra/aws/domain
 cp backend.hcl.example backend.hcl
 # Edit backend.hcl and replace REPLACE_ME with the shared state bucket name
 terraform init -backend-config=backend.hcl
+terraform import aws_route53_zone.primary Z07359592T4F9RD06WHWA # first adoption only
 terraform apply
 ```
 
 After the first apply, update the Route 53 Domains registration to use the `name_servers` output.
 The hosted zone state is intentionally separate from `prod` so DNS ownership can be managed without
 touching the ECS service stack.
+
+The same stack can also be run from GitHub using the manual `Deploy Domain DNS (prod)` workflow.
+That workflow is `workflow_dispatch` only, so merging changes is a no-op until an operator runs it.
+It uses the protected `Deploy - web-prod` environment and imports the existing hosted zone into the
+remote domain state if it is not tracked yet.
 
 ## Optional intelligence bucket
 

--- a/infra/aws/prod/main.tf
+++ b/infra/aws/prod/main.tf
@@ -468,6 +468,20 @@ data "aws_iam_policy_document" "github_deploy" {
   }
 
   dynamic "statement" {
+    for_each = var.github_actions_terraform_backend_kms_key_arn == null ? [] : [var.github_actions_terraform_backend_kms_key_arn]
+
+    content {
+      actions = [
+        "kms:Decrypt",
+        "kms:DescribeKey",
+        "kms:Encrypt",
+        "kms:GenerateDataKey"
+      ]
+      resources = [statement.value]
+    }
+  }
+
+  dynamic "statement" {
     for_each = var.github_actions_domain_hosted_zone_id == null ? [] : [var.github_actions_domain_hosted_zone_id]
 
     content {

--- a/infra/aws/prod/main.tf
+++ b/infra/aws/prod/main.tf
@@ -418,6 +418,82 @@ resource "aws_iam_role" "github_deploy" {
 
 data "aws_iam_policy_document" "github_deploy" {
   #checkov:skip=CKV_AWS_356:Some ECS/ECR actions (for deployment APIs) require wildcard resources.
+  dynamic "statement" {
+    for_each = var.github_actions_terraform_state_bucket_name == null ? [] : [var.github_actions_terraform_state_bucket_name]
+
+    content {
+      actions = [
+        "s3:ListBucket"
+      ]
+      resources = ["arn:aws:s3:::${statement.value}"]
+
+      condition {
+        test     = "StringLike"
+        variable = "s3:prefix"
+        values   = ["drasil/domain/*"]
+      }
+    }
+  }
+
+  dynamic "statement" {
+    for_each = var.github_actions_terraform_state_bucket_name == null ? [] : [var.github_actions_terraform_state_bucket_name]
+
+    content {
+      actions = [
+        "s3:DeleteObject",
+        "s3:GetObject",
+        "s3:PutObject"
+      ]
+      resources = [
+        "arn:aws:s3:::${statement.value}/drasil/domain/terraform.tfstate"
+      ]
+    }
+  }
+
+  dynamic "statement" {
+    for_each = var.github_actions_terraform_state_bucket_name == null ? [] : [var.github_actions_terraform_lock_table_name]
+
+    content {
+      actions = [
+        "dynamodb:DeleteItem",
+        "dynamodb:DescribeTable",
+        "dynamodb:GetItem",
+        "dynamodb:PutItem",
+        "dynamodb:UpdateItem"
+      ]
+      resources = [
+        "arn:aws:dynamodb:${var.aws_region}:${data.aws_caller_identity.current.account_id}:table/${statement.value}"
+      ]
+    }
+  }
+
+  dynamic "statement" {
+    for_each = var.github_actions_domain_hosted_zone_id == null ? [] : [var.github_actions_domain_hosted_zone_id]
+
+    content {
+      actions = [
+        "route53:ChangeResourceRecordSets",
+        "route53:ChangeTagsForResource",
+        "route53:GetHostedZone",
+        "route53:ListResourceRecordSets",
+        "route53:ListTagsForResource",
+        "route53:UpdateHostedZoneComment"
+      ]
+      resources = ["arn:aws:route53:::hostedzone/${statement.value}"]
+    }
+  }
+
+  dynamic "statement" {
+    for_each = var.github_actions_domain_hosted_zone_id == null ? [] : [1]
+
+    content {
+      actions = [
+        "route53:GetChange"
+      ]
+      resources = ["arn:aws:route53:::change/*"]
+    }
+  }
+
   statement {
     actions = [
       "ecr:GetAuthorizationToken"

--- a/infra/aws/prod/variables.tf
+++ b/infra/aws/prod/variables.tf
@@ -105,6 +105,12 @@ variable "github_actions_terraform_lock_table_name" {
   default     = "drasil-terraform-locks"
 }
 
+variable "github_actions_terraform_backend_kms_key_arn" {
+  type        = string
+  description = "KMS key ARN used by the Terraform state bucket and lock table. When set, grants the GitHub OIDC deploy role backend encryption access."
+  default     = null
+}
+
 variable "github_actions_domain_hosted_zone_id" {
   type        = string
   description = "Existing public Route 53 hosted zone ID that the GitHub OIDC deploy role may manage for the domain stack."

--- a/infra/aws/prod/variables.tf
+++ b/infra/aws/prod/variables.tf
@@ -93,6 +93,24 @@ variable "github_oidc_thumbprints" {
   default     = ["6938fd4d98bab03faadb97b34396831e3780aea1"]
 }
 
+variable "github_actions_terraform_state_bucket_name" {
+  type        = string
+  description = "S3 bucket name for Terraform remote state. When set, grants the GitHub OIDC deploy role access to the domain stack state object."
+  default     = null
+}
+
+variable "github_actions_terraform_lock_table_name" {
+  type        = string
+  description = "DynamoDB table name used by the Terraform S3 backend for state locking."
+  default     = "drasil-terraform-locks"
+}
+
+variable "github_actions_domain_hosted_zone_id" {
+  type        = string
+  description = "Existing public Route 53 hosted zone ID that the GitHub OIDC deploy role may manage for the domain stack."
+  default     = null
+}
+
 variable "tags" {
   type        = map(string)
   description = "Tags applied to created resources."


### PR DESCRIPTION
[AGENT]

## Summary
- Add a manual `Deploy Domain DNS (prod)` workflow for the Route53/Vercel domain stack.
- Keep merge behavior no-op: DNS changes require explicit `workflow_dispatch` in `plan` or `apply` mode plus the protected deploy environment gate.
- Document local Terraform adoption/apply and GitHub-hosted apply paths.

## Operational Notes
- Existing provider setup is ready: the deploy role has limited domain-state/Route53 permissions, and required repo variables are configured.
- No DNS records are created by this PR alone.

## Validation
- `terraform fmt -check -recursive`
- `terraform validate` for `infra/aws/prod` and `infra/aws/domain`
- `actionlint`
- `checkov --directory infra/aws --framework terraform`
- `npm run format:check`