### PR TITLE
Allow environment OIDC for domain deploy

### DIFF
--- a/infra/aws/prod/main.tf
+++ b/infra/aws/prod/main.tf
@@ -14,7 +14,9 @@ locals {
 
   github_oidc_subjects = distinct([
     "repo:${local.github_repo_owner}/${local.github_repo_name}:ref:refs/heads/main",
-    "repo:${lower(local.github_repo_owner)}/${lower(local.github_repo_name)}:ref:refs/heads/main"
+    "repo:${lower(local.github_repo_owner)}/${lower(local.github_repo_name)}:ref:refs/heads/main",
+    "repo:${local.github_repo_owner}/${local.github_repo_name}:environment:Deploy - web-prod",
+    "repo:${lower(local.github_repo_owner)}/${lower(local.github_repo_name)}:environment:Deploy - web-prod"
   ])
 
   github_oidc_provider_arn = var.github_oidc_provider_arn != null ? var.github_oidc_provider_arn : aws_iam_openid_connect_provider.github[0].arn


### PR DESCRIPTION
[AGENT]

## Summary
- Allow GitHub Actions OIDC tokens for the protected `Deploy - web-prod` environment to assume the existing deploy role.
- Preserve the existing main-branch `ref` subjects so current push deploys keep working.

## Operational Notes
- This fixes the failed `Deploy Domain DNS (prod)` plan run, which reached AWS credential setup and was denied by the role trust policy.
- No AWS trust-policy change happens from merging alone; `infra/aws/prod` still needs an explicit Terraform apply for the provider-side delta.