### PR TITLE
Refresh case notifications and improve evidence mirroring

### DIFF
--- a/src/__tests__/integration/SecurityActionService.integration.test.ts
+++ b/src/__tests__/integration/SecurityActionService.integration.test.ts
@@ -71,6 +71,7 @@ describeIntegration('SecurityActionService (integration)', () => {
       handleHistoryButtonClick: jest.fn().mockResolvedValue(true),
       updateNotificationButtons: jest.fn().mockResolvedValue(undefined),
       updateVerificationThreadAnalysis: jest.fn().mockResolvedValue(true),
+      mirrorVerificationThreadMessageToEvidenceThread: jest.fn().mockResolvedValue(false),
       upsertObservedDetectionNotification: jest
         .fn()
         .mockResolvedValue({ id: 'observe-1' } as Message),

--- a/src/__tests__/integration/UserModerationService.integration.test.ts
+++ b/src/__tests__/integration/UserModerationService.integration.test.ts
@@ -69,6 +69,7 @@ describeIntegration('UserModerationService (integration)', () => {
       handleHistoryButtonClick: jest.fn().mockResolvedValue(true),
       updateNotificationButtons: jest.fn().mockResolvedValue(undefined),
       updateVerificationThreadAnalysis: jest.fn().mockResolvedValue(true),
+      mirrorVerificationThreadMessageToEvidenceThread: jest.fn().mockResolvedValue(false),
       upsertObservedDetectionNotification: jest.fn().mockResolvedValue({} as any),
       markObservedDetectionActionTaken: jest.fn().mockResolvedValue(true),
       restoreObservedDetectionActions: jest.fn().mockResolvedValue(true),

--- a/src/__tests__/unit/CommandHandler.case.unit.test.ts
+++ b/src/__tests__/unit/CommandHandler.case.unit.test.ts
@@ -231,6 +231,105 @@ describe('CommandHandler case commands (unit)', () => {
     );
   });
 
+  it('refreshes the latest case notification via /case refresh', async () => {
+    const refreshCaseNotification = jest.fn().mockResolvedValue({
+      refreshed: true,
+      message: 'Refreshed verified case notification for target#0001.',
+      verificationEventId: 'ver-1',
+      status: 'verified',
+      notificationChannelId: 'channel-1',
+      notificationMessageId: 'message-1',
+    });
+    const { handler, securityActionService } = buildHandler({ refreshCaseNotification });
+    const invoker = { id: 'admin-1' } as any;
+    const targetUser = { id: 'user-2', tag: 'target#0001' } as any;
+    const guild = {
+      id: 'guild-1',
+      members: {
+        fetch: jest
+          .fn()
+          .mockResolvedValue({ permissions: { has: jest.fn().mockReturnValue(true) } }),
+      },
+    } as any;
+    const interaction = {
+      commandName: 'case',
+      user: invoker,
+      guild,
+      memberPermissions: { has: jest.fn().mockReturnValue(true) },
+      options: {
+        getSubcommand: jest.fn().mockReturnValue('refresh'),
+        getUser: jest.fn().mockReturnValue(targetUser),
+        getString: jest.fn().mockReturnValue(undefined),
+      },
+      deferReply: jest.fn().mockResolvedValue(undefined),
+      editReply: jest.fn().mockResolvedValue(undefined),
+      reply: jest.fn().mockResolvedValue(undefined),
+    } as any;
+
+    await handler.handleSlashCommand(interaction);
+
+    expect(interaction.deferReply).toHaveBeenCalledWith({ flags: MessageFlags.Ephemeral });
+    expect(securityActionService.refreshCaseNotification).toHaveBeenCalledWith(
+      'guild-1',
+      targetUser,
+      undefined
+    );
+    expect(interaction.editReply).toHaveBeenCalledWith({
+      content: expect.stringContaining('Refreshed verified case notification'),
+      allowedMentions: { parse: [] },
+    });
+    expect(interaction.editReply.mock.calls[0][0].content).toContain(
+      'https://discord.com/channels/guild-1/channel-1/message-1'
+    );
+  });
+
+  it('refreshes a specific case notification via /case refresh case-id', async () => {
+    const refreshCaseNotification = jest.fn().mockResolvedValue({
+      refreshed: false,
+      message: 'Case ver-older has no stored notification message to refresh.',
+      verificationEventId: 'ver-older',
+      status: 'verified',
+      notificationChannelId: null,
+      notificationMessageId: null,
+    });
+    const { handler, securityActionService } = buildHandler({ refreshCaseNotification });
+    const targetUser = { id: 'user-2', tag: 'target#0001' } as any;
+    const guild = {
+      id: 'guild-1',
+      members: {
+        fetch: jest
+          .fn()
+          .mockResolvedValue({ permissions: { has: jest.fn().mockReturnValue(true) } }),
+      },
+    } as any;
+    const interaction = {
+      commandName: 'case',
+      user: { id: 'admin-1' } as any,
+      guild,
+      memberPermissions: { has: jest.fn().mockReturnValue(true) },
+      options: {
+        getSubcommand: jest.fn().mockReturnValue('refresh'),
+        getUser: jest.fn().mockReturnValue(targetUser),
+        getString: jest.fn().mockReturnValue('ver-older'),
+      },
+      deferReply: jest.fn().mockResolvedValue(undefined),
+      editReply: jest.fn().mockResolvedValue(undefined),
+      reply: jest.fn().mockResolvedValue(undefined),
+    } as any;
+
+    await handler.handleSlashCommand(interaction);
+
+    expect(securityActionService.refreshCaseNotification).toHaveBeenCalledWith(
+      'guild-1',
+      targetUser,
+      'ver-older'
+    );
+    expect(interaction.editReply.mock.calls[0][0].content).toContain('Case: `ver-older`');
+    expect(interaction.editReply.mock.calls[0][0].content).not.toContain(
+      'https://discord.com/channels/'
+    );
+  });
+
   it('dry-runs restricted role intake via /case intake-role', async () => {
     const intakeRoleMembers = jest.fn().mockResolvedValue({
       batchId: 'role-intake-1',

--- a/src/__tests__/unit/CommandHandler.case.unit.test.ts
+++ b/src/__tests__/unit/CommandHandler.case.unit.test.ts
@@ -330,6 +330,51 @@ describe('CommandHandler case commands (unit)', () => {
     );
   });
 
+  it('returns a failure reply when /case refresh fails after deferring', async () => {
+    const refreshCaseNotification = jest
+      .fn()
+      .mockRejectedValue(new Error('notification channel fetch failed'));
+    const consoleError = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+    const { handler } = buildHandler({ refreshCaseNotification });
+    const targetUser = { id: 'user-2', tag: 'target#0001' } as any;
+    const guild = {
+      id: 'guild-1',
+      members: {
+        fetch: jest
+          .fn()
+          .mockResolvedValue({ permissions: { has: jest.fn().mockReturnValue(true) } }),
+      },
+    } as any;
+    const interaction = {
+      commandName: 'case',
+      user: { id: 'admin-1' } as any,
+      guild,
+      memberPermissions: { has: jest.fn().mockReturnValue(true) },
+      options: {
+        getSubcommand: jest.fn().mockReturnValue('refresh'),
+        getUser: jest.fn().mockReturnValue(targetUser),
+        getString: jest.fn().mockReturnValue('ver-1'),
+      },
+      deferReply: jest.fn().mockResolvedValue(undefined),
+      editReply: jest.fn().mockResolvedValue(undefined),
+      reply: jest.fn().mockResolvedValue(undefined),
+    } as any;
+
+    await handler.handleSlashCommand(interaction);
+
+    expect(interaction.deferReply).toHaveBeenCalledWith({ flags: MessageFlags.Ephemeral });
+    expect(interaction.editReply).toHaveBeenCalledWith({
+      content:
+        'Failed to refresh case notification for target#0001: notification channel fetch failed',
+      allowedMentions: { parse: [] },
+    });
+    expect(consoleError).toHaveBeenCalledWith(
+      'Failed to refresh case notification:',
+      expect.any(Error)
+    );
+    consoleError.mockRestore();
+  });
+
   it('dry-runs restricted role intake via /case intake-role', async () => {
     const intakeRoleMembers = jest.fn().mockResolvedValue({
       batchId: 'role-intake-1',

--- a/src/__tests__/unit/CommandHandler.catalog.unit.test.ts
+++ b/src/__tests__/unit/CommandHandler.catalog.unit.test.ts
@@ -237,6 +237,7 @@ describe('CommandHandler command catalog (unit)', () => {
     expect(caseCommand.options.map((option: any) => option.name)).toEqual([
       'open',
       'repair',
+      'refresh',
       'intake-role',
     ]);
 
@@ -245,6 +246,9 @@ describe('CommandHandler command catalog (unit)', () => {
 
     const repair = caseCommand.options.find((option: any) => option.name === 'repair');
     expect(repair.options.map((option: any) => option.name)).toEqual(['user']);
+
+    const refresh = caseCommand.options.find((option: any) => option.name === 'refresh');
+    expect(refresh.options.map((option: any) => option.name)).toEqual(['user', 'case-id']);
 
     const intakeRole = caseCommand.options.find((option: any) => option.name === 'intake-role');
     expect(intakeRole.options.map((option: any) => option.name)).toEqual([

--- a/src/__tests__/unit/InteractionHandler.unit.test.ts
+++ b/src/__tests__/unit/InteractionHandler.unit.test.ts
@@ -257,6 +257,7 @@ describe('InteractionHandler (unit)', () => {
       handleHistoryButtonClick: jest.fn().mockResolvedValue(true),
       updateNotificationButtons: jest.fn().mockResolvedValue(undefined),
       updateVerificationThreadAnalysis: jest.fn().mockResolvedValue(true),
+      mirrorVerificationThreadMessageToEvidenceThread: jest.fn().mockResolvedValue(false),
       upsertObservedDetectionNotification: jest.fn().mockResolvedValue(null),
       markObservedDetectionActionTaken: jest.fn().mockResolvedValue(true),
       restoreObservedDetectionActions: jest.fn().mockResolvedValue(true),
@@ -405,6 +406,34 @@ describe('InteractionHandler (unit)', () => {
       flags: MessageFlags.Ephemeral,
       allowedMentions: { parse: [] },
     });
+  });
+
+  it.each([
+    ['restrict_user-1', 'Restrict <@user-1> while keeping their case pending?'],
+    [
+      'close_user-1',
+      'Close pending verification cases for <@user-1> without verifying or banning them? If Drasil has them marked restricted, the restricted role will be removed.',
+    ],
+  ])('opens an ephemeral confirmation for persistent %s button', async (customId, message) => {
+    const handler = new InteractionHandler(
+      client,
+      notificationManager,
+      userModerationService,
+      securityActionService,
+      configService,
+      verificationEventRepository,
+      threadManager,
+      adminActionRepository
+    );
+    const interaction = buildInteraction(customId, 'guild-1', { id: 'admin-1' } as User);
+    grantInteractionPermissions(interaction);
+
+    await handler.handleButtonInteraction(interaction);
+
+    expect(interaction.reply).toHaveBeenCalledWith(
+      expect.objectContaining({ content: message, flags: MessageFlags.Ephemeral })
+    );
+    expect(interaction.update).not.toHaveBeenCalled();
   });
 
   it('handles lift-restriction case action without resolving the case', async () => {

--- a/src/__tests__/unit/InteractionHandler.unit.test.ts
+++ b/src/__tests__/unit/InteractionHandler.unit.test.ts
@@ -223,6 +223,10 @@ describe('InteractionHandler (unit)', () => {
         restrictionAttempted: false,
         restricted: false,
       }),
+      refreshCaseNotification: jest.fn().mockResolvedValue({
+        refreshed: true,
+        message: 'Refreshed pending case notification for test-user#0001.',
+      }),
       repairActiveCase: jest.fn().mockResolvedValue({
         repaired: true,
         message: 'Repaired active verification case for test-user#0001.',

--- a/src/__tests__/unit/NotificationManager.unit.test.ts
+++ b/src/__tests__/unit/NotificationManager.unit.test.ts
@@ -1,5 +1,6 @@
 import {
   ChannelType,
+  Collection,
   EmbedBuilder,
   Guild,
   GuildMember,
@@ -20,7 +21,6 @@ import {
 import { IConfigService } from '../../config/ConfigService';
 import { VERIFICATION_ACTION_FAILURES_METADATA_KEY } from '../../utils/verificationActionFailures';
 import { MODERATOR_BAN_ACTION_ENABLED_SETTING_KEY } from '../../utils/detectionResponseSettings';
-import { parseAdminActionCustomId } from '../../utils/adminActionCustomIds';
 
 type MockTextChannel = {
   send: jest.Mock;
@@ -207,12 +207,14 @@ describe('NotificationManager (unit)', () => {
       repliedUser: false,
     });
     const labels = extractLabels(sendArgs.components);
-    expect(labels).toEqual(['Admin Actions']);
-    expect(parseAdminActionCustomId(extractCustomIds(sendArgs.components)[0])).toEqual({
-      action: 'menu',
-      surface: 'case',
-      userId: 'user-1',
-    });
+    expect(labels).toEqual(['Verify', 'Restrict', 'Ban...', 'Close', 'Other Actions']);
+    expect(extractCustomIds(sendArgs.components)).toEqual([
+      'verify_user-1',
+      'restrict_user-1',
+      'ban_user-1',
+      'close_user-1',
+      'admin_actions:m:c:user-1',
+    ]);
   });
 
   it('adds a web case button to suspicious user notifications when configured', async () => {
@@ -241,7 +243,14 @@ describe('NotificationManager (unit)', () => {
     );
 
     const sendArgs = adminChannel.send.mock.calls[0][0] as { components: unknown[] };
-    expect(extractLabels(sendArgs.components)).toEqual(['Admin Actions', 'Web Case']);
+    expect(extractLabels(sendArgs.components)).toEqual([
+      'Verify',
+      'Restrict',
+      'Ban...',
+      'Close',
+      'Other Actions',
+      'Web Case',
+    ]);
     expect(extractUrls(sendArgs.components)).toEqual([
       'https://drasilbot.com/admin/guild/guild-1/cases/ver-1',
     ]);
@@ -276,7 +285,7 @@ describe('NotificationManager (unit)', () => {
     );
 
     const sendArgs = adminChannel.send.mock.calls[0][0] as { components: unknown[] };
-    expect(extractLabels(sendArgs.components)).not.toContain('Ban User');
+    expect(extractLabels(sendArgs.components)).not.toContain('Ban...');
   });
 
   it('renders moderation action warnings on suspicious user notifications', async () => {
@@ -480,12 +489,13 @@ describe('NotificationManager (unit)', () => {
       repliedUser: false,
     });
     expect(sendArgs.components).toHaveLength(1);
-    expect(parseAdminActionCustomId(extractCustomIds(sendArgs.components)[0])).toEqual({
-      action: 'menu',
-      surface: 'observed',
-      userId: 'user-1',
-      detectionEventId: detectionEvent.id,
-    });
+    expect(extractLabels(sendArgs.components)).toEqual([
+      'Open Case',
+      'Restrict',
+      'Ban...',
+      'Dismiss',
+      'Other Actions',
+    ]);
     expect(sendArgs.embeds[0].data.title).toBe('Suspicious Activity Observed');
     const fields = sendArgs.embeds[0].data.fields ?? [];
     const reasonsField = fields.find((field) => field.name === 'Reasons');
@@ -686,7 +696,13 @@ describe('NotificationManager (unit)', () => {
     );
 
     const editArgs = message.edit.mock.calls[0][0] as { components: unknown[] };
-    expect(extractLabels(editArgs.components)).toEqual(['Admin Actions']);
+    expect(extractLabels(editArgs.components)).toEqual([
+      'Open Case',
+      'Restrict',
+      'Ban...',
+      'Dismiss',
+      'Other Actions',
+    ]);
   });
 
   it('restores observed action buttons after undo', async () => {
@@ -723,7 +739,13 @@ describe('NotificationManager (unit)', () => {
       components: unknown[];
       embeds: EmbedBuilder[];
     };
-    expect(extractLabels(editArgs.components)).toEqual(['Admin Actions']);
+    expect(extractLabels(editArgs.components)).toEqual([
+      'Open Case',
+      'Restrict',
+      'Ban...',
+      'Dismiss',
+      'Other Actions',
+    ]);
     expect(editArgs.embeds[0].data.fields?.[0].name).toBe('Action Reverted');
   });
 
@@ -803,7 +825,7 @@ describe('NotificationManager (unit)', () => {
     expect(editArgs.content).toBeUndefined();
     expect(editArgs.allowedMentions).toEqual({ parse: [] });
     const labels = extractLabels(editArgs.components);
-    expect(labels).toEqual(['Admin Actions']);
+    expect(labels).toEqual(['Verify', 'Restrict', 'Ban...', 'Close', 'Other Actions']);
   });
 
   it('updates notification buttons for pending status with thread action', async () => {
@@ -825,7 +847,7 @@ describe('NotificationManager (unit)', () => {
     expect(message.edit).toHaveBeenCalledTimes(1);
     const editArgs = message.edit.mock.calls[0][0] as { components: unknown[] };
     const labels = extractLabels(editArgs.components);
-    expect(labels).toEqual(['Admin Actions']);
+    expect(labels).toEqual(['Verify', 'Restrict', 'Ban...', 'Close', 'Other Actions']);
   });
 
   it('updates notification buttons from stored notification channel', async () => {
@@ -914,7 +936,7 @@ describe('NotificationManager (unit)', () => {
     expect(message.edit).toHaveBeenCalledTimes(1);
     const editArgs = message.edit.mock.calls[0][0] as { components: unknown[] };
     const labels = extractLabels(editArgs.components);
-    expect(labels).toEqual(['Admin Actions']);
+    expect(labels).toEqual(['Reopen', 'History', 'Other Actions']);
   });
 
   it('reapplies resolved case presentation while updating buttons', async () => {
@@ -1023,6 +1045,46 @@ describe('NotificationManager (unit)', () => {
     );
     expect(analysisField?.value).toContain('Legitimacy: Specific server context matched');
     expect(analysisField?.value).not.toContain('Reason codes: normal_context');
+  });
+
+  it('mirrors verification-thread user replies into the private evidence thread', async () => {
+    const evidenceThread = { send: jest.fn().mockResolvedValue({}) };
+    const client = {
+      channels: {
+        fetch: jest.fn().mockResolvedValue(evidenceThread),
+      },
+    };
+    const manager = new NotificationManager(client as any, configService, detectionRepository);
+    const message = {
+      id: 'msg-1',
+      channelId: 'thread-1',
+      content: 'I joined for weekly races. ```not a real fence```',
+      url: 'https://discord.com/channels/guild-1/thread-1/msg-1',
+      author: { id: 'user-1', username: 'runner', tag: 'runner#0001' },
+      attachments: new Collection<string, any>([
+        [
+          'attachment-1',
+          { id: 'attachment-1', name: 'proof.png', url: 'https://cdn.example/proof.png' },
+        ],
+      ]),
+    } as Message;
+
+    const mirrored = await manager.mirrorVerificationThreadMessageToEvidenceThread(
+      buildVerificationEvent({ private_evidence_thread_id: 'evidence-thread-1' }),
+      message
+    );
+
+    expect(mirrored).toBe(true);
+    expect(client.channels.fetch).toHaveBeenCalledWith('evidence-thread-1');
+    expect(evidenceThread.send).toHaveBeenCalledWith({
+      content:
+        'Support-check reply from <@user-1> (runner#0001).\n' +
+        'Source: https://discord.com/channels/guild-1/thread-1/msg-1\n\n' +
+        "```\nI joined for weekly races. ''' not a real fence''' \n```\n\n" +
+        'Attachments:\n' +
+        '- proof.png: https://cdn.example/proof.png',
+      allowedMentions: { parse: [], roles: [], users: [], repliedUser: false },
+    });
   });
 
   it('displays fallback GPT diagnostics as unavailable', async () => {

--- a/src/__tests__/unit/NotificationManager.unit.test.ts
+++ b/src/__tests__/unit/NotificationManager.unit.test.ts
@@ -917,6 +917,37 @@ describe('NotificationManager (unit)', () => {
     expect(labels).toEqual(['Admin Actions']);
   });
 
+  it('reapplies resolved case presentation while updating buttons', async () => {
+    const embed = new EmbedBuilder().setTitle('Suspicious User').setColor(0xff0000);
+    const message: MockMessage = {
+      embeds: [embed],
+      edit: jest.fn().mockResolvedValue(undefined),
+    };
+    adminChannel.messages.fetch.mockResolvedValue(message as unknown as Message<true>);
+
+    const manager = new NotificationManager({} as any, configService, detectionRepository);
+    const verificationEvent = buildVerificationEvent({
+      notification_message_id: 'message-verified',
+      status: VerificationStatus.VERIFIED,
+      resolved_by: 'admin-1',
+      resolved_at: new Date('2026-06-12T15:04:12Z'),
+    });
+
+    await manager.updateNotificationButtons(verificationEvent, VerificationStatus.VERIFIED);
+
+    const editArgs = message.edit.mock.calls[0][0] as { embeds: EmbedBuilder[] };
+    const updatedEmbed = editArgs.embeds[0];
+    const fields = updatedEmbed.data.fields ?? [];
+    expect(updatedEmbed.data.title).toBe('Case Handled: Verified');
+    expect(updatedEmbed.data.color).toBe(0x00ff00);
+    expect(fields.find((field) => field.name === 'Resolution')?.value).toBe(
+      'Verified by <@admin-1> at <t:1781276652:F>\nNo further moderator action is pending.'
+    );
+    expect(fields.find((field) => field.name === 'Latest Admin Action')?.value).toBe(
+      'Verified by <@admin-1> at <t:1781276652:F>'
+    );
+  });
+
   it('logs action and adds a thread field for create thread', async () => {
     const embed = new EmbedBuilder().setTitle('Suspicious User');
     const message: MockMessage = {

--- a/src/__tests__/unit/NotificationManager.unit.test.ts
+++ b/src/__tests__/unit/NotificationManager.unit.test.ts
@@ -147,6 +147,8 @@ describe('NotificationManager (unit)', () => {
   });
 
   afterEach(() => {
+    jest.restoreAllMocks();
+
     if (originalDrasilWebPublicUrl === undefined) {
       delete process.env.DRASIL_WEB_PUBLIC_URL;
     } else {
@@ -1049,6 +1051,11 @@ describe('NotificationManager (unit)', () => {
 
   it('mirrors verification-thread user replies into the private evidence thread', async () => {
     const evidenceThread = { send: jest.fn().mockResolvedValue({}) };
+    const imageBytes = Uint8Array.from([1, 2, 3]);
+    const fetchImage = jest.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      arrayBuffer: jest.fn().mockResolvedValue(imageBytes.buffer),
+    } as unknown as Response);
     const client = {
       channels: {
         fetch: jest.fn().mockResolvedValue(evidenceThread),
@@ -1064,7 +1071,14 @@ describe('NotificationManager (unit)', () => {
       attachments: new Collection<string, any>([
         [
           'attachment-1',
-          { id: 'attachment-1', name: 'proof.png', url: 'https://cdn.example/proof.png' },
+          {
+            id: 'attachment-1',
+            name: 'proof.png',
+            url: 'https://cdn.example/proof.png',
+            proxyURL: 'https://media.discordapp.net/proof.png',
+            contentType: 'image/png',
+            size: imageBytes.byteLength,
+          },
         ],
       ]),
     } as Message;
@@ -1076,15 +1090,18 @@ describe('NotificationManager (unit)', () => {
 
     expect(mirrored).toBe(true);
     expect(client.channels.fetch).toHaveBeenCalledWith('evidence-thread-1');
+    expect(fetchImage).toHaveBeenCalledWith('https://media.discordapp.net/proof.png');
     expect(evidenceThread.send).toHaveBeenCalledWith({
       content:
         'Support-check reply from <@user-1> (runner#0001).\n' +
         'Source: https://discord.com/channels/guild-1/thread-1/msg-1\n\n' +
         "```\nI joined for weekly races. ''' not a real fence''' \n```\n\n" +
         'Attachments:\n' +
-        '- proof.png: https://cdn.example/proof.png',
+        '- proof.png (copied below as a spoilered image)',
+      files: [{ attachment: Buffer.from(imageBytes), name: 'SPOILER_proof.png' }],
       allowedMentions: { parse: [], roles: [], users: [], repliedUser: false },
     });
+    fetchImage.mockRestore();
   });
 
   it('displays fallback GPT diagnostics as unavailable', async () => {

--- a/src/__tests__/unit/NotificationPresentationBuilder.unit.test.ts
+++ b/src/__tests__/unit/NotificationPresentationBuilder.unit.test.ts
@@ -197,6 +197,38 @@ describe('NotificationPresentationBuilder (unit)', () => {
     );
   });
 
+  it('clears stale handled presentation when refreshing a pending case', () => {
+    const embed = new EmbedBuilder()
+      .setTitle('Case Handled: Verified')
+      .setDescription('<@user-1> has been handled. No further moderator action is pending.')
+      .setColor(0x00ff00)
+      .addFields(
+        {
+          name: 'Resolution',
+          value:
+            'Verified by <@admin-1> at <t:1767571200:F>\nNo further moderator action is pending.',
+          inline: false,
+        },
+        { name: 'User ID', value: 'user-1', inline: true },
+        { name: 'Trigger', value: 'Flagged via user report: `scam DM`', inline: false },
+        { name: 'Latest Admin Action', value: 'Reopened by <@admin-2>', inline: false },
+        { name: 'Action Log', value: 'Reopened by <@admin-2>', inline: false }
+      );
+
+    builder.upsertResolvedCasePresentation(
+      embed,
+      buildVerificationEvent({ status: VerificationStatus.PENDING }),
+      VerificationStatus.PENDING
+    );
+
+    expect(embed.data.title).toBe('User Report Submitted');
+    expect(embed.data.description).toBe('<@user-1> has been flagged as suspicious.');
+    expect(embed.data.color).toBe(0xff0000);
+    expect(getField(embed, 'Resolution')).toBeUndefined();
+    expect(getField(embed, 'Latest Admin Action')).toBe('Reopened by <@admin-2>');
+    expect(getField(embed, 'Action Log')).toBe('Reopened by <@admin-2>');
+  });
+
   it('uses specific pending titles for reports and admin-opened cases', () => {
     const reportEmbed = builder.createSuspiciousUserEmbed(
       buildMember(),

--- a/src/__tests__/unit/NotificationPresentationBuilder.unit.test.ts
+++ b/src/__tests__/unit/NotificationPresentationBuilder.unit.test.ts
@@ -215,30 +215,74 @@ describe('NotificationPresentationBuilder (unit)', () => {
     expect(adminCaseEmbed.data.title).toBe('Admin Review Case Opened');
   });
 
-  it('adds optional web links to action rows when a public web URL is configured', () => {
+  it('keeps user-facing case prompts behind the compact admin actions entry point', () => {
+    const row = builder.createActionRow('user-1');
+    const buttons = row.toJSON().components as Array<{ label?: string; custom_id?: string }>;
+
+    expect(buttons.map((button) => button.label)).toEqual(['Admin Actions']);
+    expect(buttons[0].custom_id).toBe('admin_actions:m:c:user-1');
+  });
+
+  it('adds primary admin actions and optional web links to admin notification rows', () => {
     process.env.DRASIL_WEB_PUBLIC_URL = 'https://drasilbot.com';
     delete process.env.NEXT_PUBLIC_APP_URL;
 
-    const caseRow = builder.createActionRow('user-1', {
+    const caseRows = builder.createAdminNotificationActionRows('user-1', {
       guildId: 'guild-1',
       verificationEventId: 'ver-1',
     });
     const observedRows = builder.createObservedActionRows('user-1', 'det-1', 'guild-1');
 
-    const caseButtons = caseRow.toJSON().components as Array<{ label?: string; url?: string }>;
-    const observedButtons = observedRows[0].toJSON().components as Array<{
-      label?: string;
-      url?: string;
-    }>;
+    const caseButtons = caseRows.flatMap(
+      (row) => row.toJSON().components as Array<{ label?: string; url?: string }>
+    );
+    const observedButtons = observedRows.flatMap(
+      (row) => row.toJSON().components as Array<{ label?: string; url?: string }>
+    );
 
-    expect(caseButtons.map((button) => button.label)).toEqual(['Admin Actions', 'Web Case']);
-    expect(caseButtons[1]).toMatchObject({
+    expect(caseButtons.map((button) => button.label)).toEqual([
+      'Verify',
+      'Restrict',
+      'Ban...',
+      'Close',
+      'Other Actions',
+      'Web Case',
+    ]);
+    expect(caseButtons[5]).toMatchObject({
       url: 'https://drasilbot.com/admin/guild/guild-1/cases/ver-1',
     });
-    expect(observedButtons.map((button) => button.label)).toEqual(['Admin Actions', 'Web Queue']);
-    expect(observedButtons[1]).toMatchObject({
+    expect(observedButtons.map((button) => button.label)).toEqual([
+      'Open Case',
+      'Restrict',
+      'Ban...',
+      'Dismiss',
+      'Other Actions',
+      'Web Queue',
+    ]);
+    expect(observedButtons[5]).toMatchObject({
       url: 'https://drasilbot.com/admin/guild/guild-1/cases',
     });
+  });
+
+  it('uses resolved-case admin notification rows after a case is handled', () => {
+    process.env.DRASIL_WEB_PUBLIC_URL = 'https://drasilbot.com';
+
+    const rows = builder.createAdminNotificationActionRows('user-1', {
+      guildId: 'guild-1',
+      verificationEventId: 'ver-1',
+      verificationStatus: VerificationStatus.VERIFIED,
+    });
+    const buttons = rows.flatMap(
+      (row) => row.toJSON().components as Array<{ label?: string; custom_id?: string }>
+    );
+
+    expect(buttons.map((button) => button.label)).toEqual([
+      'Reopen',
+      'History',
+      'Other Actions',
+      'Web Case',
+    ]);
+    expect(buttons[0].custom_id).toBe('reopen_user-1');
   });
 
   it('adds and removes moderation action failure warnings', () => {

--- a/src/__tests__/unit/SecurityActionService.unit.test.ts
+++ b/src/__tests__/unit/SecurityActionService.unit.test.ts
@@ -693,6 +693,74 @@ describe('SecurityActionService (unit)', () => {
     }
   });
 
+  it('refreshes the latest resolved case notification from stored state', async () => {
+    const member = buildMember('guild-1', 'user-refresh');
+    const pendingEvent = await verificationEventRepository.createFromDetection(
+      null,
+      member.guild.id,
+      member.id,
+      VerificationStatus.PENDING
+    );
+    await verificationEventRepository.update(pendingEvent.id, {
+      ...pendingEvent,
+      notification_channel_id: 'channel-old',
+      notification_message_id: 'message-old',
+    });
+    const latestEvent = await verificationEventRepository.createFromDetection(
+      null,
+      member.guild.id,
+      member.id,
+      VerificationStatus.PENDING
+    );
+    const verifiedEvent = await verificationEventRepository.update(latestEvent.id, {
+      ...latestEvent,
+      status: VerificationStatus.VERIFIED,
+      resolved_by: 'admin-1',
+      resolved_at: new Date('2026-06-12T15:04:12Z'),
+      notification_channel_id: 'channel-new',
+      notification_message_id: 'message-new',
+    });
+
+    const result = await buildService().refreshCaseNotification(member.guild.id, member.user);
+
+    expect(result).toMatchObject({
+      refreshed: true,
+      verificationEventId: latestEvent.id,
+      status: VerificationStatus.VERIFIED,
+      notificationChannelId: 'channel-new',
+      notificationMessageId: 'message-new',
+    });
+    expect(notificationManager.updateNotificationButtons).toHaveBeenCalledWith(
+      verifiedEvent,
+      VerificationStatus.VERIFIED
+    );
+  });
+
+  it('does not refresh a case without a stored notification message', async () => {
+    const member = buildMember('guild-1', 'user-no-notification');
+    const verificationEvent = await verificationEventRepository.createFromDetection(
+      null,
+      member.guild.id,
+      member.id,
+      VerificationStatus.PENDING
+    );
+
+    const result = await buildService().refreshCaseNotification(
+      member.guild.id,
+      member.user,
+      verificationEvent.id
+    );
+
+    expect(result).toMatchObject({
+      refreshed: false,
+      verificationEventId: verificationEvent.id,
+      status: VerificationStatus.PENDING,
+      notificationMessageId: null,
+    });
+    expect(result.message).toContain('no stored notification message');
+    expect(notificationManager.updateNotificationButtons).not.toHaveBeenCalled();
+  });
+
   it('does not repair moderator-only report review threads as user-facing threads', async () => {
     const guildId = 'guild-case-repair-report-review';
     const userId = 'user-case-repair-report-review';

--- a/src/__tests__/unit/SecurityActionService.unit.test.ts
+++ b/src/__tests__/unit/SecurityActionService.unit.test.ts
@@ -68,6 +68,7 @@ describe('SecurityActionService (unit)', () => {
       handleHistoryButtonClick: jest.fn().mockResolvedValue(true),
       updateNotificationButtons: jest.fn().mockResolvedValue(undefined),
       updateVerificationThreadAnalysis: jest.fn().mockResolvedValue(true),
+      mirrorVerificationThreadMessageToEvidenceThread: jest.fn().mockResolvedValue(false),
       upsertObservedDetectionNotification: jest
         .fn()
         .mockResolvedValue({ id: 'observe-1' } as Message),

--- a/src/__tests__/unit/ThreadManager.unit.test.ts
+++ b/src/__tests__/unit/ThreadManager.unit.test.ts
@@ -165,6 +165,15 @@ describe('ThreadManager (unit)', () => {
         roles: [],
         repliedUser: false,
       },
+      components: expect.any(Array),
+    });
+    const prompt = thread.send.mock.calls[0][0] as { components: unknown[] };
+    const customIds = extractComponentCustomIds(prompt.components);
+    expect(customIds).toHaveLength(1);
+    expect(parseAdminActionCustomId(customIds[0])).toEqual({
+      surface: 'case',
+      action: 'menu',
+      userId: member.id,
     });
   });
 
@@ -376,6 +385,15 @@ describe('ThreadManager (unit)', () => {
         roles: [],
         repliedUser: false,
       },
+      components: expect.any(Array),
+    });
+    const prompt = thread.send.mock.calls[0][0] as { components: unknown[] };
+    const customIds = extractComponentCustomIds(prompt.components);
+    expect(customIds).toHaveLength(1);
+    expect(parseAdminActionCustomId(customIds[0])).toEqual({
+      surface: 'case',
+      action: 'menu',
+      userId: member.id,
     });
     expect(result).toEqual({
       threadId: 'thread-1',
@@ -485,6 +503,7 @@ describe('ThreadManager (unit)', () => {
         roles: [],
         repliedUser: false,
       },
+      components: expect.any(Array),
     });
   });
 
@@ -832,6 +851,7 @@ describe('ThreadManager (unit)', () => {
           roles: [],
           repliedUser: false,
         },
+        components: expect.any(Array),
       });
       expect(warnSpy).toHaveBeenCalled();
     } finally {
@@ -979,6 +999,12 @@ describe('ThreadManager (unit)', () => {
     expect(thread.setLocked).toHaveBeenCalledWith(true);
     expect(evidenceThread.setArchived).toHaveBeenCalledWith(true);
     expect(evidenceThread.setLocked).toHaveBeenCalledWith(true);
+    expect(thread.setLocked.mock.invocationCallOrder[0]).toBeLessThan(
+      thread.setArchived.mock.invocationCallOrder[0]
+    );
+    expect(evidenceThread.setLocked.mock.invocationCallOrder[0]).toBeLessThan(
+      evidenceThread.setArchived.mock.invocationCallOrder[0]
+    );
   });
 
   it('reopens verification thread when available', async () => {
@@ -1007,5 +1033,11 @@ describe('ThreadManager (unit)', () => {
     expect(thread.setLocked).toHaveBeenCalledWith(false);
     expect(evidenceThread.setArchived).toHaveBeenCalledWith(false);
     expect(evidenceThread.setLocked).toHaveBeenCalledWith(false);
+    expect(thread.setArchived.mock.invocationCallOrder[0]).toBeLessThan(
+      thread.setLocked.mock.invocationCallOrder[0]
+    );
+    expect(evidenceThread.setArchived.mock.invocationCallOrder[0]).toBeLessThan(
+      evidenceThread.setLocked.mock.invocationCallOrder[0]
+    );
   });
 });

--- a/src/__tests__/unit/ThreadManager.unit.test.ts
+++ b/src/__tests__/unit/ThreadManager.unit.test.ts
@@ -61,6 +61,13 @@ const extractComponentCustomIds = (components: unknown[]): string[] =>
     )
   );
 
+const extractComponentLabels = (components: unknown[]): string[] =>
+  components.flatMap((row) =>
+    ((row as { components?: unknown[] }).components ?? []).map(
+      (component) => (component as { data?: { label?: string } }).data?.label ?? ''
+    )
+  );
+
 const buildThread = (id = 'thread-1'): jest.Mocked<ThreadChannel> =>
   ({
     id,
@@ -558,11 +565,13 @@ describe('ThreadManager (unit)', () => {
       components: expect.any(Array),
     });
     const prompt = thread.send.mock.calls[0][0] as { components: unknown[] };
-    expect(parseAdminActionCustomId(extractComponentCustomIds(prompt.components)[0])).toEqual({
-      surface: 'case',
-      action: 'menu',
-      userId: 'user-1',
-    });
+    expect(extractComponentLabels(prompt.components)).toEqual([
+      'Verify',
+      'Restrict',
+      'Ban...',
+      'Close',
+      'Other Actions',
+    ]);
   });
 
   it('keeps a created report review thread linked when prompt send fails', async () => {
@@ -654,11 +663,13 @@ describe('ThreadManager (unit)', () => {
       })
     );
     const prompt = thread.send.mock.calls[0][0] as { components: unknown[] };
-    expect(parseAdminActionCustomId(extractComponentCustomIds(prompt.components)[0])).toEqual({
-      surface: 'case',
-      action: 'menu',
-      userId: 'user-1',
-    });
+    expect(extractComponentLabels(prompt.components)).toEqual([
+      'Verify',
+      'Restrict',
+      'Ban...',
+      'Close',
+      'Other Actions',
+    ]);
   });
 
   it('recovers an already-attached admin evidence thread when duplicate start fails', async () => {

--- a/src/__tests__/unit/UserModerationService.unit.test.ts
+++ b/src/__tests__/unit/UserModerationService.unit.test.ts
@@ -100,6 +100,7 @@ describe('UserModerationService (unit)', () => {
       handleHistoryButtonClick: jest.fn().mockResolvedValue(true),
       updateNotificationButtons: jest.fn().mockResolvedValue(undefined),
       updateVerificationThreadAnalysis: jest.fn().mockResolvedValue(true),
+      mirrorVerificationThreadMessageToEvidenceThread: jest.fn().mockResolvedValue(false),
       upsertObservedDetectionNotification: jest.fn().mockResolvedValue({} as any),
       markObservedDetectionActionTaken: jest.fn().mockResolvedValue(true),
       restoreObservedDetectionActions: jest.fn().mockResolvedValue(true),

--- a/src/__tests__/unit/VerificationThreadAnalysisService.unit.test.ts
+++ b/src/__tests__/unit/VerificationThreadAnalysisService.unit.test.ts
@@ -18,6 +18,8 @@ describe('VerificationThreadAnalysisService (unit)', () => {
         id: 'user-1',
         username: 'runner',
       },
+      attachments: new Collection<string, any>(),
+      url: 'https://discord.com/channels/guild-1/thread-1/msg-1',
       channel: {
         name: 'Verification: runner',
         isThread: () => true,
@@ -31,7 +33,7 @@ describe('VerificationThreadAnalysisService (unit)', () => {
     return { message: base, messages };
   };
 
-  it('does nothing when thread analysis is disabled', async () => {
+  it('mirrors support-check replies before skipping disabled thread analysis', async () => {
     const verificationRepo = new InMemoryVerificationEventRepository();
     const detectionRepo = new InMemoryDetectionEventsRepository();
     const detectionEvent = await detectionRepo.create({
@@ -49,6 +51,7 @@ describe('VerificationThreadAnalysisService (unit)', () => {
     );
     await verificationRepo.update(verificationEvent.id, {
       thread_id: 'thread-1',
+      private_evidence_thread_id: 'evidence-thread-1',
       notification_message_id: 'notif-1',
     });
 
@@ -57,6 +60,7 @@ describe('VerificationThreadAnalysisService (unit)', () => {
     } as any;
     const notificationManager = {
       updateVerificationThreadAnalysis: jest.fn(),
+      mirrorVerificationThreadMessageToEvidenceThread: jest.fn().mockResolvedValue(false),
     } as any;
     const configService = {
       getServerConfig: jest.fn().mockResolvedValue({
@@ -78,6 +82,9 @@ describe('VerificationThreadAnalysisService (unit)', () => {
     const handled = await service.handleThreadMessage(message as any);
 
     expect(handled).toBe(true);
+    expect(
+      notificationManager.mirrorVerificationThreadMessageToEvidenceThread
+    ).toHaveBeenCalledWith(expect.objectContaining({ id: verificationEvent.id }), message);
     expect(gptService.analyzeVerificationThreadResponses).not.toHaveBeenCalled();
   });
 
@@ -88,7 +95,10 @@ describe('VerificationThreadAnalysisService (unit)', () => {
     const service = new VerificationThreadAnalysisService(
       { getServerConfig: jest.fn() } as any,
       { analyzeVerificationThreadResponses: jest.fn() } as any,
-      { updateVerificationThreadAnalysis: jest.fn() } as any,
+      {
+        updateVerificationThreadAnalysis: jest.fn(),
+        mirrorVerificationThreadMessageToEvidenceThread: jest.fn(),
+      } as any,
       verificationRepo,
       { findById: jest.fn() } as any
     );
@@ -124,6 +134,7 @@ describe('VerificationThreadAnalysisService (unit)', () => {
     } as any;
     const notificationManager = {
       updateVerificationThreadAnalysis: jest.fn(),
+      mirrorVerificationThreadMessageToEvidenceThread: jest.fn(),
     } as any;
     const configService = {
       getServerConfig: jest.fn(),
@@ -148,6 +159,9 @@ describe('VerificationThreadAnalysisService (unit)', () => {
     expect(configService.getServerConfig).not.toHaveBeenCalled();
     expect(gptService.analyzeVerificationThreadResponses).not.toHaveBeenCalled();
     expect(notificationManager.updateVerificationThreadAnalysis).not.toHaveBeenCalled();
+    expect(
+      notificationManager.mirrorVerificationThreadMessageToEvidenceThread
+    ).not.toHaveBeenCalled();
   });
 
   it('analyzes flagged-user verification replies and updates the admin notification', async () => {
@@ -188,6 +202,7 @@ describe('VerificationThreadAnalysisService (unit)', () => {
     } as any;
     const notificationManager = {
       updateVerificationThreadAnalysis: jest.fn().mockResolvedValue(true),
+      mirrorVerificationThreadMessageToEvidenceThread: jest.fn().mockResolvedValue(true),
     } as any;
     const configService = {
       getServerConfig: jest.fn().mockResolvedValue({
@@ -238,6 +253,9 @@ describe('VerificationThreadAnalysisService (unit)', () => {
       expect.objectContaining({ result: 'likely_legitimate', recommendedAction: 'ask_followup' }),
       2
     );
+    expect(
+      notificationManager.mirrorVerificationThreadMessageToEvidenceThread
+    ).toHaveBeenCalledWith(expect.objectContaining({ id: verificationEvent.id }), message);
 
     const updated = await verificationRepo.findById(verificationEvent.id);
     expect(updated?.metadata).toEqual({
@@ -295,6 +313,7 @@ describe('VerificationThreadAnalysisService (unit)', () => {
     } as any;
     const notificationManager = {
       updateVerificationThreadAnalysis: jest.fn().mockResolvedValue(true),
+      mirrorVerificationThreadMessageToEvidenceThread: jest.fn().mockResolvedValue(true),
     } as any;
     const configService = {
       getServerConfig: jest.fn().mockResolvedValue({
@@ -386,6 +405,7 @@ describe('VerificationThreadAnalysisService (unit)', () => {
     } as any;
     const notificationManager = {
       updateVerificationThreadAnalysis: jest.fn().mockResolvedValue(true),
+      mirrorVerificationThreadMessageToEvidenceThread: jest.fn().mockResolvedValue(true),
     } as any;
     const configService = {
       getServerConfig: jest.fn().mockResolvedValue({
@@ -445,6 +465,7 @@ describe('VerificationThreadAnalysisService (unit)', () => {
     } as any;
     const notificationManager = {
       updateVerificationThreadAnalysis: jest.fn(),
+      mirrorVerificationThreadMessageToEvidenceThread: jest.fn().mockResolvedValue(true),
     } as any;
     const configService = {
       getServerConfig: jest.fn().mockResolvedValue({
@@ -500,6 +521,7 @@ describe('VerificationThreadAnalysisService (unit)', () => {
     } as any;
     const notificationManager = {
       updateVerificationThreadAnalysis: jest.fn().mockResolvedValue(false),
+      mirrorVerificationThreadMessageToEvidenceThread: jest.fn().mockResolvedValue(true),
     } as any;
     const configService = {
       getServerConfig: jest.fn().mockResolvedValue({
@@ -575,6 +597,7 @@ describe('VerificationThreadAnalysisService (unit)', () => {
     } as any;
     const notificationManager = {
       updateVerificationThreadAnalysis: jest.fn().mockResolvedValue(true),
+      mirrorVerificationThreadMessageToEvidenceThread: jest.fn().mockResolvedValue(true),
     } as any;
     const configService = {
       getServerConfig: jest.fn().mockResolvedValue({

--- a/src/__tests__/unit/commandHandlerTestHarness.ts
+++ b/src/__tests__/unit/commandHandlerTestHarness.ts
@@ -24,6 +24,7 @@ export type HandlerOverrides = Partial<{
   handleUserReport: jest.Mock;
   handleMessageReport: jest.Mock;
   openAdminCase: jest.Mock;
+  refreshCaseNotification: jest.Mock;
   repairActiveCase: jest.Mock;
   restrictActiveCase: jest.Mock;
   intakeRoleMembers: jest.Mock;
@@ -84,6 +85,16 @@ export const buildHandler = (overrides: HandlerOverrides = {}) => {
         opened: true,
         restrictionAttempted: false,
         restricted: false,
+      }),
+    refreshCaseNotification:
+      overrides.refreshCaseNotification ??
+      jest.fn().mockResolvedValue({
+        refreshed: true,
+        message: 'Refreshed pending case notification for test-user#0001.',
+        verificationEventId: 'ver-1',
+        status: 'pending',
+        notificationChannelId: 'channel-1',
+        notificationMessageId: 'message-1',
       }),
     repairActiveCase:
       overrides.repairActiveCase ??

--- a/src/__tests__/unit/reportAttachments.unit.test.ts
+++ b/src/__tests__/unit/reportAttachments.unit.test.ts
@@ -1,0 +1,146 @@
+import { Collection, Message } from 'discord.js';
+import {
+  buildSpoilerImageAttachmentFileResult,
+  buildSpoilerImageAttachmentFiles,
+  messageAttachmentsToReportMetadata,
+  selectEligibleMessageReportImageAttachments,
+  toSpoilerFilename,
+} from '../../utils/reportAttachments';
+import { getReportAiSettings } from '../../utils/reportAiSettings';
+
+describe('reportAttachments (unit)', () => {
+  it('maps Discord message attachments to report metadata', () => {
+    const message = buildMessageWithAttachments([
+      [
+        'attachment-1',
+        {
+          id: 'attachment-1',
+          name: 'proof.png',
+          url: 'https://cdn.discordapp.com/proof.png',
+          proxyURL: 'https://media.discordapp.net/proof.png',
+          contentType: null,
+          size: 1234,
+        },
+      ],
+    ]);
+
+    expect(messageAttachmentsToReportMetadata(message)).toEqual([
+      {
+        id: 'attachment-1',
+        name: 'proof.png',
+        url: 'https://cdn.discordapp.com/proof.png',
+        proxyUrl: 'https://media.discordapp.net/proof.png',
+        contentType: undefined,
+        size: 1234,
+      },
+    ]);
+  });
+
+  it('selects eligible image attachments from a Discord message', () => {
+    const message = buildMessageWithAttachments([
+      [
+        'image-1',
+        {
+          id: 'image-1',
+          name: 'proof.png',
+          url: 'https://cdn.discordapp.com/proof.png',
+          contentType: 'image/png',
+          size: 999,
+        },
+      ],
+      [
+        'archive-1',
+        {
+          id: 'archive-1',
+          name: 'logs.zip',
+          url: 'https://cdn.discordapp.com/logs.zip',
+          contentType: 'application/zip',
+          size: 999,
+        },
+      ],
+    ]);
+
+    expect(
+      selectEligibleMessageReportImageAttachments(
+        message,
+        getReportAiSettings({ report_ai_max_images: 1 })
+      )
+    ).toEqual([
+      expect.objectContaining({
+        id: 'image-1',
+        name: 'proof.png',
+      }),
+    ]);
+  });
+
+  it('copies fetched images into spoilered Discord file payloads', async () => {
+    const imageBytes = Uint8Array.from([4, 5, 6]);
+    const fetchImage = jest.fn().mockResolvedValue({
+      ok: true,
+      arrayBuffer: jest.fn().mockResolvedValue(imageBytes.buffer),
+    });
+
+    const result = await buildSpoilerImageAttachmentFileResult(
+      [
+        {
+          id: 'image-1',
+          name: 'proof:image.png',
+          url: 'https://cdn.discordapp.com/proof.png',
+          proxyUrl: 'https://media.discordapp.net/proof.png',
+        },
+      ],
+      { fetchImage }
+    );
+
+    expect(fetchImage).toHaveBeenCalledWith('https://media.discordapp.net/proof.png');
+    expect(result.files).toEqual([
+      { attachment: Buffer.from(imageBytes), name: 'SPOILER_proof_image.png' },
+    ]);
+    expect([...result.copiedAttachmentIds]).toEqual(['image-1']);
+  });
+
+  it('skips failed image copies without adding copied ids', async () => {
+    const fetchImage = jest.fn().mockResolvedValue({ ok: false, arrayBuffer: jest.fn() });
+
+    const result = await buildSpoilerImageAttachmentFileResult(
+      [
+        {
+          id: 'image-1',
+          name: 'proof.png',
+          url: 'https://cdn.discordapp.com/proof.png',
+        },
+      ],
+      { fetchImage }
+    );
+
+    expect(result.files).toEqual([]);
+    expect([...result.copiedAttachmentIds]).toEqual([]);
+  });
+
+  it('keeps the simple file helper compatible with existing callers', async () => {
+    const imageBytes = Uint8Array.from([7]);
+    const fetchImage = jest.fn().mockResolvedValue({
+      ok: true,
+      arrayBuffer: jest.fn().mockResolvedValue(imageBytes.buffer),
+    });
+
+    await expect(
+      buildSpoilerImageAttachmentFiles(
+        [{ id: 'image-1', name: 'proof.png', url: 'https://cdn.discordapp.com/proof.png' }],
+        { fetchImage }
+      )
+    ).resolves.toEqual([{ attachment: Buffer.from(imageBytes), name: 'SPOILER_proof.png' }]);
+  });
+
+  it('normalizes spoiler filenames', () => {
+    expect(toSpoilerFilename('receipt:image?.png')).toBe('SPOILER_receipt_image_.png');
+    expect(toSpoilerFilename('SPOILER_receipt.png')).toBe('SPOILER_receipt.png');
+    expect(toSpoilerFilename('   ')).toBe('SPOILER_image');
+  });
+});
+
+function buildMessageWithAttachments(entries: [string, unknown][]): Pick<Message, 'attachments'> {
+  return {
+    attachments: new Collection<string, unknown>(entries) as unknown as Message['attachments'],
+  };
+}

--- a/src/controllers/CaseCommandHandler.ts
+++ b/src/controllers/CaseCommandHandler.ts
@@ -71,6 +71,11 @@ export class CaseCommandHandler {
       return;
     }
 
+    if (subcommand === 'refresh') {
+      await this.handleCaseRefreshCommand(interaction, guild);
+      return;
+    }
+
     if (subcommand === 'intake-role') {
       await this.handleCaseRoleIntakeCommand(interaction, guild);
       return;
@@ -184,6 +189,40 @@ export class CaseCommandHandler {
         allowedMentions: { parse: [] },
       });
     }
+  }
+
+  private async handleCaseRefreshCommand(
+    interaction: ChatInputCommandInteraction,
+    guild: Guild
+  ): Promise<void> {
+    const targetUser = interaction.options.getUser('user', true);
+    const caseId = interaction.options.getString('case-id')?.trim() || undefined;
+
+    await interaction.deferReply({ flags: MessageFlags.Ephemeral });
+
+    const result = await this.securityActionService.refreshCaseNotification(
+      guild.id,
+      targetUser,
+      caseId
+    );
+
+    const lines = [result.message];
+    if (result.verificationEventId) {
+      lines.push(`Case: \`${result.verificationEventId}\``);
+    }
+    if (result.status) {
+      lines.push(`Status: \`${result.status}\``);
+    }
+    if (result.notificationChannelId && result.notificationMessageId) {
+      lines.push(
+        `Notification: https://discord.com/channels/${guild.id}/${result.notificationChannelId}/${result.notificationMessageId}`
+      );
+    }
+
+    await interaction.editReply({
+      content: lines.join('\n'),
+      allowedMentions: { parse: [] },
+    });
   }
 
   private async resolveRoleIntakeRole(

--- a/src/controllers/CaseCommandHandler.ts
+++ b/src/controllers/CaseCommandHandler.ts
@@ -200,29 +200,38 @@ export class CaseCommandHandler {
 
     await interaction.deferReply({ flags: MessageFlags.Ephemeral });
 
-    const result = await this.securityActionService.refreshCaseNotification(
-      guild.id,
-      targetUser,
-      caseId
-    );
-
-    const lines = [result.message];
-    if (result.verificationEventId) {
-      lines.push(`Case: \`${result.verificationEventId}\``);
-    }
-    if (result.status) {
-      lines.push(`Status: \`${result.status}\``);
-    }
-    if (result.notificationChannelId && result.notificationMessageId) {
-      lines.push(
-        `Notification: https://discord.com/channels/${guild.id}/${result.notificationChannelId}/${result.notificationMessageId}`
+    try {
+      const result = await this.securityActionService.refreshCaseNotification(
+        guild.id,
+        targetUser,
+        caseId
       );
-    }
 
-    await interaction.editReply({
-      content: lines.join('\n'),
-      allowedMentions: { parse: [] },
-    });
+      const lines = [result.message];
+      if (result.verificationEventId) {
+        lines.push(`Case: \`${result.verificationEventId}\``);
+      }
+      if (result.status) {
+        lines.push(`Status: \`${result.status}\``);
+      }
+      if (result.notificationChannelId && result.notificationMessageId) {
+        lines.push(
+          `Notification: https://discord.com/channels/${guild.id}/${result.notificationChannelId}/${result.notificationMessageId}`
+        );
+      }
+
+      await interaction.editReply({
+        content: lines.join('\n'),
+        allowedMentions: { parse: [] },
+      });
+    } catch (error) {
+      console.error('Failed to refresh case notification:', error);
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      await interaction.editReply({
+        content: `Failed to refresh case notification for ${targetUser.tag}: ${message}`,
+        allowedMentions: { parse: [] },
+      });
+    }
   }
 
   private async resolveRoleIntakeRole(

--- a/src/controllers/InteractionHandler.ts
+++ b/src/controllers/InteractionHandler.ts
@@ -230,6 +230,38 @@ export class InteractionHandler implements IInteractionHandler {
             userId: targetUserId,
           });
           break;
+        case 'restrict':
+          if (
+            !(await this.hasAnyPermission(interaction, guildId, this.getModerationPermissions()))
+          ) {
+            await this.replyPermissionDenied(
+              interaction,
+              'You need moderation permissions to restrict a user.'
+            );
+            return;
+          }
+          await this.showLegacyAdminActionConfirmation(interaction, {
+            action: 'restrict_user',
+            surface: 'case',
+            userId: targetUserId,
+          });
+          break;
+        case 'close':
+          if (
+            !(await this.hasAnyPermission(interaction, guildId, this.getModerationPermissions()))
+          ) {
+            await this.replyPermissionDenied(
+              interaction,
+              'You need moderation permissions to close a case.'
+            );
+            return;
+          }
+          await this.showLegacyAdminActionConfirmation(interaction, {
+            action: 'close_no_action',
+            surface: 'case',
+            userId: targetUserId,
+          });
+          break;
         case 'ban':
           if (
             !(await this.hasAnyPermission(interaction, guildId, [PermissionFlagsBits.BanMembers]))

--- a/src/controllers/ReportInteractionHandler.ts
+++ b/src/controllers/ReportInteractionHandler.ts
@@ -26,6 +26,7 @@ import {
   USER_REPORT_MESSAGE_CONTENT_MAX_LENGTH,
 } from '../utils/userReportSettings';
 import { canModerateReportIntake } from '../utils/reportIntakeStaffAuthorization';
+import { messageAttachmentsToReportMetadata } from '../utils/reportAttachments';
 
 export const REPORT_USER_INITIATE_CUSTOM_ID = 'report_user_initiate';
 export const REPORT_USER_TYPED_MODAL_ID = 'report_user_modal_submit';
@@ -591,16 +592,7 @@ export class ReportInteractionHandler {
       return null;
     }
 
-    const attachments = [...message.attachments.values()].map((attachment) => ({
-      id: attachment.id,
-      name: attachment.name,
-      url: attachment.url,
-      proxyUrl: attachment.proxyURL,
-      contentType: attachment.contentType ?? undefined,
-      size: attachment.size,
-    }));
-
-    return { content: message.content, attachments };
+    return { content: message.content, attachments: messageAttachmentsToReportMetadata(message) };
   }
 
   public isReportIntakeConfirmCustomId(customId: string): boolean {

--- a/src/controllers/commandDefinitions.ts
+++ b/src/controllers/commandDefinitions.ts
@@ -834,6 +834,23 @@ const baseApplicationCommandBuilders = [
     )
     .addSubcommand((subcommand) =>
       subcommand
+        .setName('refresh')
+        .setDescription('Refresh a case notification embed from stored case state')
+        .addUserOption((option) =>
+          option
+            .setName('user')
+            .setDescription('The user whose latest case notification to refresh')
+            .setRequired(true)
+        )
+        .addStringOption((option) =>
+          option
+            .setName('case-id')
+            .setDescription('Specific case ID to refresh; defaults to the latest case for the user')
+            .setRequired(false)
+        )
+    )
+    .addSubcommand((subcommand) =>
+      subcommand
         .setName('intake-role')
         .setDescription('Preview or open cases for members currently in a role')
         .addRoleOption((option) =>

--- a/src/services/NotificationManager.ts
+++ b/src/services/NotificationManager.ts
@@ -918,6 +918,11 @@ export class NotificationManager implements INotificationManager {
     const updatedEmbed = messageEmbeds.length > 0 ? EmbedBuilder.from(messageEmbeds[0]) : null;
 
     if (updatedEmbed) {
+      this.presentationBuilder.upsertResolvedCasePresentation(
+        updatedEmbed,
+        verificationEvent,
+        newStatus
+      );
       this.presentationBuilder.upsertVerificationActionFailureField(
         updatedEmbed,
         verificationEvent

--- a/src/services/NotificationManager.ts
+++ b/src/services/NotificationManager.ts
@@ -973,8 +973,6 @@ export class NotificationManager implements INotificationManager {
     verificationEvent: VerificationEvent,
     newStatus: VerificationStatus
   ): Promise<void> {
-    void newStatus;
-
     if (!verificationEvent.notification_message_id) {
       throw new Error('No notification message ID found for verification event');
     }

--- a/src/services/NotificationManager.ts
+++ b/src/services/NotificationManager.ts
@@ -13,6 +13,7 @@ import {
   GuildBasedChannel,
   OverwriteResolvable,
   ButtonInteraction,
+  type MessageCreateOptions,
   MessageFlags,
   TextChannel,
 } from 'discord.js';
@@ -29,6 +30,12 @@ import {
 import { DetectionHistoryFormatter } from '../utils/DetectionHistoryFormatter';
 import type { VerificationThreadAnalysisResult } from './GPTService';
 import { getDetectionResponseSettings } from '../utils/detectionResponseSettings';
+import { getReportAiSettings, type ReportAttachmentMetadata } from '../utils/reportAiSettings';
+import {
+  buildSpoilerImageAttachmentFileResult,
+  messageAttachmentsToReportMetadata,
+  selectEligibleMessageReportImageAttachments,
+} from '../utils/reportAttachments';
 import { NotificationPresentationBuilder } from './NotificationPresentationBuilder';
 
 const VERIFICATION_CHANNEL_NAME = 'verification';
@@ -37,6 +44,11 @@ const MIRRORED_THREAD_MESSAGE_CONTENT_MAX_LENGTH = 1200;
 const MIRRORED_THREAD_MESSAGE_ATTACHMENT_LIMIT = 5;
 const MIRRORED_THREAD_MESSAGE_TRUNCATION_NOTICE =
   '\n\n[Support-check reply mirror truncated to fit Discord message limits.]';
+
+interface MirroredThreadImageFileResult {
+  readonly files: NonNullable<MessageCreateOptions['files']>;
+  readonly copiedAttachmentIds: Set<string>;
+}
 
 /**
  * Interface for NotificationManager service
@@ -489,8 +501,13 @@ export class NotificationManager implements INotificationManager {
         return false;
       }
 
+      const imageFiles = await this.buildMirroredThreadImageFiles(verificationEvent, message);
       await (channel as { send: ThreadChannel['send'] }).send({
-        content: this.formatVerificationThreadMessageMirror(message),
+        content: this.formatVerificationThreadMessageMirror(
+          message,
+          imageFiles.copiedAttachmentIds
+        ),
+        ...(imageFiles.files.length ? { files: imageFiles.files } : {}),
         allowedMentions: this.presentationBuilder.createAdminAllowedMentions(),
       });
       return true;
@@ -1000,7 +1017,10 @@ export class NotificationManager implements INotificationManager {
     });
   }
 
-  private formatVerificationThreadMessageMirror(message: Message): string {
+  private formatVerificationThreadMessageMirror(
+    message: Message,
+    copiedImageIds: Set<string>
+  ): string {
     const authorTag = message.author.tag;
     const lines = [
       `Support-check reply from <@${message.author.id}> (${authorTag}).`,
@@ -1009,7 +1029,7 @@ export class NotificationManager implements INotificationManager {
       this.formatMirroredMessageContent(message.content),
     ];
 
-    const attachments = [...message.attachments.values()].slice(
+    const attachments = messageAttachmentsToReportMetadata(message).slice(
       0,
       MIRRORED_THREAD_MESSAGE_ATTACHMENT_LIMIT
     );
@@ -1017,7 +1037,9 @@ export class NotificationManager implements INotificationManager {
       lines.push(
         '',
         'Attachments:',
-        ...attachments.map((attachment) => `- ${attachment.name}: ${attachment.url}`)
+        ...attachments.map((attachment) =>
+          this.formatMirroredAttachmentLine(attachment, copiedImageIds)
+        )
       );
       if (message.attachments.size > attachments.length) {
         lines.push(
@@ -1027,6 +1049,42 @@ export class NotificationManager implements INotificationManager {
     }
 
     return this.enforceMirroredThreadMessageLimit(lines.join('\n'));
+  }
+
+  private async buildMirroredThreadImageFiles(
+    verificationEvent: VerificationEvent,
+    message: Message
+  ): Promise<MirroredThreadImageFileResult> {
+    if (message.attachments.size === 0) {
+      return { files: [], copiedAttachmentIds: new Set() };
+    }
+
+    try {
+      const serverConfig = await this.configService.getServerConfig(verificationEvent.server_id);
+      const attachments = selectEligibleMessageReportImageAttachments(
+        message,
+        getReportAiSettings(serverConfig.settings)
+      );
+      return await buildSpoilerImageAttachmentFileResult(attachments, { logger: console });
+    } catch (error) {
+      console.warn(
+        `Failed to prepare spoilered support-check image attachments for verification event ${verificationEvent.id}:`,
+        error
+      );
+      return { files: [], copiedAttachmentIds: new Set() };
+    }
+  }
+
+  private formatMirroredAttachmentLine(
+    attachment: ReportAttachmentMetadata,
+    copiedImageIds: Set<string>
+  ): string {
+    const name = attachment.name ?? attachment.id ?? 'attachment';
+    if (attachment.id && copiedImageIds.has(attachment.id)) {
+      return `- ${name} (copied below as a spoilered image)`;
+    }
+
+    return `- ${name}: ${attachment.url ?? 'no URL available'}`;
   }
 
   private formatMirroredMessageContent(content: string): string {

--- a/src/services/NotificationManager.ts
+++ b/src/services/NotificationManager.ts
@@ -32,6 +32,11 @@ import { getDetectionResponseSettings } from '../utils/detectionResponseSettings
 import { NotificationPresentationBuilder } from './NotificationPresentationBuilder';
 
 const VERIFICATION_CHANNEL_NAME = 'verification';
+const DISCORD_MESSAGE_CONTENT_MAX_LENGTH = 2000;
+const MIRRORED_THREAD_MESSAGE_CONTENT_MAX_LENGTH = 1200;
+const MIRRORED_THREAD_MESSAGE_ATTACHMENT_LIMIT = 5;
+const MIRRORED_THREAD_MESSAGE_TRUNCATION_NOTICE =
+  '\n\n[Support-check reply mirror truncated to fit Discord message limits.]';
 
 /**
  * Interface for NotificationManager service
@@ -97,6 +102,11 @@ export interface INotificationManager {
     verificationEvent: VerificationEvent,
     analysis: VerificationThreadAnalysisResult,
     analyzedMessageCount: number
+  ): Promise<boolean>;
+
+  mirrorVerificationThreadMessageToEvidenceThread(
+    verificationEvent: VerificationEvent,
+    message: Message
   ): Promise<boolean>;
 
   upsertObservedDetectionNotification(
@@ -187,9 +197,11 @@ export class NotificationManager implements INotificationManager {
         detectionEvents,
         sourceMessage
       );
-      const actionRow = this.presentationBuilder.createActionRow(member.id, {
+      const actionRows = this.presentationBuilder.createAdminNotificationActionRows(member.id, {
         guildId: member.guild.id,
         verificationEventId: verificationEvent.id,
+        verificationStatus: verificationEvent.status,
+        includeBanAction: responseSettings.moderatorBanActionEnabled,
       });
 
       // If we have an existing message, update it, otherwise create new
@@ -206,7 +218,7 @@ export class NotificationManager implements INotificationManager {
           return await existingMessage.edit({
             allowedMentions: { parse: [] },
             embeds: [embed],
-            components: [actionRow],
+            components: actionRows,
           });
         }
       }
@@ -217,7 +229,7 @@ export class NotificationManager implements INotificationManager {
         content: this.presentationBuilder.formatRoleMentions(notificationRoleIds),
         allowedMentions: this.presentationBuilder.createAdminAllowedMentions(notificationRoleIds),
         embeds: [embed],
-        components: [actionRow],
+        components: actionRows,
       });
     } catch (error) {
       console.error('Failed to upsert suspicious user notification:', error);
@@ -262,7 +274,8 @@ export class NotificationManager implements INotificationManager {
         ? this.presentationBuilder.createObservedActionRows(
             member.id,
             actionDetectionEventId,
-            member.guild.id
+            member.guild.id,
+            { includeBanAction: responseSettings.moderatorBanActionEnabled }
           )
         : [];
 
@@ -368,7 +381,8 @@ export class NotificationManager implements INotificationManager {
       const components = this.presentationBuilder.createObservedActionRows(
         detectionEvent.user_id,
         detectionEvent.id,
-        detectionEvent.server_id
+        detectionEvent.server_id,
+        { includeBanAction: responseSettings.moderatorBanActionEnabled }
       );
 
       await message.edit({
@@ -426,7 +440,8 @@ export class NotificationManager implements INotificationManager {
       const components = this.presentationBuilder.createObservedActionRows(
         detectionEvent.user_id,
         detectionEvent.id,
-        detectionEvent.server_id
+        detectionEvent.server_id,
+        { includeBanAction: responseSettings.moderatorBanActionEnabled }
       );
       if (!message.embeds.length) {
         await message.edit({ allowedMentions: { parse: [] }, components });
@@ -450,6 +465,40 @@ export class NotificationManager implements INotificationManager {
       return true;
     } catch (error) {
       console.error('Failed to restore observed detection actions:', error);
+      return false;
+    }
+  }
+
+  public async mirrorVerificationThreadMessageToEvidenceThread(
+    verificationEvent: VerificationEvent,
+    message: Message
+  ): Promise<boolean> {
+    if (!verificationEvent.private_evidence_thread_id) {
+      return false;
+    }
+    if (verificationEvent.private_evidence_thread_id === message.channelId) {
+      return false;
+    }
+
+    try {
+      const channel = await this.client.channels
+        .fetch(verificationEvent.private_evidence_thread_id)
+        .catch(() => null);
+      const send = (channel as { send?: unknown } | null)?.send;
+      if (typeof send !== 'function') {
+        return false;
+      }
+
+      await (channel as { send: ThreadChannel['send'] }).send({
+        content: this.formatVerificationThreadMessageMirror(message),
+        allowedMentions: this.presentationBuilder.createAdminAllowedMentions(),
+      });
+      return true;
+    } catch (error) {
+      console.warn(
+        `Failed to mirror verification thread message ${message.id} to private evidence thread ${verificationEvent.private_evidence_thread_id}:`,
+        error
+      );
       return false;
     }
   }
@@ -929,15 +978,86 @@ export class NotificationManager implements INotificationManager {
       );
     }
 
+    const serverConfig = await this.configService
+      .getServerConfig(verificationEvent.server_id)
+      .catch(() => null);
+    const responseSettings = serverConfig
+      ? getDetectionResponseSettings(serverConfig.settings)
+      : null;
+
     await message.edit({
       allowedMentions: { parse: [] },
-      components: [
-        this.presentationBuilder.createActionRow(verificationEvent.user_id, {
+      components: this.presentationBuilder.createAdminNotificationActionRows(
+        verificationEvent.user_id,
+        {
           guildId: verificationEvent.server_id,
           verificationEventId: verificationEvent.id,
-        }),
-      ],
+          verificationStatus: newStatus,
+          includeBanAction: responseSettings?.moderatorBanActionEnabled ?? true,
+        }
+      ),
       ...(updatedEmbed ? { embeds: [updatedEmbed] } : {}),
     });
+  }
+
+  private formatVerificationThreadMessageMirror(message: Message): string {
+    const authorTag = message.author.tag;
+    const lines = [
+      `Support-check reply from <@${message.author.id}> (${authorTag}).`,
+      `Source: ${message.url}`,
+      '',
+      this.formatMirroredMessageContent(message.content),
+    ];
+
+    const attachments = [...message.attachments.values()].slice(
+      0,
+      MIRRORED_THREAD_MESSAGE_ATTACHMENT_LIMIT
+    );
+    if (attachments.length > 0) {
+      lines.push(
+        '',
+        'Attachments:',
+        ...attachments.map((attachment) => `- ${attachment.name}: ${attachment.url}`)
+      );
+      if (message.attachments.size > attachments.length) {
+        lines.push(
+          `- ${message.attachments.size - attachments.length} more attachment(s) omitted.`
+        );
+      }
+    }
+
+    return this.enforceMirroredThreadMessageLimit(lines.join('\n'));
+  }
+
+  private formatMirroredMessageContent(content: string): string {
+    const trimmed = content.trim();
+    if (!trimmed) {
+      return '_No text content._';
+    }
+
+    const safeContent = this.truncateMirroredMessageContent(trimmed).replace(/```/g, "''' ");
+    return `\`\`\`\n${safeContent}\n\`\`\``;
+  }
+
+  private truncateMirroredMessageContent(content: string): string {
+    if (content.length <= MIRRORED_THREAD_MESSAGE_CONTENT_MAX_LENGTH) {
+      return content;
+    }
+
+    return `${content.slice(0, MIRRORED_THREAD_MESSAGE_CONTENT_MAX_LENGTH - 3)}...`;
+  }
+
+  private enforceMirroredThreadMessageLimit(content: string): string {
+    if (content.length <= DISCORD_MESSAGE_CONTENT_MAX_LENGTH) {
+      return content;
+    }
+
+    const maxPrefixLength =
+      DISCORD_MESSAGE_CONTENT_MAX_LENGTH - MIRRORED_THREAD_MESSAGE_TRUNCATION_NOTICE.length;
+    if (maxPrefixLength <= 0) {
+      return content.slice(0, DISCORD_MESSAGE_CONTENT_MAX_LENGTH);
+    }
+
+    return `${content.slice(0, maxPrefixLength)}${MIRRORED_THREAD_MESSAGE_TRUNCATION_NOTICE}`;
   }
 }

--- a/src/services/NotificationPresentationBuilder.ts
+++ b/src/services/NotificationPresentationBuilder.ts
@@ -506,6 +506,44 @@ export class NotificationPresentationBuilder {
     }
   }
 
+  public upsertResolvedCasePresentation(
+    embed: EmbedBuilder,
+    verificationEvent: VerificationEvent,
+    status: VerificationStatus
+  ): void {
+    const actionTaken = this.getResolutionAction(status);
+    if (!actionTaken) {
+      return;
+    }
+
+    if (status === VerificationStatus.VERIFIED) {
+      embed.setColor(0x00ff00);
+    } else if (status === VerificationStatus.BANNED) {
+      embed.setColor(0x000000);
+    } else if (status === VerificationStatus.CLOSED_NO_ACTION) {
+      embed.setColor(0x808080);
+    }
+
+    const resolvedAt = verificationEvent.resolved_at
+      ? Math.floor(verificationEvent.resolved_at.getTime() / 1000)
+      : null;
+    this.upsertHandledResolutionField(
+      embed,
+      actionTaken,
+      verificationEvent.resolved_by,
+      resolvedAt
+    );
+
+    if (verificationEvent.resolved_by && resolvedAt) {
+      this.upsertLatestAdminActionField(
+        embed,
+        actionTaken,
+        verificationEvent.resolved_by,
+        resolvedAt
+      );
+    }
+  }
+
   private addOptionalAnalysisFields(
     embed: EmbedBuilder,
     detectionResult: DetectionResult,
@@ -725,14 +763,7 @@ export class NotificationPresentationBuilder {
       return;
     }
 
-    const actionTaken =
-      verificationEvent.status === VerificationStatus.BANNED
-        ? AdminActionType.BAN
-        : verificationEvent.status === VerificationStatus.VERIFIED
-          ? AdminActionType.VERIFY
-          : verificationEvent.status === VerificationStatus.CLOSED_NO_ACTION
-            ? AdminActionType.CLOSE_NO_ACTION
-            : null;
+    const actionTaken = this.getResolutionAction(verificationEvent.status);
     if (!actionTaken) {
       return;
     }
@@ -748,14 +779,7 @@ export class NotificationPresentationBuilder {
   private getVerificationResolutionPresentation(
     verificationEvent: VerificationEvent
   ): { title: string; fieldValue: string } | null {
-    const actionTaken =
-      verificationEvent.status === VerificationStatus.BANNED
-        ? AdminActionType.BAN
-        : verificationEvent.status === VerificationStatus.VERIFIED
-          ? AdminActionType.VERIFY
-          : verificationEvent.status === VerificationStatus.CLOSED_NO_ACTION
-            ? AdminActionType.CLOSE_NO_ACTION
-            : null;
+    const actionTaken = this.getResolutionAction(verificationEvent.status);
     if (!actionTaken) {
       return null;
     }
@@ -777,8 +801,8 @@ export class NotificationPresentationBuilder {
   private upsertHandledResolutionField(
     embed: EmbedBuilder,
     actionTaken: AdminActionType,
-    adminId: string,
-    timestamp: number
+    adminId: string | null,
+    timestamp: number | null
   ): void {
     if (
       actionTaken !== AdminActionType.VERIFY &&
@@ -799,6 +823,19 @@ export class NotificationPresentationBuilder {
     );
     fields.splice(0, 0, field);
     embed.setFields(...fields);
+  }
+
+  private getResolutionAction(status: VerificationStatus): AdminActionType | null {
+    switch (status) {
+      case VerificationStatus.BANNED:
+        return AdminActionType.BAN;
+      case VerificationStatus.VERIFIED:
+        return AdminActionType.VERIFY;
+      case VerificationStatus.CLOSED_NO_ACTION:
+        return AdminActionType.CLOSE_NO_ACTION;
+      case VerificationStatus.PENDING:
+        return null;
+    }
   }
 
   private formatHandledTitle(actionTaken: AdminActionType): string {

--- a/src/services/NotificationPresentationBuilder.ts
+++ b/src/services/NotificationPresentationBuilder.ts
@@ -30,6 +30,8 @@ import { getVerificationActionFailures } from '../utils/verificationActionFailur
 interface AdminActionRowOptions {
   readonly guildId?: string;
   readonly verificationEventId?: string;
+  readonly verificationStatus?: VerificationStatus;
+  readonly includeBanAction?: boolean;
 }
 
 interface ThreadAnalysisMetadata {
@@ -334,24 +336,122 @@ export class NotificationPresentationBuilder {
     return new ActionRowBuilder<ButtonBuilder>().addComponents(...buttons);
   }
 
+  public createAdminNotificationActionRows(
+    userId: string,
+    options: AdminActionRowOptions = {}
+  ): ActionRowBuilder<ButtonBuilder>[] {
+    const isPending =
+      !options.verificationStatus || options.verificationStatus === VerificationStatus.PENDING;
+    const primaryButtons = isPending
+      ? this.createPendingCaseAdminButtons(userId, options.includeBanAction !== false)
+      : [
+          this.createCustomButton(`reopen_${userId}`, 'Reopen', ButtonStyle.Primary),
+          this.createCustomButton(`history_${userId}`, 'History', ButtonStyle.Secondary),
+          this.createCustomButton(
+            buildCaseAdminActionsCustomId(userId),
+            'Other Actions',
+            ButtonStyle.Secondary
+          ),
+        ];
+
+    const rows = [new ActionRowBuilder<ButtonBuilder>().addComponents(...primaryButtons)];
+    const webCaseUrl =
+      options.guildId && options.verificationEventId
+        ? buildAdminCaseDetailUrl(options.guildId, options.verificationEventId)
+        : null;
+    if (webCaseUrl) {
+      rows.push(
+        new ActionRowBuilder<ButtonBuilder>().addComponents(
+          this.createLinkButton('Web Case', webCaseUrl)
+        )
+      );
+    }
+
+    return rows;
+  }
+
   public createObservedActionRows(
     userId: string,
     detectionEventId: string,
-    guildId?: string
+    guildId?: string,
+    options: Pick<AdminActionRowOptions, 'includeBanAction'> = {}
   ): ActionRowBuilder<ButtonBuilder>[] {
     const buttons = [
-      new ButtonBuilder()
-        .setCustomId(buildObservedAdminActionsCustomId(userId, detectionEventId))
-        .setLabel('Admin Actions')
-        .setStyle(ButtonStyle.Primary),
+      this.createCustomButton(
+        `observed:open:${userId}:${detectionEventId}`,
+        'Open Case',
+        ButtonStyle.Primary
+      ),
+      this.createCustomButton(
+        `observed:restrict:${userId}:${detectionEventId}`,
+        'Restrict',
+        ButtonStyle.Danger
+      ),
     ];
 
-    const webQueueUrl = guildId ? buildAdminCaseQueueUrl(guildId) : null;
-    if (webQueueUrl) {
-      buttons.push(this.createLinkButton('Web Queue', webQueueUrl));
+    if (options.includeBanAction !== false) {
+      buttons.push(
+        this.createCustomButton(
+          `observed:ban:${userId}:${detectionEventId}`,
+          'Ban...',
+          ButtonStyle.Danger
+        )
+      );
     }
 
-    return [new ActionRowBuilder<ButtonBuilder>().addComponents(...buttons)];
+    buttons.push(
+      this.createCustomButton(
+        `observed:dismiss:${userId}:${detectionEventId}`,
+        'Dismiss',
+        ButtonStyle.Secondary
+      ),
+      this.createCustomButton(
+        buildObservedAdminActionsCustomId(userId, detectionEventId),
+        'Other Actions',
+        ButtonStyle.Secondary
+      )
+    );
+
+    const webQueueUrl = guildId ? buildAdminCaseQueueUrl(guildId) : null;
+    const rows = [new ActionRowBuilder<ButtonBuilder>().addComponents(...buttons)];
+    if (webQueueUrl) {
+      rows.push(
+        new ActionRowBuilder<ButtonBuilder>().addComponents(
+          this.createLinkButton('Web Queue', webQueueUrl)
+        )
+      );
+    }
+
+    return rows;
+  }
+
+  private createPendingCaseAdminButtons(
+    userId: string,
+    includeBanAction: boolean
+  ): ButtonBuilder[] {
+    const buttons = [
+      this.createCustomButton(`verify_${userId}`, 'Verify', ButtonStyle.Success),
+      this.createCustomButton(`restrict_${userId}`, 'Restrict', ButtonStyle.Danger),
+    ];
+
+    if (includeBanAction) {
+      buttons.push(this.createCustomButton(`ban_${userId}`, 'Ban...', ButtonStyle.Danger));
+    }
+
+    buttons.push(
+      this.createCustomButton(`close_${userId}`, 'Close', ButtonStyle.Secondary),
+      this.createCustomButton(
+        buildCaseAdminActionsCustomId(userId),
+        'Other Actions',
+        ButtonStyle.Secondary
+      )
+    );
+
+    return buttons;
+  }
+
+  private createCustomButton(customId: string, label: string, style: ButtonStyle): ButtonBuilder {
+    return new ButtonBuilder().setCustomId(customId).setLabel(label).setStyle(style);
   }
 
   private createLinkButton(label: string, url: string): ButtonBuilder {

--- a/src/services/NotificationPresentationBuilder.ts
+++ b/src/services/NotificationPresentationBuilder.ts
@@ -613,6 +613,7 @@ export class NotificationPresentationBuilder {
   ): void {
     const actionTaken = this.getResolutionAction(status);
     if (!actionTaken) {
+      this.clearResolvedCasePresentation(embed);
       return;
     }
 
@@ -642,6 +643,51 @@ export class NotificationPresentationBuilder {
         resolvedAt
       );
     }
+  }
+
+  private clearResolvedCasePresentation(embed: EmbedBuilder): void {
+    const fields = embed.data.fields ?? [];
+    const hasResolutionField = fields.some(
+      (field) => field.name === NotificationPresentationBuilder.RESOLUTION_FIELD_NAME
+    );
+    const hasHandledTitle = embed.data.title?.startsWith('Case Handled:') ?? false;
+    const hasHandledDescription =
+      embed.data.description?.includes('No further moderator action is pending.') ?? false;
+
+    if (!hasResolutionField && !hasHandledTitle && !hasHandledDescription) {
+      return;
+    }
+
+    embed.setColor(0xff0000);
+    embed.setTitle(this.getPendingTitleFromExistingEmbed(embed));
+    embed.setDescription(this.getPendingDescriptionFromExistingEmbed(embed));
+    embed.setFields(
+      ...fields.filter(
+        (field) => field.name !== NotificationPresentationBuilder.RESOLUTION_FIELD_NAME
+      )
+    );
+  }
+
+  private getPendingTitleFromExistingEmbed(embed: EmbedBuilder): string {
+    const trigger = embed.data.fields?.find((field) => field.name === 'Trigger')?.value ?? '';
+    if (trigger.startsWith('Flagged via user report:')) {
+      return 'User Report Submitted';
+    }
+
+    if (trigger.startsWith('Admin-opened case:')) {
+      return 'Admin Review Case Opened';
+    }
+
+    return 'Suspicious User Detected';
+  }
+
+  private getPendingDescriptionFromExistingEmbed(embed: EmbedBuilder): string {
+    const userId = embed.data.fields?.find((field) => field.name === 'User ID')?.value;
+    if (userId) {
+      return `<@${userId}> has been flagged as suspicious.`;
+    }
+
+    return 'Case is pending moderator review.';
   }
 
   private addOptionalAnalysisFields(

--- a/src/services/ReportIntakeService.ts
+++ b/src/services/ReportIntakeService.ts
@@ -8,11 +8,8 @@ import { IServerMemberRepository } from '../repositories/ServerMemberRepository'
 import { IServerRepository } from '../repositories/ServerRepository';
 import { ReportIntake, ReportIntakeEvidenceKind, ReportIntakeStatus } from '../repositories/types';
 import { IUserRepository } from '../repositories/UserRepository';
-import {
-  getReportAiSettings,
-  ReportAttachmentMetadata,
-  selectEligibleReportImageAttachments,
-} from '../utils/reportAiSettings';
+import { getReportAiSettings, ReportAttachmentMetadata } from '../utils/reportAiSettings';
+import { selectEligibleMessageReportImageAttachments } from '../utils/reportAttachments';
 import type { ReportIntakeEvidenceExtraction } from './GPTService';
 import { IReportCandidateService, ReportCandidate } from './ReportCandidateService';
 
@@ -523,22 +520,13 @@ export class ReportIntakeService implements IReportIntakeService {
     serverId: string,
     message: Message
   ): Promise<ReportAttachmentMetadata[]> {
-    const attachments = message.attachments.map((attachment) => ({
-      id: attachment.id,
-      name: attachment.name,
-      url: attachment.url,
-      proxyUrl: attachment.proxyURL,
-      contentType: attachment.contentType ?? undefined,
-      size: attachment.size,
-    }));
-
-    if (attachments.length === 0) {
+    if (message.attachments.size === 0) {
       return [];
     }
 
     const serverConfig = await this.configService.getServerConfig(serverId);
-    return selectEligibleReportImageAttachments(
-      attachments,
+    return selectEligibleMessageReportImageAttachments(
+      message,
       getReportAiSettings(serverConfig.settings)
     );
   }

--- a/src/services/SecurityActionService.ts
+++ b/src/services/SecurityActionService.ts
@@ -106,6 +106,12 @@ export interface ISecurityActionService {
     options: AdminCaseOptions
   ): Promise<AdminCaseResult>;
 
+  refreshCaseNotification(
+    guildId: string,
+    user: User,
+    verificationEventId?: string
+  ): Promise<CaseNotificationRefreshResult>;
+
   repairActiveCase(member: GuildMember): Promise<ActiveCaseRepairResult>;
 
   restrictActiveCase(member: GuildMember, moderator: User): Promise<boolean>;
@@ -221,6 +227,15 @@ export interface ActiveCaseRepairResult extends VerificationThreadRepairResult {
   repaired: boolean;
   message: string;
   verificationEventId?: string;
+}
+
+export interface CaseNotificationRefreshResult {
+  refreshed: boolean;
+  message: string;
+  verificationEventId?: string;
+  status?: VerificationStatus;
+  notificationMessageId?: string | null;
+  notificationChannelId?: string | null;
 }
 
 export interface RoleIntakeOptions {
@@ -1612,6 +1627,66 @@ export class SecurityActionService implements ISecurityActionService {
       message: `Repaired active verification case for ${member.user.tag}.${notificationUpdateMessage}`,
       verificationEventId: repairCase.id,
     };
+  }
+
+  public async refreshCaseNotification(
+    guildId: string,
+    user: User,
+    verificationEventId?: string
+  ): Promise<CaseNotificationRefreshResult> {
+    const verificationEvent = verificationEventId
+      ? await this.verificationEventRepository.findById(verificationEventId)
+      : ((await this.verificationEventRepository.findByUserAndServer(user.id, guildId))[0] ?? null);
+
+    if (
+      !verificationEvent ||
+      verificationEvent.server_id !== guildId ||
+      verificationEvent.user_id !== user.id
+    ) {
+      return {
+        refreshed: false,
+        message: verificationEventId
+          ? `No matching case ${verificationEventId} found for ${user.tag}.`
+          : `No verification case found for ${user.tag}.`,
+      };
+    }
+
+    if (!verificationEvent.notification_message_id) {
+      return {
+        refreshed: false,
+        message: `Case ${verificationEvent.id} has no stored notification message to refresh.`,
+        verificationEventId: verificationEvent.id,
+        status: verificationEvent.status,
+        notificationMessageId: null,
+        notificationChannelId: verificationEvent.notification_channel_id,
+      };
+    }
+
+    try {
+      await this.notificationManager.updateNotificationButtons(
+        verificationEvent,
+        verificationEvent.status
+      );
+      return {
+        refreshed: true,
+        message: `Refreshed ${verificationEvent.status} case notification for ${user.tag}.`,
+        verificationEventId: verificationEvent.id,
+        status: verificationEvent.status,
+        notificationMessageId: verificationEvent.notification_message_id,
+        notificationChannelId: verificationEvent.notification_channel_id,
+      };
+    } catch (error) {
+      console.error(`Failed to refresh case notification ${verificationEvent.id}:`, error);
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      return {
+        refreshed: false,
+        message: `Failed to refresh case ${verificationEvent.id} notification: ${message}`,
+        verificationEventId: verificationEvent.id,
+        status: verificationEvent.status,
+        notificationMessageId: verificationEvent.notification_message_id,
+        notificationChannelId: verificationEvent.notification_channel_id,
+      };
+    }
   }
 
   public async restrictActiveCase(member: GuildMember, moderator: User): Promise<boolean> {

--- a/src/services/ThreadManager.ts
+++ b/src/services/ThreadManager.ts
@@ -696,6 +696,7 @@ export class ThreadManager implements IThreadManager {
         roles: [],
         repliedUser: false,
       },
+      components: [this.presentationBuilder.createActionRow(member.id)],
     });
   }
 
@@ -1144,13 +1145,27 @@ export class ThreadManager implements IThreadManager {
     }
 
     try {
-      await thread.setArchived(archived);
-      await thread.setLocked(locked);
+      await this.setThreadArchiveAndLockState(thread, archived, locked);
       return true;
     } catch (error) {
       console.warn(`Failed to update private evidence thread ${threadId}:`, error);
       return false;
     }
+  }
+
+  private async setThreadArchiveAndLockState(
+    thread: ThreadChannel,
+    archived: boolean,
+    locked: boolean
+  ): Promise<void> {
+    if (archived) {
+      await thread.setLocked(locked);
+      await thread.setArchived(archived);
+      return;
+    }
+
+    await thread.setArchived(archived);
+    await thread.setLocked(locked);
   }
 
   /**
@@ -1182,8 +1197,7 @@ export class ThreadManager implements IThreadManager {
             });
           }
 
-          await thread.setArchived(true);
-          await thread.setLocked(true);
+          await this.setThreadArchiveAndLockState(thread, true, true);
           resolvedMainThread = true;
         }
       }
@@ -1299,8 +1313,7 @@ export class ThreadManager implements IThreadManager {
       if (verificationEvent.thread_id) {
         const thread = await this.fetchStoredThread(verificationEvent);
         if (thread) {
-          await thread.setArchived(false);
-          await thread.setLocked(false);
+          await this.setThreadArchiveAndLockState(thread, false, false);
           reopenedMainThread = true;
         }
       }

--- a/src/services/ThreadManager.ts
+++ b/src/services/ThreadManager.ts
@@ -917,12 +917,11 @@ export class ThreadManager implements IThreadManager {
           roles: [],
           repliedUser: false,
         },
-        components: [
-          this.presentationBuilder.createActionRow(member.id, {
-            guildId: member.guild.id,
-            verificationEventId: verificationEvent.id,
-          }),
-        ],
+        components: this.presentationBuilder.createAdminNotificationActionRows(member.id, {
+          guildId: member.guild.id,
+          verificationEventId: verificationEvent.id,
+          verificationStatus: verificationEvent.status,
+        }),
       });
 
       return thread;
@@ -1000,12 +999,11 @@ export class ThreadManager implements IThreadManager {
           sourceMessage
         ),
         allowedMentions: this.createNoMentionAllowedMentions(),
-        components: [
-          this.presentationBuilder.createActionRow(member.id, {
-            guildId: member.guild.id,
-            verificationEventId: verificationEvent.id,
-          }),
-        ],
+        components: this.presentationBuilder.createAdminNotificationActionRows(member.id, {
+          guildId: member.guild.id,
+          verificationEventId: verificationEvent.id,
+          verificationStatus: verificationEvent.status,
+        }),
       });
 
       return thread;

--- a/src/services/VerificationThreadAnalysisService.ts
+++ b/src/services/VerificationThreadAnalysisService.ts
@@ -83,6 +83,11 @@ export class VerificationThreadAnalysisService implements IVerificationThreadAna
       return;
     }
 
+    await this.notificationManager.mirrorVerificationThreadMessageToEvidenceThread(
+      verificationEvent,
+      message
+    );
+
     const serverConfig = await this.configService.getServerConfig(verificationEvent.server_id);
     const settings = getVerificationThreadAnalysisSettings(serverConfig.settings);
     if (!settings.enabled || settings.maxAction === 'off') {

--- a/src/utils/reportAttachments.ts
+++ b/src/utils/reportAttachments.ts
@@ -1,0 +1,123 @@
+import type { MessageCreateOptions } from 'discord.js';
+import {
+  selectEligibleReportImageAttachments,
+  type ReportAiSettings,
+  type ReportAttachmentMetadata,
+} from './reportAiSettings';
+
+type SpoilerAttachmentFile = NonNullable<MessageCreateOptions['files']>[number];
+
+interface MessageAttachmentLike {
+  readonly id?: string;
+  readonly name?: string | null;
+  readonly url?: string;
+  readonly proxyURL?: string;
+  readonly contentType?: string | null;
+  readonly size?: number;
+}
+
+interface MessageAttachmentCollectionLike {
+  readonly map?: <T>(callback: (attachment: MessageAttachmentLike) => T) => T[];
+  readonly values?: () => Iterable<MessageAttachmentLike>;
+}
+
+interface MessageWithAttachmentsLike {
+  readonly attachments: MessageAttachmentCollectionLike;
+}
+
+interface SpoilerImageFileLogger {
+  warn(message?: unknown, ...optionalParams: unknown[]): void;
+}
+
+interface SpoilerImageFileOptions {
+  readonly fetchImage?: (url: string) => Promise<Pick<Response, 'ok' | 'arrayBuffer'>>;
+  readonly logger?: SpoilerImageFileLogger;
+}
+
+export function messageAttachmentsToReportMetadata(
+  message: MessageWithAttachmentsLike
+): ReportAttachmentMetadata[] {
+  return getMessageAttachments(message.attachments).map((attachment) => ({
+    id: attachment.id,
+    name: attachment.name ?? undefined,
+    url: attachment.url,
+    proxyUrl: attachment.proxyURL,
+    contentType: attachment.contentType ?? undefined,
+    size: attachment.size,
+  }));
+}
+
+export function selectEligibleMessageReportImageAttachments(
+  message: MessageWithAttachmentsLike,
+  settings: ReportAiSettings
+): ReportAttachmentMetadata[] {
+  return selectEligibleReportImageAttachments(
+    messageAttachmentsToReportMetadata(message),
+    settings
+  );
+}
+
+function getMessageAttachments(
+  attachments: MessageAttachmentCollectionLike
+): MessageAttachmentLike[] {
+  if (typeof attachments.map === 'function') {
+    return attachments.map((attachment) => attachment);
+  }
+
+  if (typeof attachments.values === 'function') {
+    return [...attachments.values()];
+  }
+
+  return [];
+}
+
+export async function buildSpoilerImageAttachmentFiles(
+  attachments: readonly ReportAttachmentMetadata[],
+  options: SpoilerImageFileOptions = {}
+): Promise<SpoilerAttachmentFile[]> {
+  return (await buildSpoilerImageAttachmentFileResult(attachments, options)).files;
+}
+
+export async function buildSpoilerImageAttachmentFileResult(
+  attachments: readonly ReportAttachmentMetadata[],
+  options: SpoilerImageFileOptions = {}
+): Promise<{ readonly files: SpoilerAttachmentFile[]; readonly copiedAttachmentIds: Set<string> }> {
+  const fetchImage = options.fetchImage ?? fetch;
+  const files: SpoilerAttachmentFile[] = [];
+  const copiedAttachmentIds = new Set<string>();
+
+  for (const attachment of attachments) {
+    const url = attachment.proxyUrl ?? attachment.url;
+    if (!url) {
+      continue;
+    }
+
+    try {
+      const response = await fetchImage(url);
+      if (!response.ok) {
+        options.logger?.warn(`Failed to fetch report image attachment ${attachment.id ?? url}`);
+        continue;
+      }
+
+      files.push({
+        attachment: Buffer.from(await response.arrayBuffer()),
+        name: toSpoilerFilename(attachment.name ?? attachment.id ?? 'image'),
+      });
+      if (attachment.id) {
+        copiedAttachmentIds.add(attachment.id);
+      }
+    } catch (error) {
+      options.logger?.warn(
+        `Failed to copy report image attachment ${attachment.id ?? url}:`,
+        error
+      );
+    }
+  }
+
+  return { files, copiedAttachmentIds };
+}
+
+export function toSpoilerFilename(filename: string): string {
+  const sanitized = filename.replace(/[\\/:*?"<>|]/g, '_').trim() || 'image';
+  return sanitized.startsWith('SPOILER_') ? sanitized : `SPOILER_${sanitized}`;
+}


### PR DESCRIPTION
[AGENT]

Summary:
- Add `/case refresh` to re-render stored case notifications without mutating case state.
- Preserve resolved-case presentation while refreshing notifications and restoring current admin actions.
- Improve Discord admin workflow surfaces: flatten admin notification actions, keep user-facing support-check prompts compact, and fix thread lock/archive ordering.
- Mirror support-check replies into private evidence threads, including eligible image attachments copied as spoilered files through shared report attachment handling.

Operator note:
- Existing stale notification embeds can be repaired after deploy with `/case refresh`; the command is notification-only and does not change case state.

Follow-up:
- Full live Discord queue/channel work remains tracked in #140.
