### PR TITLE
Route first messages through GPT

### DIFF
--- a/src/__tests__/unit/DetectionOrchestrator.unit.test.ts
+++ b/src/__tests__/unit/DetectionOrchestrator.unit.test.ts
@@ -256,6 +256,53 @@ describe('DetectionOrchestrator (unit)', () => {
     expect(events).toHaveLength(2);
   });
 
+  it('uses GPT for established users when message detection is forced', async () => {
+    heuristicService.analyzeMessage.mockReturnValue({ result: 'OK', reasons: [] });
+    gptService.analyzeProfile.mockResolvedValue(
+      makeGptAnalysis({
+        result: 'SUSPICIOUS',
+        confidence: 0.85,
+        reasons: ['AI analysis flagged recent message context as suspicious'],
+        reasonCodes: ['call_to_action'],
+        primarySignal: 'message_content',
+        summary: 'Recent message context contains suspicious outreach.',
+      })
+    );
+
+    const orchestrator = new DetectionOrchestrator(
+      heuristicService,
+      gptService,
+      detectionEventsRepository,
+      userRepository,
+      serverRepository
+    );
+
+    const profile: UserProfileData = {
+      username: 'established-user',
+      accountCreatedAt: new Date('2020-01-01T00:00:00.000Z'),
+      joinedServerAt: new Date('2020-01-01T00:00:00.000Z'),
+      recentMessages: [],
+    };
+
+    const result = await orchestrator.detectMessage(
+      serverId,
+      userId,
+      'commission advert',
+      profile,
+      {
+        forceGpt: true,
+      }
+    );
+
+    expect(gptService.analyzeProfile).toHaveBeenCalledWith(
+      expect.objectContaining({
+        recentMessages: ['commission advert'],
+      })
+    );
+    expect(result.label).toBe('SUSPICIOUS');
+    expect(result.detectionEventId).toBeDefined();
+  });
+
   it('does not count false-positive detections toward future suspicion', async () => {
     await detectionEventsRepository.create({
       server_id: serverId,

--- a/src/__tests__/unit/DetectionOrchestrator.unit.test.ts
+++ b/src/__tests__/unit/DetectionOrchestrator.unit.test.ts
@@ -299,8 +299,36 @@ describe('DetectionOrchestrator (unit)', () => {
         recentMessages: ['commission advert'],
       })
     );
+    expect(result.gptTriggerReasons).toEqual(['first_recent_messages']);
     expect(result.label).toBe('SUSPICIOUS');
     expect(result.detectionEventId).toBeDefined();
+  });
+
+  it('warns when forced GPT is requested without profile data', async () => {
+    heuristicService.analyzeMessage.mockReturnValue({ result: 'OK', reasons: [] });
+    const consoleWarn = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    try {
+      const orchestrator = new DetectionOrchestrator(
+        heuristicService,
+        gptService,
+        detectionEventsRepository,
+        userRepository,
+        serverRepository
+      );
+
+      const result = await orchestrator.detectMessage(serverId, userId, 'hello', undefined, {
+        forceGpt: true,
+      });
+
+      expect(gptService.analyzeProfile).not.toHaveBeenCalled();
+      expect(result.gptAnalysis).toBeUndefined();
+      expect(consoleWarn).toHaveBeenCalledWith(
+        'forceGpt requested without profileData; skipping GPT analysis.'
+      );
+    } finally {
+      consoleWarn.mockRestore();
+    }
   });
 
   it('does not count false-positive detections toward future suspicion', async () => {

--- a/src/__tests__/unit/EventHandler.unit.test.ts
+++ b/src/__tests__/unit/EventHandler.unit.test.ts
@@ -53,7 +53,6 @@ describe('EventHandler (unit)', () => {
           detection_response_mode: 'notify_only',
           min_confidence_threshold: 70,
         },
-        gptTriggerReasons: ['first_recent_messages'],
       }),
       updateServerConfig: jest.fn().mockResolvedValue({}),
       updateServerSettings: jest.fn().mockResolvedValue({}),

--- a/src/__tests__/unit/EventHandler.unit.test.ts
+++ b/src/__tests__/unit/EventHandler.unit.test.ts
@@ -22,6 +22,7 @@ describe('EventHandler (unit)', () => {
     reportIntakeAgentService?: Record<string, jest.Mock>;
     messageContextRepository?: Record<string, jest.Mock>;
     userModerationService?: Record<string, jest.Mock>;
+    productAnalyticsService?: Record<string, jest.Mock>;
   }): EventHandler {
     const client = overrides?.client ?? { on: jest.fn(), user: { id: 'bot-1' } };
     const detectionOrchestrator = overrides?.detectionOrchestrator ?? {
@@ -70,7 +71,7 @@ describe('EventHandler (unit)', () => {
       { handleTestCommands: jest.fn(), registerCommands: jest.fn() } as any,
       { handleButtonInteraction: jest.fn(), handleModalSubmit: jest.fn() } as any,
       { handleThreadMessage: jest.fn().mockResolvedValue(false) } as any,
-      undefined,
+      overrides?.productAnalyticsService as any,
       overrides?.setupDiagnosticsService as any,
       overrides?.reportIntakeService as any,
       overrides?.reportIntakeAgentService as any,
@@ -594,6 +595,152 @@ describe('EventHandler (unit)', () => {
       })
     );
     expect(messageContextRepository.recordMessage).toHaveBeenCalled();
+  });
+
+  it('forces GPT for messages inside the configured first-message window', async () => {
+    const detectionOrchestrator = {
+      detectMessage: jest.fn().mockResolvedValue({
+        label: 'OK',
+        confidence: 0.6,
+        reasons: [],
+        triggerSource: DetectionType.SUSPICIOUS_CONTENT,
+        triggerContent: 'free nitro',
+        gptAnalysis: {
+          result: 'OK',
+          confidence: 0.8,
+          reasons: ['Context looks legitimate'],
+          reasonCodes: ['normal_context'],
+          primarySignal: 'none',
+          summary: 'Context looks legitimate.',
+          model: 'test-model',
+          promptVersion: 'test-prompt',
+          isFallback: false,
+        },
+      }),
+      detectNewJoin: jest.fn(),
+    };
+    const productAnalyticsService = {
+      getStatus: jest.fn(),
+      captureGuildEvent: jest.fn(),
+      captureUserEvent: jest.fn().mockResolvedValue(undefined),
+      shutdown: jest.fn(),
+    };
+    const configService = {
+      initialize: jest.fn().mockResolvedValue(undefined),
+      getCachedServerConfig: jest.fn().mockReturnValue({}),
+      getServerConfig: jest.fn().mockResolvedValue({
+        settings: {
+          detection_response_mode: 'notify_only',
+          gpt_message_check_count: 3,
+          min_confidence_threshold: 70,
+        },
+      }),
+    };
+    const messageContextRepository = {
+      findRecentByServerAndUser: jest.fn().mockResolvedValue([]),
+      recordMessage: jest.fn().mockResolvedValue(undefined),
+      pruneExpired: jest.fn().mockResolvedValue(0),
+    };
+    const handler = buildHandler({
+      detectionOrchestrator,
+      configService,
+      messageContextRepository,
+      productAnalyticsService,
+    });
+
+    await (handler as any).handleMessage(buildMessage(new PermissionsBitField()));
+
+    expect(detectionOrchestrator.detectMessage).toHaveBeenCalledWith(
+      'guild-1',
+      'user-1',
+      'free nitro',
+      expect.objectContaining({
+        recentMessages: [],
+      }),
+      { forceGpt: true }
+    );
+    expect(productAnalyticsService.captureUserEvent).toHaveBeenCalledWith(
+      'guild-1',
+      'user-1',
+      'message detection forced gpt analyzed',
+      expect.objectContaining({
+        detection_type: DetectionType.SUSPICIOUS_CONTENT,
+        detection_label: 'OK',
+        confidence: 0.6,
+        confidence_bucket: '50-69',
+        detection_response_mode: 'notify_only',
+        gpt_force_reason: 'first_recent_messages',
+        recent_message_count: 0,
+        gpt_message_check_count: 3,
+        gpt_used: true,
+        gpt_result: 'OK',
+        gpt_confidence: 0.8,
+        gpt_confidence_bucket: '70-89',
+        gpt_primary_signal: 'none',
+        gpt_reason_codes: ['normal_context'],
+        gpt_is_fallback: false,
+      }),
+      { detectionEventId: undefined }
+    );
+  });
+
+  it('does not force GPT after the configured first-message window is full', async () => {
+    const detectionOrchestrator = {
+      detectMessage: jest.fn().mockResolvedValue({
+        label: 'OK',
+        confidence: 0,
+        reasons: [],
+        triggerSource: DetectionType.SUSPICIOUS_CONTENT,
+        triggerContent: 'free nitro',
+      }),
+      detectNewJoin: jest.fn(),
+    };
+    const productAnalyticsService = {
+      getStatus: jest.fn(),
+      captureGuildEvent: jest.fn(),
+      captureUserEvent: jest.fn().mockResolvedValue(undefined),
+      shutdown: jest.fn(),
+    };
+    const configService = {
+      initialize: jest.fn().mockResolvedValue(undefined),
+      getCachedServerConfig: jest.fn().mockReturnValue({}),
+      getServerConfig: jest.fn().mockResolvedValue({
+        settings: {
+          detection_response_mode: 'notify_only',
+          gpt_message_check_count: 3,
+          min_confidence_threshold: 70,
+        },
+      }),
+    };
+    const messageContextRepository = {
+      findRecentByServerAndUser: jest
+        .fn()
+        .mockResolvedValue([
+          { content_preview: 'message 1' },
+          { content_preview: 'message 2' },
+          { content_preview: 'message 3' },
+        ]),
+      recordMessage: jest.fn().mockResolvedValue(undefined),
+      pruneExpired: jest.fn().mockResolvedValue(0),
+    };
+    const handler = buildHandler({
+      detectionOrchestrator,
+      configService,
+      messageContextRepository,
+      productAnalyticsService,
+    });
+
+    await (handler as any).handleMessage(buildMessage(new PermissionsBitField()));
+
+    expect(detectionOrchestrator.detectMessage).toHaveBeenCalledWith(
+      'guild-1',
+      'user-1',
+      'free nitro',
+      expect.objectContaining({
+        recentMessages: ['message 1', 'message 2', 'message 3'],
+      })
+    );
+    expect(productAnalyticsService.captureUserEvent).not.toHaveBeenCalled();
   });
 
   it('loads config before exempting moderators when no cached config exists', async () => {

--- a/src/__tests__/unit/EventHandler.unit.test.ts
+++ b/src/__tests__/unit/EventHandler.unit.test.ts
@@ -53,6 +53,7 @@ describe('EventHandler (unit)', () => {
           detection_response_mode: 'notify_only',
           min_confidence_threshold: 70,
         },
+        gptTriggerReasons: ['first_recent_messages'],
       }),
       updateServerConfig: jest.fn().mockResolvedValue({}),
       updateServerSettings: jest.fn().mockResolvedValue({}),
@@ -616,6 +617,7 @@ describe('EventHandler (unit)', () => {
           promptVersion: 'test-prompt',
           isFallback: false,
         },
+        gptTriggerReasons: ['first_recent_messages'],
       }),
       detectNewJoin: jest.fn(),
     };
@@ -670,6 +672,8 @@ describe('EventHandler (unit)', () => {
         confidence_bucket: '50-69',
         detection_response_mode: 'notify_only',
         gpt_force_reason: 'first_recent_messages',
+        gpt_force_net_new: true,
+        gpt_trigger_reasons: ['first_recent_messages'],
         recent_message_count: 0,
         gpt_message_check_count: 3,
         gpt_used: true,
@@ -741,6 +745,56 @@ describe('EventHandler (unit)', () => {
       })
     );
     expect(productAnalyticsService.captureUserEvent).not.toHaveBeenCalled();
+  });
+
+  it('clamps the forced GPT message window to retained context capacity', async () => {
+    const detectionOrchestrator = {
+      detectMessage: jest.fn().mockResolvedValue({
+        label: 'OK',
+        confidence: 0,
+        reasons: [],
+        triggerSource: DetectionType.SUSPICIOUS_CONTENT,
+        triggerContent: 'free nitro',
+      }),
+      detectNewJoin: jest.fn(),
+    };
+    const configService = {
+      initialize: jest.fn().mockResolvedValue(undefined),
+      getCachedServerConfig: jest.fn().mockReturnValue({}),
+      getServerConfig: jest.fn().mockResolvedValue({
+        settings: {
+          detection_response_mode: 'notify_only',
+          gpt_message_check_count: 25,
+          min_confidence_threshold: 70,
+        },
+      }),
+    };
+    const messageContextRepository = {
+      findRecentByServerAndUser: jest.fn().mockResolvedValue(
+        Array.from({ length: 20 }, (_, index) => ({
+          content_preview: `message ${index + 1}`,
+        }))
+      ),
+      recordMessage: jest.fn().mockResolvedValue(undefined),
+      pruneExpired: jest.fn().mockResolvedValue(0),
+    };
+    const handler = buildHandler({
+      detectionOrchestrator,
+      configService,
+      messageContextRepository,
+    });
+
+    await (handler as any).handleMessage(buildMessage(new PermissionsBitField()));
+
+    expect(detectionOrchestrator.detectMessage).toHaveBeenCalledWith(
+      'guild-1',
+      'user-1',
+      'free nitro',
+      expect.objectContaining({
+        recentMessages: expect.arrayContaining(['message 1', 'message 20']),
+      })
+    );
+    expect(detectionOrchestrator.detectMessage.mock.calls[0]).toHaveLength(4);
   });
 
   it('loads config before exempting moderators when no cached config exists', async () => {

--- a/src/controllers/EventHandler.ts
+++ b/src/controllers/EventHandler.ts
@@ -31,8 +31,9 @@ import {
   IProductAnalyticsService,
   NOOP_PRODUCT_ANALYTICS_SERVICE,
 } from '../services/ProductAnalyticsService';
+import { getConfidenceBucket } from '../utils/analyticsHelpers';
 import { REPORT_INTAKE_THREAD_NAME_PREFIX } from '../services/ThreadManager';
-import { Server } from '../repositories/types';
+import { Server, ServerSettings } from '../repositories/types';
 import {
   ISetupDiagnosticsService,
   SetupDiagnosticReport,
@@ -305,6 +306,9 @@ export class EventHandler implements IEventHandler {
       }
 
       const recentMessages = await this.getRecentUserMessages(serverId, userId);
+      const gptMessageCheckCount = this.getGptMessageCheckCount(serverConfig.settings);
+      const forceGpt =
+        gptMessageCheckCount !== null && recentMessages.length < gptMessageCheckCount;
 
       // Get user profile data for detection context
       const profileData = this.extractUserProfileData(message.member, {
@@ -313,12 +317,21 @@ export class EventHandler implements IEventHandler {
       });
 
       // Use the detection orchestrator to analyze the message
-      const detectionResult = await this.detectionOrchestrator.detectMessage(
-        serverId,
-        userId,
-        content,
-        profileData
-      );
+      const detectionResult = forceGpt
+        ? await this.detectionOrchestrator.detectMessage(serverId, userId, content, profileData, {
+            forceGpt: true,
+          })
+        : await this.detectionOrchestrator.detectMessage(serverId, userId, content, profileData);
+
+      if (forceGpt) {
+        this.captureForcedGptMessageAnalytics(
+          message.member,
+          detectionResult,
+          responseSettings,
+          recentMessages.length,
+          gptMessageCheckCount
+        );
+      }
 
       await this.handleAutomaticDetection(
         message.member,
@@ -720,6 +733,53 @@ export class EventHandler implements IEventHandler {
       );
       return [];
     }
+  }
+
+  private getGptMessageCheckCount(settings: ServerSettings): number | null {
+    const configuredCount = settings.gpt_message_check_count;
+    if (
+      typeof configuredCount === 'number' &&
+      Number.isFinite(configuredCount) &&
+      configuredCount > 0
+    ) {
+      return configuredCount;
+    }
+
+    return null;
+  }
+
+  private captureForcedGptMessageAnalytics(
+    member: GuildMember,
+    detectionResult: DetectionResult,
+    responseSettings: DetectionResponseSettings,
+    recentMessageCount: number,
+    gptMessageCheckCount: number
+  ): void {
+    void this.productAnalyticsService.captureUserEvent(
+      member.guild.id,
+      member.id,
+      'message detection forced gpt analyzed',
+      {
+        detection_type: detectionResult.triggerSource,
+        detection_label: detectionResult.label,
+        confidence: detectionResult.confidence,
+        confidence_bucket: getConfidenceBucket(detectionResult.confidence),
+        detection_response_mode: responseSettings.mode,
+        gpt_force_reason: 'first_recent_messages',
+        recent_message_count: recentMessageCount,
+        gpt_message_check_count: gptMessageCheckCount,
+        gpt_used: detectionResult.gptAnalysis !== undefined,
+        gpt_result: detectionResult.gptAnalysis?.result,
+        gpt_confidence: detectionResult.gptAnalysis?.confidence,
+        gpt_confidence_bucket: detectionResult.gptAnalysis
+          ? getConfidenceBucket(detectionResult.gptAnalysis.confidence)
+          : undefined,
+        gpt_primary_signal: detectionResult.gptAnalysis?.primarySignal,
+        gpt_reason_codes: detectionResult.gptAnalysis?.reasonCodes,
+        gpt_is_fallback: detectionResult.gptAnalysis?.isFallback,
+      },
+      { detectionEventId: detectionResult.detectionEventId }
+    );
   }
 
   private rememberRecentMessage(message: Message): void {

--- a/src/controllers/EventHandler.ts
+++ b/src/controllers/EventHandler.ts
@@ -742,7 +742,7 @@ export class EventHandler implements IEventHandler {
       Number.isFinite(configuredCount) &&
       configuredCount > 0
     ) {
-      return configuredCount;
+      return Math.min(configuredCount, MESSAGE_CONTEXT_USER_LIMIT);
     }
 
     return null;
@@ -766,6 +766,10 @@ export class EventHandler implements IEventHandler {
         confidence_bucket: getConfidenceBucket(detectionResult.confidence),
         detection_response_mode: responseSettings.mode,
         gpt_force_reason: 'first_recent_messages',
+        gpt_force_net_new:
+          detectionResult.gptTriggerReasons?.length === 1 &&
+          detectionResult.gptTriggerReasons[0] === 'first_recent_messages',
+        gpt_trigger_reasons: detectionResult.gptTriggerReasons,
         recent_message_count: recentMessageCount,
         gpt_message_check_count: gptMessageCheckCount,
         gpt_used: detectionResult.gptAnalysis !== undefined,

--- a/src/services/DetectionOrchestrator.ts
+++ b/src/services/DetectionOrchestrator.ts
@@ -36,6 +36,10 @@ export interface DetectionResult {
   reportAiAnalysis?: ReportAIAnalysis;
 }
 
+export interface DetectionMessageOptions {
+  forceGpt?: boolean;
+}
+
 /**
  * Interface for the DetectionOrchestrator service
  */
@@ -53,7 +57,8 @@ export interface IDetectionOrchestrator {
     serverId: string,
     userId: string,
     content: string,
-    profileData?: UserProfileData
+    profileData?: UserProfileData,
+    options?: DetectionMessageOptions
   ): Promise<DetectionResult>;
 
   /**
@@ -170,7 +175,8 @@ export class DetectionOrchestrator implements IDetectionOrchestrator {
     serverId: string,
     userId: string,
     content: string,
-    profileData?: UserProfileData // Make optional to match caller
+    profileData?: UserProfileData, // Make optional to match caller
+    options: DetectionMessageOptions = {}
   ): Promise<DetectionResult> {
     try {
       // Add outer try block
@@ -241,11 +247,11 @@ export class DetectionOrchestrator implements IDetectionOrchestrator {
       }
 
       // Determine if we should use GPT
-      // Use GPT if:
-      // 1. The user is new (either to Discord or to the server) OR
-      // 2. The suspicion score is borderline (not clearly OK or clearly SUSPICIOUS)
+      // Use GPT if explicitly requested by the caller, if the user is new, or if the
+      // suspicion score is borderline (not clearly OK or clearly SUSPICIOUS).
       const shouldUseGPT =
-        (isNewAccount ||
+        (options.forceGpt === true ||
+          isNewAccount ||
           isNewServerMember ||
           (suspicionScore >= this.BORDERLINE_LOWER && suspicionScore <= this.BORDERLINE_UPPER)) &&
         profileData !== undefined;

--- a/src/services/DetectionOrchestrator.ts
+++ b/src/services/DetectionOrchestrator.ts
@@ -33,10 +33,18 @@ export interface DetectionResult {
   profileData?: UserProfileData;
   detectionEventId?: string;
   gptAnalysis?: GPTProfileAnalysis;
+  gptTriggerReasons?: DetectionGptTriggerReason[];
   reportAiAnalysis?: ReportAIAnalysis;
 }
 
+export type DetectionGptTriggerReason =
+  | 'first_recent_messages'
+  | 'new_account'
+  | 'new_server_member'
+  | 'borderline_score';
+
 export interface DetectionMessageOptions {
+  /** Requires profileData because GPT analysis is profile-context based. */
   forceGpt?: boolean;
 }
 
@@ -246,15 +254,28 @@ export class DetectionOrchestrator implements IDetectionOrchestrator {
         profileData.recentMessages = [...profileData.recentMessages, content];
       }
 
+      const gptTriggerReasons: DetectionGptTriggerReason[] = [];
+      if (options.forceGpt === true) {
+        gptTriggerReasons.push('first_recent_messages');
+      }
+      if (isNewAccount) {
+        gptTriggerReasons.push('new_account');
+      }
+      if (isNewServerMember) {
+        gptTriggerReasons.push('new_server_member');
+      }
+      if (suspicionScore >= this.BORDERLINE_LOWER && suspicionScore <= this.BORDERLINE_UPPER) {
+        gptTriggerReasons.push('borderline_score');
+      }
+
+      if (options.forceGpt === true && profileData === undefined) {
+        console.warn('forceGpt requested without profileData; skipping GPT analysis.');
+      }
+
       // Determine if we should use GPT
       // Use GPT if explicitly requested by the caller, if the user is new, or if the
       // suspicion score is borderline (not clearly OK or clearly SUSPICIOUS).
-      const shouldUseGPT =
-        (options.forceGpt === true ||
-          isNewAccount ||
-          isNewServerMember ||
-          (suspicionScore >= this.BORDERLINE_LOWER && suspicionScore <= this.BORDERLINE_UPPER)) &&
-        profileData !== undefined;
+      const shouldUseGPT = gptTriggerReasons.length > 0 && profileData !== undefined;
 
       let result: DetectionResult;
       let gptAnalysis: GPTProfileAnalysis | undefined;
@@ -281,6 +302,7 @@ export class DetectionOrchestrator implements IDetectionOrchestrator {
           triggerContent: content,
           profileData: profileData,
           gptAnalysis,
+          gptTriggerReasons,
         };
       } else {
         result = {


### PR DESCRIPTION
[AGENT]

## What / Why
Routes the configured first/stale recent messages through GPT by honoring `gpt_message_check_count` before the normal new-user/borderline heuristic gate.

Adds analytics for forced GPT outcomes without recording message content, so we can measure volume, GPT result/confidence, and final detection label.

## Risk / rollout
This intentionally increases GPT calls for users with fewer retained recent messages. Servers can disable the path by setting `gpt_message_check_count` to `0` or unset/non-positive values.

## AI Review Packet
Primary goal: make the existing first-message GPT setting actually route established or long-quiet users through GPT.
Non-goals: add advert-specific keyword rules or deterministic commercial-spam heuristics.
Key files changed: `EventHandler`, `DetectionOrchestrator`, focused unit tests.
Invariants this PR must preserve: no message content in analytics; existing new-user and borderline GPT behavior continues.