### PR TITLE
[AGENT] Add support thread reminders

### DIFF
--- a/docs/manual-qa.md
+++ b/docs/manual-qa.md
@@ -154,7 +154,20 @@ Prefer deterministic flows first. Use `/flaguser` instead of hoping heuristics t
   - the embed says no automatic restriction was applied
   - the embed shows heuristic reasons separately from the `Risk Analysis` field
 
-### 10. Observe-only notification coalescing
+### 10. Case review and user reminder flow
+
+- Start a fresh pending verification case with a user-facing verification thread.
+- For deterministic local QA, set the case `updated_at` and reminder metadata in a test database instead of waiting real days.
+- Run the bot long enough for `CaseReviewReminderService` to tick.
+- Expected result:
+  - admin digest groups pending cases into fresh, stale, and very stale
+  - digest lines include the target user mention and direct admin/thread links
+  - digest lines show the next user reminder timestamp or final manual review language
+  - user reminder posts in the user-facing verification thread and pings only the target user
+  - user reminder does not post within one hour after the admin digest
+  - target-user replies stop later user reminders and still notify admins through evidence mirroring/live queue
+
+### 11. Observe-only notification coalescing
 
 - Keep detection mode set to `notify_only`.
 - Set the window with `/config detection set-notification-window minutes:60`.
@@ -163,7 +176,7 @@ Prefer deterministic flows first. Use `/flaguser` instead of hoping heuristics t
   - the second detection updates the recent observed notification
   - the second detection does not send a second role ping inside the window
 
-### 11. Server-context prompt flow
+### 12. Server-context prompt flow
 
 - Set `server-about`, `verification-context`, and `expected-topics` in `/config verification context-set`.
 - Preview them with `/config verification context-view`.

--- a/docs/test-cases.md
+++ b/docs/test-cases.md
@@ -18,6 +18,8 @@ For a real-server walkthrough, use `docs/manual-qa.md`.
 - Verify button: restricted role removed, thread resolved, notification updated, admin action logged.
 - Ban button: member banned, verification status set to BANNED (if present), thread resolved, admin action logged.
 - Reopen button: verification returns to PENDING, thread reopened, user restricted again.
+- Stale case digest: groups pending cases into fresh, stale, and very stale; very stale users are shown for final manual review.
+- User-facing support reminder: pings only the target user in their verification thread, not admins, and stops after the target replies or reaches the very-stale day threshold.
 
 ## Automated tests (high-signal, easy to maintain)
 
@@ -45,6 +47,11 @@ For a real-server walkthrough, use `docs/manual-qa.md`.
 - `UserModerationService.banUser`
   - Calls Discord ban and updates `server_member` to BANNED.
   - Updates `verification_event` and resolves thread when one exists.
+- `CaseReviewReminderService`
+  - Sends one grouped admin digest per repeat window.
+  - Shows next user reminder timestamps using the same scheduling logic that sends reminders.
+  - Moves user reminders to the end of the admin review window when they collide with a digest.
+  - Stops user reminders after target response or the very-stale reminder limit.
 
 ## Full-stack smoke test (optional)
 

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -121,6 +121,26 @@ The user-facing verification thread, when present, remains separate in the
 verification/quarantine channel and is linked prominently in the admin embed's
 `Case Threads` field.
 
+## Case review reminders
+
+`CaseReviewReminderService` runs every 15 minutes and uses a daily, opinionated
+case-review workflow by default.
+
+- Admin stale-case digests post to the admin channel at most once per server repeat
+  window. The default stale threshold and repeat cadence are 24 hours.
+- Digests group pending cases as fresh, stale, and very stale. Very stale cases are
+  cases beyond the configured day threshold, defaulting to 3 days, and should get a
+  final manual ban/no-ban review.
+- User-facing support-thread reminders post only in the normal user-facing
+  verification thread. They ping the target user, not admins.
+- User reminders use fixed copy: `Ticket reminder: {elapsed} elapsed. {user_mention} See above.`
+- User reminders run every 24 hours until the very-stale day threshold or until the
+  target user responds. Target replies are also mirrored to admin evidence and the
+  live moderation queue when configured.
+- User reminders do not post inside the one-hour admin review window after a stale
+  digest. If a reminder would collide with that window, it is moved to the end of
+  the window and the digest shows the same next-reminder timestamp.
+
 ## User report
 
 1. A user submits the report modal.

--- a/src/__tests__/unit/CaseReviewReminderService.unit.test.ts
+++ b/src/__tests__/unit/CaseReviewReminderService.unit.test.ts
@@ -162,7 +162,7 @@ describe('CaseReviewReminderService (unit)', () => {
     const content = adminSend.mock.calls[0][0].content;
     expect(content).toContain('<@&123456789012345678>');
     expect(content.indexOf('Stale - waiting')).toBeLessThan(content.indexOf('Fresh - pending'));
-    expect(content).toContain('next user reminder <t:1780491600:F> (0/3 sent)');
+    expect(content).toContain('next user reminder <t:1780491600:F> (0/2 sent)');
     expect(content).toContain(
       'admin: https://discord.com/channels/guild-1/admin-channel-actual/admin-message-1'
     );
@@ -279,7 +279,7 @@ describe('CaseReviewReminderService (unit)', () => {
     const veryStaleCase = buildPendingCase(new Date('2026-06-02T10:00:00.000Z'), {
       support_thread_reminder: {
         lastReminderAt: '2026-06-05T12:00:00.000Z',
-        reminderCount: 3,
+        reminderCount: 2,
       },
     });
     const adminSend = jest.fn().mockResolvedValue(undefined);
@@ -297,7 +297,7 @@ describe('CaseReviewReminderService (unit)', () => {
 
     const content = adminSend.mock.calls[0][0].content;
     expect(content).toContain('Very stale - final manual check recommended (1)');
-    expect(content).toContain('user reminders sent 3/3; final manual check recommended');
+    expect(content).toContain('user reminders sent 2/2; final manual check recommended');
     expect(client.channels.fetch).not.toHaveBeenCalled();
     expect(verificationEventRepository.update).not.toHaveBeenCalled();
   });

--- a/src/__tests__/unit/CaseReviewReminderService.unit.test.ts
+++ b/src/__tests__/unit/CaseReviewReminderService.unit.test.ts
@@ -1,4 +1,4 @@
-import type { TextChannel } from 'discord.js';
+import type { Client, TextChannel, ThreadChannel } from 'discord.js';
 import type { IConfigService } from '../../config/ConfigService';
 import type { IServerRepository } from '../../repositories/ServerRepository';
 import type { IVerificationEventRepository } from '../../repositories/VerificationEventRepository';
@@ -31,18 +31,69 @@ const buildPendingCase = (
   server_id: 'guild-1',
   user_id: overrides.user_id ?? 'user-1',
   detection_event_id: overrides.detection_event_id ?? 'det-1',
-  thread_id: overrides.thread_id ?? 'case-thread-1',
+  thread_id: 'thread_id' in overrides ? (overrides.thread_id ?? null) : 'case-thread-1',
   private_evidence_thread_id: overrides.private_evidence_thread_id ?? 'evidence-thread-1',
-  notification_channel_id: overrides.notification_channel_id ?? null,
-  notification_message_id: overrides.notification_message_id ?? 'message-1',
+  notification_channel_id:
+    'notification_channel_id' in overrides ? (overrides.notification_channel_id ?? null) : null,
+  notification_message_id:
+    'notification_message_id' in overrides
+      ? (overrides.notification_message_id ?? null)
+      : 'message-1',
   status: VerificationStatus.PENDING,
-  created_at: updatedAt,
+  created_at: overrides.created_at ?? updatedAt,
   updated_at: updatedAt,
   resolved_at: null,
   resolved_by: null,
   notes: null,
   metadata,
 });
+
+function buildService(input: {
+  server: Server;
+  pendingCases: VerificationEvent[];
+  adminSend?: jest.Mock;
+  threadSend?: jest.Mock;
+}): {
+  service: CaseReviewReminderService;
+  configService: jest.Mocked<IConfigService>;
+  verificationEventRepository: jest.Mocked<IVerificationEventRepository>;
+  client: Client;
+} {
+  const adminSend = input.adminSend ?? jest.fn().mockResolvedValue(undefined);
+  const threadSend = input.threadSend ?? jest.fn().mockResolvedValue(undefined);
+  const serverRepository = {
+    findAllActive: jest.fn().mockResolvedValue([input.server]),
+  } as unknown as jest.Mocked<IServerRepository>;
+  const verificationEventRepository = {
+    findPendingByServer: jest.fn().mockResolvedValue(input.pendingCases),
+    update: jest.fn().mockResolvedValue({} as VerificationEvent),
+  } as unknown as jest.Mocked<IVerificationEventRepository>;
+  const configService = {
+    getAdminChannel: jest
+      .fn()
+      .mockResolvedValue({ id: 'admin-channel-actual', send: adminSend } as unknown as TextChannel),
+    updateServerSettings: jest.fn().mockResolvedValue({} as Server),
+  } as unknown as jest.Mocked<IConfigService>;
+  const client = {
+    channels: {
+      fetch: jest
+        .fn()
+        .mockResolvedValue({ isThread: () => true, send: threadSend } as unknown as ThreadChannel),
+    },
+  } as unknown as Client;
+
+  return {
+    service: new CaseReviewReminderService(
+      serverRepository,
+      verificationEventRepository,
+      configService,
+      client
+    ),
+    configService,
+    verificationEventRepository,
+    client,
+  };
+}
 
 describe('CaseReviewReminderService (unit)', () => {
   const originalDrasilWebPublicUrl = process.env.DRASIL_WEB_PUBLIC_URL;
@@ -67,7 +118,7 @@ describe('CaseReviewReminderService (unit)', () => {
     }
   });
 
-  it('sends one all-pending digest, stale cases first, with direct admin links', async () => {
+  it('sends a grouped all-pending digest with direct admin links and user reminder timing', async () => {
     const now = new Date('2026-06-03T12:00:00.000Z');
     const staleCase = buildPendingCase(
       new Date('2026-06-02T10:00:00.000Z'),
@@ -82,39 +133,24 @@ describe('CaseReviewReminderService (unit)', () => {
       user_id: 'user-fresh',
       notification_message_id: 'admin-message-2',
     });
-    const send = jest.fn().mockResolvedValue(undefined);
-    const serverRepository = {
-      findAllActive: jest.fn().mockResolvedValue([
-        buildServer({
-          case_review_reminders_enabled: true,
-          case_review_reminder_stale_hours: 24,
-          case_review_reminder_repeat_hours: 24,
-          case_responder_role_ids: ['123456789012345678'],
-          case_responder_routing_mode: 'ping_only',
-        }),
-      ]),
-    } as unknown as jest.Mocked<IServerRepository>;
-    const verificationEventRepository = {
-      findPendingByServer: jest.fn().mockResolvedValue([freshCase, staleCase]),
-      update: jest.fn(),
-    } as unknown as jest.Mocked<IVerificationEventRepository>;
-    const configService = {
-      getAdminChannel: jest
-        .fn()
-        .mockResolvedValue({ id: 'admin-channel-actual', send } as unknown as TextChannel),
-      updateServerSettings: jest.fn().mockResolvedValue({} as Server),
-    } as unknown as jest.Mocked<IConfigService>;
-
-    const service = new CaseReviewReminderService(
-      serverRepository,
-      verificationEventRepository,
-      configService
-    );
+    const adminSend = jest.fn().mockResolvedValue(undefined);
+    const { service, configService, verificationEventRepository, client } = buildService({
+      server: buildServer({
+        case_review_reminder_stale_hours: 24,
+        case_review_reminder_repeat_hours: 24,
+        case_responder_role_ids: ['123456789012345678'],
+        case_responder_routing_mode: 'ping_only',
+      }),
+      pendingCases: [freshCase, staleCase],
+      adminSend,
+    });
 
     await service.runOnce(now);
 
-    expect(send).toHaveBeenCalledWith({
-      content: expect.stringContaining('There are 2 pending cases needing review; 1 is stale.'),
+    expect(adminSend).toHaveBeenCalledWith({
+      content: expect.stringContaining(
+        'There are 2 pending cases needing review: 1 fresh, 1 stale, 0 very stale.'
+      ),
       allowedMentions: {
         parse: [],
         users: [],
@@ -123,11 +159,10 @@ describe('CaseReviewReminderService (unit)', () => {
       },
       components: expect.any(Array),
     });
-    const content = send.mock.calls[0][0].content;
+    const content = adminSend.mock.calls[0][0].content;
     expect(content).toContain('<@&123456789012345678>');
-    expect(content.indexOf('[STALE] <@user-stale>')).toBeLessThan(
-      content.indexOf('[pending] <@user-fresh>')
-    );
+    expect(content.indexOf('Stale - waiting')).toBeLessThan(content.indexOf('Fresh - pending'));
+    expect(content).toContain('next user reminder <t:1780491600:F> (0/3 sent)');
     expect(content).toContain(
       'admin: https://discord.com/channels/guild-1/admin-channel-actual/admin-message-1'
     );
@@ -135,13 +170,17 @@ describe('CaseReviewReminderService (unit)', () => {
     expect(content).toContain(
       'source: https://discord.com/channels/guild-1/source-channel-1/source-message-1'
     );
-    expect(send.mock.calls[0][0].components).toHaveLength(1);
+    expect(content).toContain(
+      'User-facing support reminders are sent every 24h until the very-stale threshold'
+    );
+    expect(adminSend.mock.calls[0][0].components).toHaveLength(1);
     expect(configService.updateServerSettings).toHaveBeenCalledWith(
       'guild-1',
       expect.objectContaining({
         [CASE_REVIEW_DIGEST_LAST_SENT_AT_SETTING_KEY]: now.toISOString(),
       })
     );
+    expect(client.channels.fetch).not.toHaveBeenCalled();
     expect(verificationEventRepository.update).not.toHaveBeenCalled();
   });
 
@@ -150,36 +189,19 @@ describe('CaseReviewReminderService (unit)', () => {
     delete process.env.NEXT_PUBLIC_APP_URL;
     const now = new Date('2026-06-03T12:00:00.000Z');
     const pendingCase = buildPendingCase(new Date('2026-06-02T10:00:00.000Z'));
-    const send = jest.fn().mockResolvedValue(undefined);
-    const serverRepository = {
-      findAllActive: jest.fn().mockResolvedValue([
-        buildServer({
-          case_review_reminders_enabled: true,
-          case_review_reminder_stale_hours: 24,
-          case_review_reminder_repeat_hours: 24,
-        }),
-      ]),
-    } as unknown as jest.Mocked<IServerRepository>;
-    const verificationEventRepository = {
-      findPendingByServer: jest.fn().mockResolvedValue([pendingCase]),
-      update: jest.fn(),
-    } as unknown as jest.Mocked<IVerificationEventRepository>;
-    const configService = {
-      getAdminChannel: jest
-        .fn()
-        .mockResolvedValue({ id: 'admin-channel-actual', send } as unknown as TextChannel),
-      updateServerSettings: jest.fn().mockResolvedValue({} as Server),
-    } as unknown as jest.Mocked<IConfigService>;
-
-    const service = new CaseReviewReminderService(
-      serverRepository,
-      verificationEventRepository,
-      configService
-    );
+    const adminSend = jest.fn().mockResolvedValue(undefined);
+    const { service } = buildService({
+      server: buildServer({
+        case_review_reminder_stale_hours: 24,
+        case_review_reminder_repeat_hours: 24,
+      }),
+      pendingCases: [pendingCase],
+      adminSend,
+    });
 
     await service.runOnce(now);
 
-    const buttons = send.mock.calls[0][0].components[0].toJSON().components as Array<{
+    const buttons = adminSend.mock.calls[0][0].components[0].toJSON().components as Array<{
       label?: string;
       url?: string;
     }>;
@@ -189,39 +211,94 @@ describe('CaseReviewReminderService (unit)', () => {
     });
   });
 
-  it('suppresses newly stale cases until the server repeat interval elapses', async () => {
+  it('suppresses newly stale admin digests until the server repeat interval elapses', async () => {
     const now = new Date('2026-06-03T12:00:00.000Z');
-    const newlyStaleCase = buildPendingCase(new Date('2026-06-02T10:00:00.000Z'));
-    const send = jest.fn().mockResolvedValue(undefined);
-    const serverRepository = {
-      findAllActive: jest.fn().mockResolvedValue([
-        buildServer({
-          case_review_reminders_enabled: true,
-          case_review_reminder_stale_hours: 24,
-          case_review_reminder_repeat_hours: 24,
-          [CASE_REVIEW_DIGEST_LAST_SENT_AT_SETTING_KEY]: '2026-06-03T10:00:00.000Z',
-        }),
-      ]),
-    } as unknown as jest.Mocked<IServerRepository>;
-    const verificationEventRepository = {
-      findPendingByServer: jest.fn().mockResolvedValue([newlyStaleCase]),
-      update: jest.fn(),
-    } as unknown as jest.Mocked<IVerificationEventRepository>;
-    const configService = {
-      getAdminChannel: jest.fn().mockResolvedValue({ send } as unknown as TextChannel),
-      updateServerSettings: jest.fn(),
-    } as unknown as jest.Mocked<IConfigService>;
-
-    const service = new CaseReviewReminderService(
-      serverRepository,
-      verificationEventRepository,
-      configService
-    );
+    const newlyStaleCase = buildPendingCase(new Date('2026-06-02T10:00:00.000Z'), null, {
+      thread_id: null,
+    });
+    const adminSend = jest.fn().mockResolvedValue(undefined);
+    const { service, configService, verificationEventRepository } = buildService({
+      server: buildServer({
+        case_review_reminder_stale_hours: 24,
+        case_review_reminder_repeat_hours: 24,
+        [CASE_REVIEW_DIGEST_LAST_SENT_AT_SETTING_KEY]: '2026-06-03T10:00:00.000Z',
+      }),
+      pendingCases: [newlyStaleCase],
+      adminSend,
+    });
 
     await service.runOnce(now);
 
-    expect(send).not.toHaveBeenCalled();
+    expect(adminSend).not.toHaveBeenCalled();
     expect(verificationEventRepository.update).not.toHaveBeenCalled();
     expect(configService.updateServerSettings).not.toHaveBeenCalled();
+  });
+
+  it('sends due user-facing support reminders after the admin review window', async () => {
+    const now = new Date('2026-06-03T12:00:00.000Z');
+    const staleCase = buildPendingCase(new Date('2026-06-02T10:00:00.000Z'));
+    const threadSend = jest.fn().mockResolvedValue(undefined);
+    const { service, verificationEventRepository, client } = buildService({
+      server: buildServer({
+        case_review_reminder_stale_hours: 24,
+        case_review_reminder_repeat_hours: 24,
+        [CASE_REVIEW_DIGEST_LAST_SENT_AT_SETTING_KEY]: '2026-06-03T10:00:00.000Z',
+      }),
+      pendingCases: [staleCase],
+      threadSend,
+    });
+
+    await service.runOnce(now);
+
+    expect(client.channels.fetch).toHaveBeenCalledWith('case-thread-1');
+    expect(threadSend).toHaveBeenCalledWith({
+      content: 'Ticket reminder: 26h elapsed. <@user-1> See above.',
+      allowedMentions: {
+        parse: [],
+        users: ['user-1'],
+        roles: [],
+        repliedUser: false,
+      },
+    });
+    expect(verificationEventRepository.update).toHaveBeenCalledWith(
+      staleCase.id,
+      {
+        metadata: {
+          support_thread_reminder: {
+            lastReminderAt: now.toISOString(),
+            reminderCount: 1,
+          },
+        },
+      },
+      { touchUpdatedAt: false }
+    );
+  });
+
+  it('keeps very stale cases in final manual review after user reminders are complete', async () => {
+    const now = new Date('2026-06-06T12:00:00.000Z');
+    const veryStaleCase = buildPendingCase(new Date('2026-06-02T10:00:00.000Z'), {
+      support_thread_reminder: {
+        lastReminderAt: '2026-06-05T12:00:00.000Z',
+        reminderCount: 3,
+      },
+    });
+    const adminSend = jest.fn().mockResolvedValue(undefined);
+    const { service, verificationEventRepository, client } = buildService({
+      server: buildServer({
+        case_review_reminder_stale_hours: 24,
+        case_review_reminder_repeat_hours: 24,
+        case_review_very_stale_days: 3,
+      }),
+      pendingCases: [veryStaleCase],
+      adminSend,
+    });
+
+    await service.runOnce(now);
+
+    const content = adminSend.mock.calls[0][0].content;
+    expect(content).toContain('Very stale - final manual check recommended (1)');
+    expect(content).toContain('user reminders sent 3/3; final manual check recommended');
+    expect(client.channels.fetch).not.toHaveBeenCalled();
+    expect(verificationEventRepository.update).not.toHaveBeenCalled();
   });
 });

--- a/src/__tests__/unit/VerificationThreadAnalysisService.unit.test.ts
+++ b/src/__tests__/unit/VerificationThreadAnalysisService.unit.test.ts
@@ -7,6 +7,8 @@ import { VerificationThreadAnalysisService } from '../../services/VerificationTh
 import { DetectionType, VerificationStatus } from '../../repositories/types';
 
 describe('VerificationThreadAnalysisService (unit)', () => {
+  const messageCreatedTimestamp = Date.parse('2026-06-03T12:00:00.000Z');
+
   const buildMessage = (overrides: Partial<any> = {}) => {
     const messages = new Collection<string, any>();
     const base = {
@@ -14,6 +16,7 @@ describe('VerificationThreadAnalysisService (unit)', () => {
       guildId: 'guild-1',
       channelId: 'thread-1',
       content: 'I joined for the weekly speedrun races.',
+      createdTimestamp: messageCreatedTimestamp,
       author: {
         id: 'user-1',
         username: 'runner',
@@ -259,6 +262,10 @@ describe('VerificationThreadAnalysisService (unit)', () => {
 
     const updated = await verificationRepo.findById(verificationEvent.id);
     expect(updated?.metadata).toEqual({
+      support_thread_reminder: {
+        reminderCount: 0,
+        userRespondedAt: '2026-06-03T12:00:00.000Z',
+      },
       thread_analysis: {
         analyzedMessageIds: ['msg-1'],
         latestAnalysis: {
@@ -558,7 +565,12 @@ describe('VerificationThreadAnalysisService (unit)', () => {
       );
 
       const updated = await verificationRepo.findById(verificationEvent.id);
-      expect(updated?.metadata).toBeNull();
+      expect(updated?.metadata).toEqual({
+        support_thread_reminder: {
+          reminderCount: 0,
+          userRespondedAt: '2026-06-03T12:00:00.000Z',
+        },
+      });
     } finally {
       warnSpy.mockRestore();
     }

--- a/src/__tests__/unit/VerificationThreadAnalysisService.unit.test.ts
+++ b/src/__tests__/unit/VerificationThreadAnalysisService.unit.test.ts
@@ -91,6 +91,62 @@ describe('VerificationThreadAnalysisService (unit)', () => {
     expect(gptService.analyzeVerificationThreadResponses).not.toHaveBeenCalled();
   });
 
+  it('does not rewrite support reminder response metadata after the first target reply', async () => {
+    const verificationRepo = new InMemoryVerificationEventRepository();
+    const detectionRepo = new InMemoryDetectionEventsRepository();
+    const verificationEvent = await verificationRepo.createFromDetection(
+      null,
+      'guild-1',
+      'user-1',
+      VerificationStatus.PENDING
+    );
+    await verificationRepo.update(verificationEvent.id, {
+      thread_id: 'thread-1',
+      private_evidence_thread_id: 'evidence-thread-1',
+      metadata: {
+        support_thread_reminder: {
+          lastReminderAt: '2026-06-02T12:00:00.000Z',
+          reminderCount: 1,
+          userRespondedAt: '2026-06-03T12:00:00.000Z',
+        },
+      },
+    });
+
+    const gptService = {
+      analyzeVerificationThreadResponses: jest.fn(),
+    } as any;
+    const notificationManager = {
+      updateVerificationThreadAnalysis: jest.fn(),
+      mirrorVerificationThreadMessageToEvidenceThread: jest.fn().mockResolvedValue(false),
+    } as any;
+    const configService = {
+      getServerConfig: jest.fn().mockResolvedValue({
+        settings: {
+          verification_ai_thread_analysis_enabled: false,
+          verification_ai_thread_analysis_message_limit: 3,
+        },
+      }),
+    } as any;
+    const service = new VerificationThreadAnalysisService(
+      configService,
+      gptService,
+      notificationManager,
+      verificationRepo,
+      detectionRepo
+    );
+    const updateSpy = jest.spyOn(verificationRepo, 'update');
+
+    const { message } = buildMessage({ id: 'msg-2' });
+    const handled = await service.handleThreadMessage(message as any);
+
+    expect(handled).toBe(true);
+    expect(
+      notificationManager.mirrorVerificationThreadMessageToEvidenceThread
+    ).toHaveBeenCalledWith(expect.objectContaining({ id: verificationEvent.id }), message);
+    expect(updateSpy).not.toHaveBeenCalled();
+    expect(gptService.analyzeVerificationThreadResponses).not.toHaveBeenCalled();
+  });
+
   it('ignores non-verification threads before hitting the repository', async () => {
     const verificationRepo = {
       findByThreadId: jest.fn(),

--- a/src/__tests__/unit/caseReviewReminderSchedule.unit.test.ts
+++ b/src/__tests__/unit/caseReviewReminderSchedule.unit.test.ts
@@ -45,6 +45,7 @@ describe('caseReviewReminderSchedule (unit)', () => {
     });
 
     expect(plan.nextUserReminderAt?.toISOString()).toBe('2026-06-03T13:00:00.000Z');
+    expect(plan.userReminderLimit).toBe(2);
   });
 
   it('uses the stale threshold for the first user reminder', () => {
@@ -56,6 +57,7 @@ describe('caseReviewReminderSchedule (unit)', () => {
     });
 
     expect(plan.nextUserReminderAt?.toISOString()).toBe('2026-06-04T10:00:00.000Z');
+    expect(plan.userReminderLimit).toBe(1);
   });
 
   it('marks cases very stale at the configured day threshold', () => {
@@ -65,20 +67,43 @@ describe('caseReviewReminderSchedule (unit)', () => {
     const plan = buildCaseReminderPlan(event, settings, now, { supportsUserReminder: true });
 
     expect(plan.freshness).toBe('very_stale');
+    expect(plan.nextUserReminderAt).toBeNull();
   });
 
-  it('stops user reminders once the very stale reminder count is reached', () => {
-    const now = new Date('2026-06-05T10:00:00.000Z');
+  it('stops user reminders before a shifted reminder would cross the very-stale cutoff', () => {
+    const now = new Date('2026-06-05T13:00:00.000Z');
     const event = buildEvent(new Date('2026-06-02T10:00:00.000Z'), {
       support_thread_reminder: {
-        lastReminderAt: '2026-06-04T10:00:00.000Z',
-        reminderCount: 3,
+        lastReminderAt: '2026-06-04T13:00:00.000Z',
+        reminderCount: 2,
       },
     });
 
     const plan = buildCaseReminderPlan(event, settings, now, { supportsUserReminder: true });
 
     expect(plan.userRemindersComplete).toBe(true);
+    expect(plan.userReminderLimit).toBe(2);
+    expect(plan.userReminderCount).toBe(2);
+    expect(plan.nextUserReminderAt).toBeNull();
+  });
+
+  it('caps reminders for custom stale thresholds before the very-stale cutoff', () => {
+    const now = new Date('2026-06-05T10:00:00.000Z');
+    const event = buildEvent(new Date('2026-06-02T10:00:00.000Z'), {
+      support_thread_reminder: {
+        lastReminderAt: '2026-06-04T10:00:00.000Z',
+        reminderCount: 1,
+      },
+    });
+
+    const plan = buildCaseReminderPlan(event, { ...settings, staleHours: 48 }, now, {
+      supportsUserReminder: true,
+    });
+
+    expect(plan.freshness).toBe('very_stale');
+    expect(plan.userRemindersComplete).toBe(true);
+    expect(plan.userReminderLimit).toBe(1);
+    expect(plan.userReminderCount).toBe(1);
     expect(plan.nextUserReminderAt).toBeNull();
   });
 

--- a/src/__tests__/unit/caseReviewReminderSchedule.unit.test.ts
+++ b/src/__tests__/unit/caseReviewReminderSchedule.unit.test.ts
@@ -1,0 +1,93 @@
+import { VerificationEvent, VerificationStatus } from '../../repositories/types';
+import {
+  buildCaseReminderPlan,
+  formatElapsed,
+  renderSupportThreadReminder,
+} from '../../utils/caseReviewReminderSchedule';
+import { CaseReviewReminderSettings } from '../../utils/caseReviewReminderSettings';
+
+const settings: CaseReviewReminderSettings = {
+  enabled: true,
+  staleHours: 24,
+  repeatHours: 24,
+  veryStaleDays: 3,
+};
+
+const buildEvent = (
+  updatedAt: Date,
+  metadata: VerificationEvent['metadata'] = null
+): VerificationEvent => ({
+  id: 'ver-1',
+  server_id: 'guild-1',
+  user_id: 'user-1',
+  detection_event_id: null,
+  thread_id: 'thread-1',
+  private_evidence_thread_id: null,
+  notification_channel_id: null,
+  notification_message_id: null,
+  status: VerificationStatus.PENDING,
+  created_at: updatedAt,
+  updated_at: updatedAt,
+  resolved_at: null,
+  resolved_by: null,
+  notes: null,
+  metadata,
+});
+
+describe('caseReviewReminderSchedule (unit)', () => {
+  it('moves due user reminders to the end of the admin review window', () => {
+    const now = new Date('2026-06-03T12:00:00.000Z');
+    const event = buildEvent(new Date('2026-06-02T10:00:00.000Z'));
+
+    const plan = buildCaseReminderPlan(event, settings, now, {
+      lastAdminDigestAt: now,
+      supportsUserReminder: true,
+    });
+
+    expect(plan.nextUserReminderAt?.toISOString()).toBe('2026-06-03T13:00:00.000Z');
+  });
+
+  it('uses the stale threshold for the first user reminder', () => {
+    const now = new Date('2026-06-03T12:00:00.000Z');
+    const event = buildEvent(new Date('2026-06-02T10:00:00.000Z'));
+
+    const plan = buildCaseReminderPlan(event, { ...settings, staleHours: 48 }, now, {
+      supportsUserReminder: true,
+    });
+
+    expect(plan.nextUserReminderAt?.toISOString()).toBe('2026-06-04T10:00:00.000Z');
+  });
+
+  it('marks cases very stale at the configured day threshold', () => {
+    const now = new Date('2026-06-05T10:00:00.000Z');
+    const event = buildEvent(new Date('2026-06-02T10:00:00.000Z'));
+
+    const plan = buildCaseReminderPlan(event, settings, now, { supportsUserReminder: true });
+
+    expect(plan.freshness).toBe('very_stale');
+  });
+
+  it('stops user reminders once the very stale reminder count is reached', () => {
+    const now = new Date('2026-06-05T10:00:00.000Z');
+    const event = buildEvent(new Date('2026-06-02T10:00:00.000Z'), {
+      support_thread_reminder: {
+        lastReminderAt: '2026-06-04T10:00:00.000Z',
+        reminderCount: 3,
+      },
+    });
+
+    const plan = buildCaseReminderPlan(event, settings, now, { supportsUserReminder: true });
+
+    expect(plan.userRemindersComplete).toBe(true);
+    expect(plan.nextUserReminderAt).toBeNull();
+  });
+
+  it('formats reminder copy with elapsed time', () => {
+    const event = buildEvent(new Date('2026-06-02T10:00:00.000Z'));
+
+    expect(renderSupportThreadReminder(event, new Date('2026-06-04T10:00:00.000Z'))).toBe(
+      'Ticket reminder: 2d elapsed. <@user-1> See above.'
+    );
+    expect(formatElapsed(24)).toBe('24h');
+  });
+});

--- a/src/__tests__/unit/caseReviewReminderSchedule.unit.test.ts
+++ b/src/__tests__/unit/caseReviewReminderSchedule.unit.test.ts
@@ -70,6 +70,18 @@ describe('caseReviewReminderSchedule (unit)', () => {
     expect(plan.nextUserReminderAt).toBeNull();
   });
 
+  it('does not mark unsupported cases as user reminder complete', () => {
+    const now = new Date('2026-06-05T10:00:00.000Z');
+    const event = buildEvent(new Date('2026-06-02T10:00:00.000Z'));
+
+    const plan = buildCaseReminderPlan(event, settings, now, { supportsUserReminder: false });
+
+    expect(plan.supportsUserReminder).toBe(false);
+    expect(plan.userReminderLimit).toBe(0);
+    expect(plan.userRemindersComplete).toBe(false);
+    expect(plan.nextUserReminderAt).toBeNull();
+  });
+
   it('stops user reminders before a shifted reminder would cross the very-stale cutoff', () => {
     const now = new Date('2026-06-05T13:00:00.000Z');
     const event = buildEvent(new Date('2026-06-02T10:00:00.000Z'), {

--- a/src/__tests__/unit/caseReviewReminderSettings.unit.test.ts
+++ b/src/__tests__/unit/caseReviewReminderSettings.unit.test.ts
@@ -1,25 +1,28 @@
 import { getCaseReviewReminderSettings } from '../../utils/caseReviewReminderSettings';
 
 describe('caseReviewReminderSettings (unit)', () => {
-  it('defaults reminders off with conservative intervals', () => {
+  it('defaults reminders on with conservative intervals', () => {
     expect(getCaseReviewReminderSettings({})).toEqual({
-      enabled: false,
+      enabled: true,
       staleHours: 24,
       repeatHours: 24,
+      veryStaleDays: 3,
     });
   });
 
-  it('coerces configured hours into safe bounds', () => {
+  it('coerces configured hours and days into safe bounds', () => {
     expect(
       getCaseReviewReminderSettings({
-        case_review_reminders_enabled: true,
+        case_review_reminders_enabled: false,
         case_review_reminder_stale_hours: 0,
         case_review_reminder_repeat_hours: 999,
+        case_review_very_stale_days: 999,
       })
     ).toEqual({
-      enabled: true,
+      enabled: false,
       staleHours: 1,
       repeatHours: 168,
+      veryStaleDays: 30,
     });
   });
 });

--- a/src/controllers/ConfigSubcommandHandler.ts
+++ b/src/controllers/ConfigSubcommandHandler.ts
@@ -22,6 +22,7 @@ import {
   CASE_REVIEW_REMINDER_REPEAT_HOURS_SETTING_KEY,
   CASE_REVIEW_REMINDER_STALE_HOURS_SETTING_KEY,
   CASE_REVIEW_REMINDERS_ENABLED_SETTING_KEY,
+  CASE_REVIEW_VERY_STALE_DAYS_SETTING_KEY,
   getCaseReviewReminderSettings,
 } from '../utils/caseReviewReminderSettings';
 import {
@@ -744,6 +745,21 @@ export class ConfigSubcommandHandler {
           return;
         }
 
+        case 'set-very-stale-days': {
+          const days = interaction.options.getInteger('days', true);
+          const updated = await this.configService.updateServerSettings(guildId, {
+            [CASE_REVIEW_VERY_STALE_DAYS_SETTING_KEY]: days,
+          });
+          const settings = getCaseReviewReminderSettings(updated.settings);
+          await interaction.reply({
+            content:
+              'Updated very stale case threshold.\n\n' +
+              this.formatCaseReviewReminderSettings(settings),
+            flags: MessageFlags.Ephemeral,
+          });
+          return;
+        }
+
         default:
           await interaction.reply({
             content: 'Unsupported case-review subcommand.',
@@ -769,7 +785,9 @@ export class ConfigSubcommandHandler {
       `Enabled: \`${settings.enabled ? 'yes' : 'no'}\``,
       `Stale threshold: \`${settings.staleHours}h\``,
       `Repeat interval: \`${settings.repeatHours}h\``,
-      'Reminders post to the admin channel and mention configured case responder roles.',
+      `Very stale threshold: \`${settings.veryStaleDays}d\``,
+      'Admin reminders post to the admin channel and mention configured case responder roles.',
+      'User-facing support reminders post every 24h until the very-stale threshold.',
     ].join('\n');
   }
 

--- a/src/controllers/commandDefinitions.ts
+++ b/src/controllers/commandDefinitions.ts
@@ -11,7 +11,9 @@ import {
 import { MAX_CASE_RESPONDER_THREAD_MEMBER_CAP } from '../utils/caseResponderSettings';
 import {
   MAX_CASE_REVIEW_REMINDER_HOURS,
+  MAX_CASE_REVIEW_VERY_STALE_DAYS,
   MIN_CASE_REVIEW_REMINDER_HOURS,
+  MIN_CASE_REVIEW_VERY_STALE_DAYS,
 } from '../utils/caseReviewReminderSettings';
 import { MAX_REPORT_AI_MAX_IMAGE_BYTES, MAX_REPORT_AI_MAX_IMAGES } from '../utils/reportAiSettings';
 import { USER_REPORT_REASON_MAX_LENGTH } from '../utils/userReportSettings';
@@ -511,6 +513,19 @@ const baseApplicationCommandBuilders = [
                 .setRequired(true)
                 .setMinValue(MIN_CASE_REVIEW_REMINDER_HOURS)
                 .setMaxValue(MAX_CASE_REVIEW_REMINDER_HOURS)
+            )
+        )
+        .addSubcommand((subcommand) =>
+          subcommand
+            .setName('set-very-stale-days')
+            .setDescription('Set days before pending cases need final manual review')
+            .addIntegerOption((option) =>
+              option
+                .setName('days')
+                .setDescription('Days before a pending case is very stale')
+                .setRequired(true)
+                .setMinValue(MIN_CASE_REVIEW_VERY_STALE_DAYS)
+                .setMaxValue(MAX_CASE_REVIEW_VERY_STALE_DAYS)
             )
         )
     )

--- a/src/repositories/types.ts
+++ b/src/repositories/types.ts
@@ -75,6 +75,7 @@ export interface ServerSettings {
   case_review_reminders_enabled?: boolean;
   case_review_reminder_stale_hours?: number;
   case_review_reminder_repeat_hours?: number;
+  case_review_very_stale_days?: number;
   case_review_digest_last_sent_at?: string | null;
   moderation_queue_channel_id?: string | null;
   setup_nudge_last_attempt_at?: string | null;

--- a/src/services/CaseReviewReminderService.ts
+++ b/src/services/CaseReviewReminderService.ts
@@ -325,6 +325,10 @@ export class CaseReviewReminderService implements ICaseReviewReminderService {
       return 'user responded; awaiting staff review';
     }
     if (plan.userRemindersComplete) {
+      if (plan.userReminderLimit === 0) {
+        return 'user reminder window closed; final manual check recommended';
+      }
+
       return `user reminders sent ${plan.userReminderCount}/${plan.userReminderLimit}; final manual check recommended`;
     }
     if (plan.nextUserReminderAt) {

--- a/src/services/CaseReviewReminderService.ts
+++ b/src/services/CaseReviewReminderService.ts
@@ -1,20 +1,28 @@
-import { ActionRowBuilder, ButtonBuilder, ButtonStyle } from 'discord.js';
+import { ActionRowBuilder, ButtonBuilder, ButtonStyle, Client, ThreadChannel } from 'discord.js';
 import { inject, injectable } from 'inversify';
 import { IConfigService } from '../config/ConfigService';
 import { TYPES } from '../di/symbols';
 import { IServerRepository } from '../repositories/ServerRepository';
 import { IVerificationEventRepository } from '../repositories/VerificationEventRepository';
-import { Server, VerificationEvent } from '../repositories/types';
+import { Server, VerificationEvent, VerificationStatus } from '../repositories/types';
 import { CASE_REVIEW_DIGEST_OPEN_CUSTOM_ID } from '../utils/caseReviewDigestCustomIds';
 import {
   CASE_REVIEW_DIGEST_LAST_SENT_AT_SETTING_KEY,
   getCaseReviewReminderSettings,
 } from '../utils/caseReviewReminderSettings';
+import {
+  buildCaseReminderPlan,
+  CaseFreshness,
+  CaseReminderPlan,
+  renderSupportThreadReminder,
+} from '../utils/caseReviewReminderSchedule';
+import { markSupportThreadReminderSent } from '../utils/supportThreadReminderState';
 import { buildAdminCaseQueueUrl } from '../utils/publicWebLinks';
 import { NotificationPresentationBuilder } from './NotificationPresentationBuilder';
+import { REPORT_REVIEW_THREAD_TYPE, VERIFICATION_THREAD_TYPE_METADATA_KEY } from './ThreadManager';
 
 const CASE_REVIEW_REMINDER_INTERVAL_MS = 15 * 60 * 1000;
-const CASE_REVIEW_REMINDER_MAX_CASES = 10;
+const CASE_REVIEW_REMINDER_MAX_VISIBLE_CASES = 10;
 
 export interface ICaseReviewReminderService {
   start(): void;
@@ -32,7 +40,8 @@ export class CaseReviewReminderService implements ICaseReviewReminderService {
     @inject(TYPES.ServerRepository) private readonly serverRepository: IServerRepository,
     @inject(TYPES.VerificationEventRepository)
     private readonly verificationEventRepository: IVerificationEventRepository,
-    @inject(TYPES.ConfigService) private readonly configService: IConfigService
+    @inject(TYPES.ConfigService) private readonly configService: IConfigService,
+    @inject(TYPES.DiscordClient) private readonly client: Client
   ) {}
 
   public start(): void {
@@ -85,57 +94,75 @@ export class CaseReviewReminderService implements ICaseReviewReminderService {
     const pendingCases = await this.verificationEventRepository.findPendingByServer(
       server.guild_id
     );
-    const staleCases = pendingCases.filter((event) =>
-      this.shouldRemind(event, now, settings.staleHours)
+    const lastAdminDigestAt = this.parseDate(
+      server.settings[CASE_REVIEW_DIGEST_LAST_SENT_AT_SETTING_KEY]
     );
-    if (staleCases.length === 0) {
-      return;
-    }
-    if (!this.shouldSendDigest(server, now, settings.repeatHours)) {
-      return;
+    let adminDigestSentAt: Date | null = null;
+
+    const initialPlans = new Map(
+      pendingCases.map((event) => [
+        event.id,
+        buildCaseReminderPlan(event, settings, now, {
+          lastAdminDigestAt,
+          supportsUserReminder: this.isUserFacingSupportCase(event),
+        }),
+      ])
+    );
+    const staleCases = pendingCases.filter(
+      (event) => initialPlans.get(event.id)?.freshness !== 'fresh'
+    );
+    if (
+      staleCases.length > 0 &&
+      this.shouldSendDigest(lastAdminDigestAt, now, settings.repeatHours)
+    ) {
+      const channel = await this.configService.getAdminChannel(server.guild_id);
+      if (channel) {
+        const digestPlans = new Map(
+          pendingCases.map((event) => [
+            event.id,
+            buildCaseReminderPlan(event, settings, now, {
+              lastAdminDigestAt: now,
+              supportsUserReminder: this.isUserFacingSupportCase(event),
+            }),
+          ])
+        );
+        const roleIds = this.presentationBuilder.getCaseNotificationRoleIds(server);
+        await channel.send({
+          content: this.buildReminderMessage(
+            server.guild_id,
+            channel.id,
+            this.sortPendingCasesForDigest(pendingCases, digestPlans),
+            digestPlans,
+            now,
+            this.presentationBuilder.formatRoleMentions(roleIds)
+          ),
+          allowedMentions: this.presentationBuilder.createAdminAllowedMentions(roleIds),
+          components: [this.createDigestActionRow(server.guild_id)],
+        });
+
+        adminDigestSentAt = now;
+        try {
+          await this.configService.updateServerSettings(server.guild_id, {
+            [CASE_REVIEW_DIGEST_LAST_SENT_AT_SETTING_KEY]: now.toISOString(),
+          });
+        } catch (error) {
+          console.error(
+            `Failed to stamp case review digest metadata for ${server.guild_id}:`,
+            error
+          );
+        }
+      }
     }
 
-    const channel = await this.configService.getAdminChannel(server.guild_id);
-    if (!channel) {
-      return;
-    }
-
-    const sortedCases = this.sortPendingCasesForDigest(pendingCases, staleCases);
-
-    const roleIds = this.presentationBuilder.getCaseNotificationRoleIds(server);
-    await channel.send({
-      content: this.buildReminderMessage(
-        server.guild_id,
-        channel.id,
-        sortedCases,
-        new Set(staleCases.map((event) => event.id)),
-        now,
-        this.presentationBuilder.formatRoleMentions(roleIds)
-      ),
-      allowedMentions: this.presentationBuilder.createAdminAllowedMentions(roleIds),
-      components: [this.createDigestActionRow(server.guild_id)],
-    });
-
-    try {
-      await this.configService.updateServerSettings(server.guild_id, {
-        [CASE_REVIEW_DIGEST_LAST_SENT_AT_SETTING_KEY]: now.toISOString(),
-      });
-    } catch (error) {
-      console.error(`Failed to stamp case review digest metadata for ${server.guild_id}:`, error);
-    }
+    await this.processUserThreadReminders(
+      pendingCases,
+      settings,
+      now,
+      adminDigestSentAt ?? lastAdminDigestAt
+    );
   }
 
-  private shouldRemind(event: VerificationEvent, now: Date, staleHours: number): boolean {
-    const lastMovementAt = event.updated_at;
-    if (now.getTime() - lastMovementAt.getTime() < staleHours * 60 * 60 * 1000) {
-      return false;
-    }
-
-    return true;
-  }
-
-  private shouldSendDigest(server: Server, now: Date, repeatHours: number): boolean {
-    const lastSentAt = this.parseDate(server.settings[CASE_REVIEW_DIGEST_LAST_SENT_AT_SETTING_KEY]);
+  private shouldSendDigest(lastSentAt: Date | null, now: Date, repeatHours: number): boolean {
     if (!lastSentAt) {
       return true;
     }
@@ -145,14 +172,18 @@ export class CaseReviewReminderService implements ICaseReviewReminderService {
 
   private sortPendingCasesForDigest(
     pendingCases: VerificationEvent[],
-    staleCases: VerificationEvent[]
+    plans: Map<string, CaseReminderPlan>
   ): VerificationEvent[] {
-    const staleCaseIds = new Set(staleCases.map((event) => event.id));
+    const freshnessRank: Record<CaseFreshness, number> = {
+      very_stale: 0,
+      stale: 1,
+      fresh: 2,
+    };
     return [...pendingCases].sort((left, right) => {
-      const leftIsStale = staleCaseIds.has(left.id);
-      const rightIsStale = staleCaseIds.has(right.id);
-      if (leftIsStale !== rightIsStale) {
-        return leftIsStale ? -1 : 1;
+      const leftRank = freshnessRank[plans.get(left.id)?.freshness ?? 'fresh'];
+      const rightRank = freshnessRank[plans.get(right.id)?.freshness ?? 'fresh'];
+      if (leftRank !== rightRank) {
+        return leftRank - rightRank;
       }
 
       return left.updated_at.getTime() - right.updated_at.getTime();
@@ -163,29 +194,104 @@ export class CaseReviewReminderService implements ICaseReviewReminderService {
     guildId: string,
     adminChannelId: string,
     events: VerificationEvent[],
-    staleCaseIds: Set<string>,
+    plans: Map<string, CaseReminderPlan>,
     now: Date,
     heading = 'Case review reminder'
   ): string {
-    const visibleEvents = events.slice(0, CASE_REVIEW_REMINDER_MAX_CASES);
-    const staleCount = events.filter((event) => staleCaseIds.has(event.id)).length;
+    const groupedEvents = this.groupEventsByFreshness(events, plans);
+    const staleCount = groupedEvents.stale.length;
+    const veryStaleCount = groupedEvents.very_stale.length;
     const lines = [
       heading,
-      `There ${events.length === 1 ? 'is' : 'are'} ${events.length} pending case${events.length === 1 ? '' : 's'} needing review; ${staleCount} ${staleCount === 1 ? 'is' : 'are'} stale.`,
-      '',
-      ...visibleEvents.map((event) =>
-        this.formatCaseLine(guildId, adminChannelId, event, now, staleCaseIds.has(event.id))
-      ),
+      `There ${events.length === 1 ? 'is' : 'are'} ${events.length} pending case${events.length === 1 ? '' : 's'} needing review: ${groupedEvents.fresh.length} fresh, ${staleCount} stale, ${veryStaleCount} very stale.`,
     ];
 
-    if (events.length > visibleEvents.length) {
-      lines.push(
-        '',
-        `Showing first ${visibleEvents.length}; ${events.length - visibleEvents.length} more pending case(s) are also stale.`
-      );
+    let remainingVisibleCases = CASE_REVIEW_REMINDER_MAX_VISIBLE_CASES;
+
+    remainingVisibleCases = this.appendCaseGroup(
+      lines,
+      'Very stale - final manual check recommended',
+      groupedEvents.very_stale,
+      plans,
+      guildId,
+      adminChannelId,
+      now,
+      remainingVisibleCases
+    );
+    remainingVisibleCases = this.appendCaseGroup(
+      lines,
+      'Stale - waiting on review or user response',
+      groupedEvents.stale,
+      plans,
+      guildId,
+      adminChannelId,
+      now,
+      remainingVisibleCases
+    );
+    this.appendCaseGroup(
+      lines,
+      'Fresh - pending but not stale yet',
+      groupedEvents.fresh,
+      plans,
+      guildId,
+      adminChannelId,
+      now,
+      remainingVisibleCases
+    );
+
+    if (events.length > CASE_REVIEW_REMINDER_MAX_VISIBLE_CASES) {
+      lines.push('', 'Open the case selector to review additional pending cases.');
     }
 
+    lines.push(
+      '',
+      'User-facing support reminders are sent every 24h until the very-stale threshold, then moderators should make a final manual call.'
+    );
+
     return lines.join('\n');
+  }
+
+  private groupEventsByFreshness(
+    events: VerificationEvent[],
+    plans: Map<string, CaseReminderPlan>
+  ): Record<CaseFreshness, VerificationEvent[]> {
+    return events.reduce<Record<CaseFreshness, VerificationEvent[]>>(
+      (groups, event) => {
+        groups[plans.get(event.id)?.freshness ?? 'fresh'].push(event);
+        return groups;
+      },
+      { fresh: [], stale: [], very_stale: [] }
+    );
+  }
+
+  private appendCaseGroup(
+    lines: string[],
+    heading: string,
+    events: VerificationEvent[],
+    plans: Map<string, CaseReminderPlan>,
+    guildId: string,
+    adminChannelId: string,
+    now: Date,
+    maxVisibleEvents: number
+  ): number {
+    if (events.length === 0) {
+      return maxVisibleEvents;
+    }
+
+    const visibleEvents = events.slice(0, Math.max(0, maxVisibleEvents));
+    lines.push('', `${heading} (${events.length})`);
+    if (visibleEvents.length > 0) {
+      lines.push(
+        ...visibleEvents.map((event) =>
+          this.formatCaseLine(guildId, adminChannelId, event, now, plans.get(event.id))
+        )
+      );
+    }
+    if (events.length > visibleEvents.length) {
+      lines.push(`... ${events.length - visibleEvents.length} more in this group.`);
+    }
+
+    return maxVisibleEvents - visibleEvents.length;
   }
 
   private formatCaseLine(
@@ -193,13 +299,9 @@ export class CaseReviewReminderService implements ICaseReviewReminderService {
     adminChannelId: string,
     event: VerificationEvent,
     now: Date,
-    isStale: boolean
+    plan: CaseReminderPlan | undefined
   ): string {
-    const lastMovementAt = event.updated_at;
-    const ageHours = Math.max(
-      1,
-      Math.floor((now.getTime() - lastMovementAt.getTime()) / (60 * 60 * 1000))
-    );
+    const ageHours = plan?.ageHours ?? 1;
     const links = [
       event.notification_message_id
         ? `admin: https://discord.com/channels/${guildId}/${adminChannelId}/${event.notification_message_id}`
@@ -210,8 +312,112 @@ export class CaseReviewReminderService implements ICaseReviewReminderService {
       event.thread_id ? `case: https://discord.com/channels/${guildId}/${event.thread_id}` : null,
       this.formatSourceMessageLink(guildId, event),
     ].filter((value): value is string => Boolean(value));
+    const reminderStatus = this.formatUserReminderStatus(plan);
 
-    return `- ${isStale ? '[STALE]' : '[pending]'} <@${event.user_id}> (${event.user_id}) ${ageHours}h since update${links.length ? ` - ${links.join(' | ')}` : ''}`;
+    return `- <@${event.user_id}> (${event.user_id}) ${ageHours}h since update${reminderStatus ? ` - ${reminderStatus}` : ''}${links.length ? ` - ${links.join(' | ')}` : ''}`;
+  }
+
+  private formatUserReminderStatus(plan: CaseReminderPlan | undefined): string | null {
+    if (!plan) {
+      return null;
+    }
+    if (plan.userResponded) {
+      return 'user responded; awaiting staff review';
+    }
+    if (plan.userRemindersComplete) {
+      return `user reminders sent ${plan.userReminderCount}/${plan.userReminderLimit}; final manual check recommended`;
+    }
+    if (plan.nextUserReminderAt) {
+      return `next user reminder ${this.formatTimestamp(plan.nextUserReminderAt)} (${plan.userReminderCount}/${plan.userReminderLimit} sent)`;
+    }
+
+    return null;
+  }
+
+  private async processUserThreadReminders(
+    pendingCases: VerificationEvent[],
+    settings: ReturnType<typeof getCaseReviewReminderSettings>,
+    now: Date,
+    lastAdminDigestAt: Date | null
+  ): Promise<void> {
+    for (const verificationEvent of pendingCases) {
+      await this.processUserThreadReminder(
+        verificationEvent,
+        settings,
+        now,
+        lastAdminDigestAt
+      ).catch((error) => {
+        console.warn(
+          `Failed to process support-thread reminder for case ${verificationEvent.id}:`,
+          error
+        );
+      });
+    }
+  }
+
+  private async processUserThreadReminder(
+    verificationEvent: VerificationEvent,
+    settings: ReturnType<typeof getCaseReviewReminderSettings>,
+    now: Date,
+    lastAdminDigestAt: Date | null
+  ): Promise<void> {
+    if (!this.isUserFacingSupportCase(verificationEvent)) {
+      return;
+    }
+
+    const plan = buildCaseReminderPlan(verificationEvent, settings, now, {
+      lastAdminDigestAt,
+      supportsUserReminder: true,
+    });
+    if (!plan.nextUserReminderAt || plan.nextUserReminderAt.getTime() > now.getTime()) {
+      return;
+    }
+
+    const thread = await this.fetchSupportThread(verificationEvent);
+    if (!thread) {
+      return;
+    }
+
+    await thread.send({
+      content: renderSupportThreadReminder(verificationEvent, now),
+      allowedMentions: {
+        parse: [],
+        users: [verificationEvent.user_id],
+        roles: [],
+        repliedUser: false,
+      },
+    });
+
+    await this.verificationEventRepository.update(
+      verificationEvent.id,
+      {
+        metadata: markSupportThreadReminderSent(
+          verificationEvent.metadata,
+          now
+        ) as VerificationEvent['metadata'],
+      },
+      { touchUpdatedAt: false }
+    );
+  }
+
+  private isUserFacingSupportCase(verificationEvent: VerificationEvent): boolean {
+    if (verificationEvent.status !== VerificationStatus.PENDING || !verificationEvent.thread_id) {
+      return false;
+    }
+
+    const metadata = this.metadataToRecord(verificationEvent.metadata);
+    return metadata[VERIFICATION_THREAD_TYPE_METADATA_KEY] !== REPORT_REVIEW_THREAD_TYPE;
+  }
+
+  private async fetchSupportThread(
+    verificationEvent: VerificationEvent
+  ): Promise<ThreadChannel | null> {
+    if (!verificationEvent.thread_id) {
+      return null;
+    }
+
+    const channel = await this.client.channels.fetch(verificationEvent.thread_id).catch(() => null);
+    return channel?.isThread() ? channel : null;
   }
 
   private formatSourceMessageLink(guildId: string, event: VerificationEvent): string | null {
@@ -245,6 +451,11 @@ export class CaseReviewReminderService implements ICaseReviewReminderService {
 
   private readString(value: unknown): string | null {
     return typeof value === 'string' && value ? value : null;
+  }
+
+  private formatTimestamp(value: Date): string {
+    const timestamp = Math.floor(value.getTime() / 1000);
+    return `<t:${timestamp}:F>`;
   }
 
   private metadataToRecord(metadata: unknown): Record<string, unknown> {

--- a/src/services/CaseReviewReminderService.ts
+++ b/src/services/CaseReviewReminderService.ts
@@ -15,6 +15,7 @@ import {
   CaseFreshness,
   CaseReminderPlan,
   renderSupportThreadReminder,
+  SUPPORT_THREAD_REMINDER_INTERVAL_HOURS,
 } from '../utils/caseReviewReminderSchedule';
 import { markSupportThreadReminderSent } from '../utils/supportThreadReminderState';
 import { buildAdminCaseQueueUrl } from '../utils/publicWebLinks';
@@ -245,7 +246,7 @@ export class CaseReviewReminderService implements ICaseReviewReminderService {
 
     lines.push(
       '',
-      'User-facing support reminders are sent every 24h until the very-stale threshold, then moderators should make a final manual call.'
+      `User-facing support reminders are sent every ${SUPPORT_THREAD_REMINDER_INTERVAL_HOURS}h until the very-stale threshold, then moderators should make a final manual call.`
     );
 
     return lines.join('\n');
@@ -318,7 +319,7 @@ export class CaseReviewReminderService implements ICaseReviewReminderService {
   }
 
   private formatUserReminderStatus(plan: CaseReminderPlan | undefined): string | null {
-    if (!plan) {
+    if (!plan || !plan.supportsUserReminder) {
       return null;
     }
     if (plan.userResponded) {

--- a/src/services/VerificationThreadAnalysisService.ts
+++ b/src/services/VerificationThreadAnalysisService.ts
@@ -6,12 +6,13 @@ import type { IGPTService, VerificationThreadAnalysisResult } from './GPTService
 import type { INotificationManager } from './NotificationManager';
 import type { IVerificationEventRepository } from '../repositories/VerificationEventRepository';
 import type { IDetectionEventsRepository } from '../repositories/DetectionEventsRepository';
-import { VerificationStatus } from '../repositories/types';
+import { VerificationEvent, VerificationStatus } from '../repositories/types';
 import {
   getVerificationThreadAnalysisSettings,
   VERIFICATION_THREAD_ANALYSIS_FETCH_LIMIT,
 } from '../utils/verificationThreadAnalysisSettings';
 import { IModerationQueueService } from './ModerationQueueService';
+import { markSupportThreadReminderUserResponded } from '../utils/supportThreadReminderState';
 
 interface ThreadAnalysisMetadata {
   analyzedMessageIds: string[];
@@ -82,10 +83,12 @@ export class VerificationThreadAnalysisService implements IVerificationThreadAna
     message: Message,
     verificationEventId: string
   ): Promise<void> {
-    const verificationEvent = await this.verificationEventRepository.findById(verificationEventId);
+    let verificationEvent = await this.verificationEventRepository.findById(verificationEventId);
     if (!verificationEvent || verificationEvent.status !== VerificationStatus.PENDING) {
       return;
     }
+
+    verificationEvent = await this.markSupportThreadReminderResponded(verificationEvent, message);
 
     await this.notificationManager.mirrorVerificationThreadMessageToEvidenceThread(
       verificationEvent,
@@ -173,6 +176,28 @@ export class VerificationThreadAnalysisService implements IVerificationThreadAna
         `[VerificationThreadAnalysis] Failed to persist metadata for verification event ${verificationEvent.id}`,
         error
       );
+    }
+  }
+
+  private async markSupportThreadReminderResponded(
+    verificationEvent: VerificationEvent,
+    message: Message
+  ): Promise<VerificationEvent> {
+    const metadata = markSupportThreadReminderUserResponded(
+      verificationEvent.metadata,
+      new Date(message.createdTimestamp || Date.now())
+    ) as VerificationEvent['metadata'];
+    try {
+      const updatedEvent = await this.verificationEventRepository.update(verificationEvent.id, {
+        metadata,
+      });
+      return updatedEvent ?? { ...verificationEvent, metadata };
+    } catch (error) {
+      console.warn(
+        `[VerificationThreadAnalysis] Failed to persist support-thread response metadata for verification event ${verificationEvent.id}`,
+        error
+      );
+      return { ...verificationEvent, metadata };
     }
   }
 

--- a/src/services/VerificationThreadAnalysisService.ts
+++ b/src/services/VerificationThreadAnalysisService.ts
@@ -12,7 +12,10 @@ import {
   VERIFICATION_THREAD_ANALYSIS_FETCH_LIMIT,
 } from '../utils/verificationThreadAnalysisSettings';
 import { IModerationQueueService } from './ModerationQueueService';
-import { markSupportThreadReminderUserResponded } from '../utils/supportThreadReminderState';
+import {
+  getSupportThreadReminderState,
+  markSupportThreadReminderUserResponded,
+} from '../utils/supportThreadReminderState';
 
 interface ThreadAnalysisMetadata {
   analyzedMessageIds: string[];
@@ -183,6 +186,10 @@ export class VerificationThreadAnalysisService implements IVerificationThreadAna
     verificationEvent: VerificationEvent,
     message: Message
   ): Promise<VerificationEvent> {
+    if (getSupportThreadReminderState(verificationEvent.metadata).userRespondedAt) {
+      return verificationEvent;
+    }
+
     const metadata = markSupportThreadReminderUserResponded(
       verificationEvent.metadata,
       new Date(message.createdTimestamp || Date.now())

--- a/src/utils/caseReviewReminderSchedule.ts
+++ b/src/utils/caseReviewReminderSchedule.ts
@@ -16,6 +16,7 @@ export interface CaseReminderPlan {
   readonly freshness: CaseFreshness;
   readonly ageHours: number;
   readonly nextUserReminderAt: Date | null;
+  readonly supportsUserReminder: boolean;
   readonly userReminderCount: number;
   readonly userReminderLimit: number;
   readonly userResponded: boolean;
@@ -34,13 +35,17 @@ export function buildCaseReminderPlan(
   const freshness =
     ageHours >= veryStaleHours ? 'very_stale' : ageHours >= settings.staleHours ? 'stale' : 'fresh';
   const reminderState = getSupportThreadReminderState(event.metadata);
-  const userReminderLimit = getUserReminderLimit(settings.staleHours, veryStaleHours);
+  const supportsUserReminder = options.supportsUserReminder !== false;
+  const userReminderLimit = supportsUserReminder
+    ? getUserReminderLimit(settings.staleHours, veryStaleHours)
+    : 0;
   const userResponded = Boolean(reminderState.userRespondedAt);
   const cutoffReached = freshness === 'very_stale';
-  let userRemindersComplete = cutoffReached || reminderState.reminderCount >= userReminderLimit;
+  let userRemindersComplete =
+    supportsUserReminder && (cutoffReached || reminderState.reminderCount >= userReminderLimit);
   let nextUserReminderAt: Date | null = null;
 
-  if (options.supportsUserReminder !== false && !userResponded && !userRemindersComplete) {
+  if (supportsUserReminder && !userResponded && !userRemindersComplete) {
     const candidate = avoidAdminReviewWindow(
       getRawNextUserReminderAt(event, reminderState.lastReminderAt, settings.staleHours),
       now,
@@ -57,6 +62,7 @@ export function buildCaseReminderPlan(
     freshness,
     ageHours,
     nextUserReminderAt,
+    supportsUserReminder,
     userReminderCount: Math.min(reminderState.reminderCount, userReminderLimit),
     userReminderLimit,
     userResponded,

--- a/src/utils/caseReviewReminderSchedule.ts
+++ b/src/utils/caseReviewReminderSchedule.ts
@@ -30,26 +30,34 @@ export function buildCaseReminderPlan(
 ): CaseReminderPlan {
   const ageHours = getElapsedHours(event.updated_at, now);
   const veryStaleHours = Math.max(settings.veryStaleDays * DAY_HOURS, settings.staleHours);
+  const veryStaleAt = addHours(event.updated_at, veryStaleHours);
   const freshness =
     ageHours >= veryStaleHours ? 'very_stale' : ageHours >= settings.staleHours ? 'stale' : 'fresh';
   const reminderState = getSupportThreadReminderState(event.metadata);
-  const userReminderLimit = settings.veryStaleDays;
+  const userReminderLimit = getUserReminderLimit(settings.staleHours, veryStaleHours);
   const userResponded = Boolean(reminderState.userRespondedAt);
-  const userRemindersComplete = reminderState.reminderCount >= userReminderLimit;
-  const nextUserReminderAt =
-    options.supportsUserReminder === false || userResponded || userRemindersComplete
-      ? null
-      : avoidAdminReviewWindow(
-          getRawNextUserReminderAt(event, reminderState.lastReminderAt, settings.staleHours),
-          now,
-          options.lastAdminDigestAt ?? null
-        );
+  const cutoffReached = freshness === 'very_stale';
+  let userRemindersComplete = cutoffReached || reminderState.reminderCount >= userReminderLimit;
+  let nextUserReminderAt: Date | null = null;
+
+  if (options.supportsUserReminder !== false && !userResponded && !userRemindersComplete) {
+    const candidate = avoidAdminReviewWindow(
+      getRawNextUserReminderAt(event, reminderState.lastReminderAt, settings.staleHours),
+      now,
+      options.lastAdminDigestAt ?? null
+    );
+    if (candidate < veryStaleAt) {
+      nextUserReminderAt = candidate;
+    } else {
+      userRemindersComplete = true;
+    }
+  }
 
   return {
     freshness,
     ageHours,
     nextUserReminderAt,
-    userReminderCount: reminderState.reminderCount,
+    userReminderCount: Math.min(reminderState.reminderCount, userReminderLimit),
     userReminderLimit,
     userResponded,
     userRemindersComplete,
@@ -107,6 +115,15 @@ function getRawNextUserReminderAt(
   }
 
   return addHours(event.updated_at, staleHours);
+}
+
+function getUserReminderLimit(staleHours: number, veryStaleHours: number): number {
+  const reminderWindowHours = veryStaleHours - staleHours;
+  if (reminderWindowHours <= 0) {
+    return 0;
+  }
+
+  return Math.ceil(reminderWindowHours / SUPPORT_THREAD_REMINDER_INTERVAL_HOURS);
 }
 
 function parseDate(value: string | undefined): Date | null {

--- a/src/utils/caseReviewReminderSchedule.ts
+++ b/src/utils/caseReviewReminderSchedule.ts
@@ -1,0 +1,119 @@
+import type { VerificationEvent } from '../repositories/types';
+import type { CaseReviewReminderSettings } from './caseReviewReminderSettings';
+import { getSupportThreadReminderState } from './supportThreadReminderState';
+
+export const SUPPORT_THREAD_REMINDER_INTERVAL_HOURS = 24;
+export const ADMIN_REVIEW_WINDOW_HOURS = 1;
+export const DEFAULT_SUPPORT_THREAD_REMINDER_TEMPLATE =
+  'Ticket reminder: {elapsed} elapsed. {user_mention} See above.';
+
+const HOUR_MS = 60 * 60 * 1000;
+const DAY_HOURS = 24;
+
+export type CaseFreshness = 'fresh' | 'stale' | 'very_stale';
+
+export interface CaseReminderPlan {
+  readonly freshness: CaseFreshness;
+  readonly ageHours: number;
+  readonly nextUserReminderAt: Date | null;
+  readonly userReminderCount: number;
+  readonly userReminderLimit: number;
+  readonly userResponded: boolean;
+  readonly userRemindersComplete: boolean;
+}
+
+export function buildCaseReminderPlan(
+  event: VerificationEvent,
+  settings: CaseReviewReminderSettings,
+  now: Date,
+  options: { lastAdminDigestAt?: Date | null; supportsUserReminder?: boolean } = {}
+): CaseReminderPlan {
+  const ageHours = getElapsedHours(event.updated_at, now);
+  const veryStaleHours = Math.max(settings.veryStaleDays * DAY_HOURS, settings.staleHours);
+  const freshness =
+    ageHours >= veryStaleHours ? 'very_stale' : ageHours >= settings.staleHours ? 'stale' : 'fresh';
+  const reminderState = getSupportThreadReminderState(event.metadata);
+  const userReminderLimit = settings.veryStaleDays;
+  const userResponded = Boolean(reminderState.userRespondedAt);
+  const userRemindersComplete = reminderState.reminderCount >= userReminderLimit;
+  const nextUserReminderAt =
+    options.supportsUserReminder === false || userResponded || userRemindersComplete
+      ? null
+      : avoidAdminReviewWindow(
+          getRawNextUserReminderAt(event, reminderState.lastReminderAt, settings.staleHours),
+          now,
+          options.lastAdminDigestAt ?? null
+        );
+
+  return {
+    freshness,
+    ageHours,
+    nextUserReminderAt,
+    userReminderCount: reminderState.reminderCount,
+    userReminderLimit,
+    userResponded,
+    userRemindersComplete,
+  };
+}
+
+export function renderSupportThreadReminder(event: VerificationEvent, now: Date): string {
+  return DEFAULT_SUPPORT_THREAD_REMINDER_TEMPLATE.replace(
+    /\{elapsed\}/gi,
+    formatElapsed(getElapsedHours(event.updated_at, now))
+  ).replace(/\{user_mention\}/gi, `<@${event.user_id}>`);
+}
+
+export function formatElapsed(hours: number): string {
+  if (hours >= 48 && hours % DAY_HOURS === 0) {
+    return `${hours / DAY_HOURS}d`;
+  }
+
+  return `${hours}h`;
+}
+
+function avoidAdminReviewWindow(candidate: Date, now: Date, lastAdminDigestAt: Date | null): Date {
+  if (!lastAdminDigestAt) {
+    return candidate;
+  }
+
+  const windowEnd = addHours(lastAdminDigestAt, ADMIN_REVIEW_WINDOW_HOURS);
+  const nowIsInsideWindow = now.getTime() >= lastAdminDigestAt.getTime() && now < windowEnd;
+  const candidateIsInsideWindow = candidate >= lastAdminDigestAt && candidate < windowEnd;
+  const overdueDuringWindow = nowIsInsideWindow && candidate <= windowEnd;
+
+  if (candidateIsInsideWindow || overdueDuringWindow) {
+    return windowEnd;
+  }
+
+  return candidate;
+}
+
+function getElapsedHours(from: Date, to: Date): number {
+  return Math.max(1, Math.floor((to.getTime() - from.getTime()) / HOUR_MS));
+}
+
+function addHours(value: Date, hours: number): Date {
+  return new Date(value.getTime() + hours * HOUR_MS);
+}
+
+function getRawNextUserReminderAt(
+  event: VerificationEvent,
+  lastReminderAt: string | undefined,
+  staleHours: number
+): Date {
+  const parsedLastReminderAt = parseDate(lastReminderAt);
+  if (parsedLastReminderAt) {
+    return addHours(parsedLastReminderAt, SUPPORT_THREAD_REMINDER_INTERVAL_HOURS);
+  }
+
+  return addHours(event.updated_at, staleHours);
+}
+
+function parseDate(value: string | undefined): Date | null {
+  if (!value) {
+    return null;
+  }
+
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date;
+}

--- a/src/utils/caseReviewReminderSettings.ts
+++ b/src/utils/caseReviewReminderSettings.ts
@@ -3,17 +3,22 @@ import type { ServerSettings } from '../repositories/types';
 export const CASE_REVIEW_REMINDERS_ENABLED_SETTING_KEY = 'case_review_reminders_enabled';
 export const CASE_REVIEW_REMINDER_STALE_HOURS_SETTING_KEY = 'case_review_reminder_stale_hours';
 export const CASE_REVIEW_REMINDER_REPEAT_HOURS_SETTING_KEY = 'case_review_reminder_repeat_hours';
+export const CASE_REVIEW_VERY_STALE_DAYS_SETTING_KEY = 'case_review_very_stale_days';
 export const CASE_REVIEW_DIGEST_LAST_SENT_AT_SETTING_KEY = 'case_review_digest_last_sent_at';
 
 export const DEFAULT_CASE_REVIEW_REMINDER_STALE_HOURS = 24;
 export const DEFAULT_CASE_REVIEW_REMINDER_REPEAT_HOURS = 24;
+export const DEFAULT_CASE_REVIEW_VERY_STALE_DAYS = 3;
 export const MIN_CASE_REVIEW_REMINDER_HOURS = 1;
 export const MAX_CASE_REVIEW_REMINDER_HOURS = 168;
+export const MIN_CASE_REVIEW_VERY_STALE_DAYS = 1;
+export const MAX_CASE_REVIEW_VERY_STALE_DAYS = 30;
 
 export interface CaseReviewReminderSettings {
   readonly enabled: boolean;
   readonly staleHours: number;
   readonly repeatHours: number;
+  readonly veryStaleDays: number;
 }
 
 function readHours(value: unknown, fallback: number): number {
@@ -24,11 +29,22 @@ function readHours(value: unknown, fallback: number): number {
   return Math.min(Math.max(value, MIN_CASE_REVIEW_REMINDER_HOURS), MAX_CASE_REVIEW_REMINDER_HOURS);
 }
 
+function readDays(value: unknown, fallback: number): number {
+  if (typeof value !== 'number' || !Number.isInteger(value)) {
+    return fallback;
+  }
+
+  return Math.min(
+    Math.max(value, MIN_CASE_REVIEW_VERY_STALE_DAYS),
+    MAX_CASE_REVIEW_VERY_STALE_DAYS
+  );
+}
+
 export function getCaseReviewReminderSettings(
   settings: ServerSettings = {}
 ): CaseReviewReminderSettings {
   return {
-    enabled: settings[CASE_REVIEW_REMINDERS_ENABLED_SETTING_KEY] === true,
+    enabled: settings[CASE_REVIEW_REMINDERS_ENABLED_SETTING_KEY] !== false,
     staleHours: readHours(
       settings[CASE_REVIEW_REMINDER_STALE_HOURS_SETTING_KEY],
       DEFAULT_CASE_REVIEW_REMINDER_STALE_HOURS
@@ -36,6 +52,10 @@ export function getCaseReviewReminderSettings(
     repeatHours: readHours(
       settings[CASE_REVIEW_REMINDER_REPEAT_HOURS_SETTING_KEY],
       DEFAULT_CASE_REVIEW_REMINDER_REPEAT_HOURS
+    ),
+    veryStaleDays: readDays(
+      settings[CASE_REVIEW_VERY_STALE_DAYS_SETTING_KEY],
+      DEFAULT_CASE_REVIEW_VERY_STALE_DAYS
     ),
   };
 }

--- a/src/utils/supportThreadReminderState.ts
+++ b/src/utils/supportThreadReminderState.ts
@@ -1,0 +1,83 @@
+export const SUPPORT_THREAD_REMINDER_METADATA_KEY = 'support_thread_reminder';
+
+export interface SupportThreadReminderState {
+  readonly lastReminderAt?: string;
+  readonly reminderCount: number;
+  readonly userRespondedAt?: string;
+}
+
+function toRecord(value: unknown): Record<string, unknown> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return {};
+  }
+
+  return { ...(value as Record<string, unknown>) };
+}
+
+function readString(value: unknown): string | undefined {
+  return typeof value === 'string' && value ? value : undefined;
+}
+
+function readReminderCount(value: unknown): number {
+  return typeof value === 'number' && Number.isInteger(value) && value >= 0 ? value : 0;
+}
+
+function compactState(state: Partial<SupportThreadReminderState>): Record<string, unknown> {
+  const compacted: Record<string, unknown> = {};
+  if (state.lastReminderAt !== undefined) {
+    compacted.lastReminderAt = state.lastReminderAt;
+  }
+  if (state.reminderCount !== undefined) {
+    compacted.reminderCount = state.reminderCount;
+  }
+  if (state.userRespondedAt !== undefined) {
+    compacted.userRespondedAt = state.userRespondedAt;
+  }
+
+  return compacted;
+}
+
+export function getSupportThreadReminderState(metadata: unknown): SupportThreadReminderState {
+  const root = toRecord(metadata);
+  const reminder = toRecord(root[SUPPORT_THREAD_REMINDER_METADATA_KEY]);
+
+  return {
+    lastReminderAt: readString(reminder.lastReminderAt),
+    reminderCount: readReminderCount(reminder.reminderCount),
+    userRespondedAt: readString(reminder.userRespondedAt),
+  };
+}
+
+export function withSupportThreadReminderState(
+  metadata: unknown,
+  nextState: Partial<SupportThreadReminderState>
+): Record<string, unknown> {
+  const root = toRecord(metadata);
+  return {
+    ...root,
+    [SUPPORT_THREAD_REMINDER_METADATA_KEY]: compactState(nextState),
+  };
+}
+
+export function markSupportThreadReminderSent(
+  metadata: unknown,
+  now: Date
+): Record<string, unknown> {
+  const state = getSupportThreadReminderState(metadata);
+  return withSupportThreadReminderState(metadata, {
+    ...state,
+    lastReminderAt: now.toISOString(),
+    reminderCount: state.reminderCount + 1,
+  });
+}
+
+export function markSupportThreadReminderUserResponded(
+  metadata: unknown,
+  respondedAt: Date
+): Record<string, unknown> {
+  const state = getSupportThreadReminderState(metadata);
+  return withSupportThreadReminderState(metadata, {
+    ...state,
+    userRespondedAt: respondedAt.toISOString(),
+  });
+}


### PR DESCRIPTION
[AGENT]

## What / Why

Adds the follow-up daily reminder workflow after #142: the existing admin digest now coordinates user-facing support-thread reminders so moderators get one grouped stale-case surface while users get a bounded 24h ping in their verification thread.

## Linked issues

- Builds on #123 and #142

## Risk / rollout

Default-on for existing servers. User reminders ping only target users and skip report-review threads; bot reminder metadata does not touch case updated_at.

## AI Review Packet (fresh-context friendly)

- Primary goal: coordinate stale-case admin digest and user-facing verification-thread reminders without adding a second admin ping stream.
- Non-goals: per-case reminder controls, custom reminder templates, new DB tables/migrations.
- Key files changed: `CaseReviewReminderService`, `caseReviewReminderSchedule`, `supportThreadReminderState`, `VerificationThreadAnalysisService`.
- Invariants this PR must preserve: admin digest remains rate-limited per server; user reminders never mention admins; target-user replies stop later user reminders; bot reminders do not reset stale case age.
- Manual test notes: not run; Discord staging smoke remains optional.
- Questions for reviewers: Are the default 3-day very-stale threshold and final manual-review wording clear enough for moderators?

## Merge checklist

- [ ] All PR review threads resolved (or explicitly addressed)