### PR TITLE
Keep domain backend workspace list scoped

### DIFF
--- a/.github/workflows/deploy-domain.yml
+++ b/.github/workflows/deploy-domain.yml
@@ -83,11 +83,12 @@ jobs:
         run: |
           set -euo pipefail
           cat > backend.ci.hcl <<EOF
-          bucket         = "${TERRAFORM_STATE_BUCKET}"
-          key            = "drasil/domain/terraform.tfstate"
-          region         = "${AWS_REGION}"
-          dynamodb_table = "${TERRAFORM_LOCK_TABLE}"
-          encrypt        = true
+          bucket               = "${TERRAFORM_STATE_BUCKET}"
+          key                  = "drasil/domain/terraform.tfstate"
+          region               = "${AWS_REGION}"
+          dynamodb_table       = "${TERRAFORM_LOCK_TABLE}"
+          workspace_key_prefix = "drasil/domain/workspaces"
+          encrypt              = true
           EOF
 
       - name: Terraform init

--- a/infra/aws/domain/backend.hcl.example
+++ b/infra/aws/domain/backend.hcl.example
@@ -1,7 +1,8 @@
 # Used by: terraform init -backend-config=backend.hcl
 
-bucket         = "REPLACE_ME"
-key            = "drasil/domain/terraform.tfstate"
-region         = "us-east-1"
-dynamodb_table = "drasil-terraform-locks"
-encrypt        = true
+bucket               = "REPLACE_ME"
+key                  = "drasil/domain/terraform.tfstate"
+region               = "us-east-1"
+dynamodb_table       = "drasil-terraform-locks"
+workspace_key_prefix = "drasil/domain/workspaces"
+encrypt              = true


### PR DESCRIPTION
[AGENT]

## Summary
- Set `workspace_key_prefix` for the domain Terraform backend under `drasil/domain/workspaces`.
- Keep Terraform backend workspace listing within the S3 prefix already granted to the deploy role.
- Mirror the setting in the local backend example.

## Operational Notes
- This fixes the latest domain plan failure at `terraform init`, where Terraform tried to list backend workspaces outside the allowed prefix.
- No DNS changes or AWS mutations happen from this PR alone.
