### PR TITLE
Fix case reminder digest overflow

### DIFF
--- a/docs/manual-qa.md
+++ b/docs/manual-qa.md
@@ -162,7 +162,7 @@ Prefer deterministic flows first. Use `/flaguser` instead of hoping heuristics t
 - Expected result:
   - admin digest groups pending cases into fresh, stale, and very stale
   - digest lines include the target user mention and direct admin/thread links
-  - digest lines show the next user reminder timestamp or final manual review language
+  - digest lines show the next user reminder timestamp or moderator-review language
   - user reminder posts in the user-facing verification thread and pings only the target user
   - user reminder does not post within one hour after the admin digest
   - target-user replies stop later user reminders and still notify admins through evidence mirroring/live queue

--- a/docs/test-cases.md
+++ b/docs/test-cases.md
@@ -18,7 +18,7 @@ For a real-server walkthrough, use `docs/manual-qa.md`.
 - Verify button: restricted role removed, thread resolved, notification updated, admin action logged.
 - Ban button: member banned, verification status set to BANNED (if present), thread resolved, admin action logged.
 - Reopen button: verification returns to PENDING, thread reopened, user restricted again.
-- Stale case digest: groups pending cases into fresh, stale, and very stale; very stale users are shown for final manual review.
+- Stale case digest: groups pending cases into fresh, stale, and very stale; very stale users remain pending for moderator review.
 - User-facing support reminder: pings only the target user in their verification thread, not admins, and stops after the target replies or reaches the very-stale day threshold.
 
 ## Automated tests (high-signal, easy to maintain)

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -129,8 +129,8 @@ case-review workflow by default.
 - Admin stale-case digests post to the admin channel at most once per server repeat
   window. The default stale threshold and repeat cadence are 24 hours.
 - Digests group pending cases as fresh, stale, and very stale. Very stale cases are
-  cases beyond the configured day threshold, defaulting to 3 days, and should get a
-  final manual ban/no-ban review.
+  cases beyond the configured day threshold, defaulting to 3 days, and remain pending
+  for moderator review.
 - User-facing support-thread reminders post only in the normal user-facing
   verification thread. They ping the target user, not admins.
 - User reminders use fixed copy: `Ticket reminder: {elapsed} elapsed. {user_mention} See above.`

--- a/src/__tests__/unit/CaseReviewReminderService.unit.test.ts
+++ b/src/__tests__/unit/CaseReviewReminderService.unit.test.ts
@@ -48,6 +48,27 @@ const buildPendingCase = (
   metadata,
 });
 
+const buildLargePendingCases = (count: number, updatedAt: Date): VerificationEvent[] =>
+  Array.from({ length: count }, (_, index) => {
+    const suffix = String(index + 1).padStart(2, '0');
+    const longId = `${suffix}12345678901234567890123456789012345678901234567890`;
+
+    return buildPendingCase(
+      updatedAt,
+      {
+        source_channel_id: `source-channel-${longId}`,
+        source_message_id: `source-message-${longId}`,
+      },
+      {
+        id: `ver-${suffix}`,
+        user_id: longId,
+        notification_message_id: `admin-message-${longId}`,
+        private_evidence_thread_id: `evidence-thread-${longId}`,
+        thread_id: `case-thread-${longId}`,
+      }
+    );
+  });
+
 function buildService(input: {
   server: Server;
   pendingCases: VerificationEvent[];
@@ -173,6 +194,8 @@ describe('CaseReviewReminderService (unit)', () => {
     expect(content).toContain(
       'User-facing support reminders are sent every 24h until the very-stale threshold'
     );
+    expect(content).toContain('Very stale cases remain pending for moderator review.');
+    expect(content).not.toContain('then moderators should make a final manual call');
     expect(adminSend.mock.calls[0][0].components).toHaveLength(1);
     expect(configService.updateServerSettings).toHaveBeenCalledWith(
       'guild-1',
@@ -182,6 +205,42 @@ describe('CaseReviewReminderService (unit)', () => {
     );
     expect(client.channels.fetch).not.toHaveBeenCalled();
     expect(verificationEventRepository.update).not.toHaveBeenCalled();
+  });
+
+  it('splits large admin digests on whole line boundaries and only pings roles once', async () => {
+    const now = new Date('2026-06-03T12:00:00.000Z');
+    const adminSend = jest.fn().mockResolvedValue(undefined);
+    const { service } = buildService({
+      server: buildServer({
+        case_review_reminder_stale_hours: 24,
+        case_review_reminder_repeat_hours: 24,
+        case_responder_role_ids: ['123456789012345678'],
+        case_responder_routing_mode: 'ping_only',
+      }),
+      pendingCases: buildLargePendingCases(10, new Date('2026-06-02T10:00:00.000Z')),
+      adminSend,
+    });
+
+    await service.runOnce(now);
+
+    expect(adminSend.mock.calls.length).toBeGreaterThan(1);
+    const payloads = adminSend.mock.calls.map(([payload]) => payload);
+    expect(payloads[0].allowedMentions.roles).toEqual(['123456789012345678']);
+    expect(payloads[0].components).toHaveLength(1);
+
+    for (const payload of payloads) {
+      expect(payload.content.length).toBeLessThanOrEqual(4000);
+      const caseLines = payload.content
+        .split('\n')
+        .filter((line: string) => line.includes('since update'));
+      expect(caseLines.every((line: string) => line.startsWith('- <@'))).toBe(true);
+    }
+
+    for (const payload of payloads.slice(1)) {
+      expect(payload.content).toMatch(/^Case review reminder continued\n/);
+      expect(payload.allowedMentions.roles).toEqual([]);
+      expect(payload.components).toBeUndefined();
+    }
   });
 
   it('adds a web queue link to the digest when the public web URL is configured', async () => {
@@ -274,7 +333,51 @@ describe('CaseReviewReminderService (unit)', () => {
     );
   });
 
-  it('keeps very stale cases in final manual review after user reminders are complete', async () => {
+  it('continues user reminders when the admin digest fails to send', async () => {
+    const now = new Date('2026-06-03T12:00:00.000Z');
+    const staleCase = buildPendingCase(new Date('2026-06-02T10:00:00.000Z'));
+    const adminSend = jest.fn().mockRejectedValue(new Error('digest too long'));
+    const threadSend = jest.fn().mockResolvedValue(undefined);
+    const consoleWarn = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const { service, configService, verificationEventRepository } = buildService({
+      server: buildServer({
+        case_review_reminder_stale_hours: 24,
+        case_review_reminder_repeat_hours: 24,
+      }),
+      pendingCases: [staleCase],
+      adminSend,
+      threadSend,
+    });
+
+    try {
+      await service.runOnce(now);
+    } finally {
+      consoleWarn.mockRestore();
+    }
+
+    expect(adminSend).toHaveBeenCalled();
+    expect(threadSend).toHaveBeenCalledWith({
+      content: 'Ticket reminder: 26h elapsed. <@user-1> See above.',
+      allowedMentions: {
+        parse: [],
+        users: ['user-1'],
+        roles: [],
+        repliedUser: false,
+      },
+    });
+    expect(configService.updateServerSettings).not.toHaveBeenCalled();
+    expect(verificationEventRepository.update).toHaveBeenCalledWith(
+      staleCase.id,
+      expect.objectContaining({
+        metadata: expect.objectContaining({
+          support_thread_reminder: expect.objectContaining({ reminderCount: 1 }),
+        }),
+      }),
+      { touchUpdatedAt: false }
+    );
+  });
+
+  it('keeps very stale cases pending for moderator review after user reminders are complete', async () => {
     const now = new Date('2026-06-06T12:00:00.000Z');
     const veryStaleCase = buildPendingCase(new Date('2026-06-02T10:00:00.000Z'), {
       support_thread_reminder: {
@@ -296,8 +399,8 @@ describe('CaseReviewReminderService (unit)', () => {
     await service.runOnce(now);
 
     const content = adminSend.mock.calls[0][0].content;
-    expect(content).toContain('Very stale - final manual check recommended (1)');
-    expect(content).toContain('user reminders sent 2/2; final manual check recommended');
+    expect(content).toContain('Very stale - awaiting moderator review (1)');
+    expect(content).toContain('user reminders sent 2/2; awaiting moderator review');
     expect(client.channels.fetch).not.toHaveBeenCalled();
     expect(verificationEventRepository.update).not.toHaveBeenCalled();
   });

--- a/src/__tests__/unit/CaseReviewReminderService.unit.test.ts
+++ b/src/__tests__/unit/CaseReviewReminderService.unit.test.ts
@@ -229,7 +229,7 @@ describe('CaseReviewReminderService (unit)', () => {
     expect(payloads[0].components).toHaveLength(1);
 
     for (const payload of payloads) {
-      expect(payload.content.length).toBeLessThanOrEqual(4000);
+      expect(payload.content.length).toBeLessThanOrEqual(1900);
       const caseLines = payload.content
         .split('\n')
         .filter((line: string) => line.includes('since update'));
@@ -241,6 +241,39 @@ describe('CaseReviewReminderService (unit)', () => {
       expect(payload.allowedMentions.roles).toEqual([]);
       expect(payload.components).toBeUndefined();
     }
+  });
+
+  it('stamps the digest after the role-ping chunk when continuation chunks fail', async () => {
+    const now = new Date('2026-06-03T12:00:00.000Z');
+    const adminSend = jest
+      .fn()
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValue(new Error('continuation failed'));
+    const consoleWarn = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const { service, configService } = buildService({
+      server: buildServer({
+        case_review_reminder_stale_hours: 24,
+        case_review_reminder_repeat_hours: 24,
+        case_responder_role_ids: ['123456789012345678'],
+        case_responder_routing_mode: 'ping_only',
+      }),
+      pendingCases: buildLargePendingCases(10, new Date('2026-06-02T10:00:00.000Z')),
+      adminSend,
+    });
+
+    try {
+      await service.runOnce(now);
+    } finally {
+      consoleWarn.mockRestore();
+    }
+
+    expect(adminSend.mock.calls.length).toBeGreaterThan(1);
+    expect(configService.updateServerSettings).toHaveBeenCalledWith(
+      'guild-1',
+      expect.objectContaining({
+        [CASE_REVIEW_DIGEST_LAST_SENT_AT_SETTING_KEY]: now.toISOString(),
+      })
+    );
   });
 
   it('adds a web queue link to the digest when the public web URL is configured', async () => {

--- a/src/controllers/commandDefinitions.ts
+++ b/src/controllers/commandDefinitions.ts
@@ -558,7 +558,7 @@ const baseApplicationCommandBuilders = [
         .addSubcommand((subcommand) =>
           subcommand
             .setName('set-very-stale-days')
-            .setDescription('Set days before pending cases need final manual review')
+            .setDescription('Set days before pending cases are very stale')
             .addIntegerOption((option) =>
               option
                 .setName('days')

--- a/src/services/CaseReviewReminderService.ts
+++ b/src/services/CaseReviewReminderService.ts
@@ -24,7 +24,7 @@ import { REPORT_REVIEW_THREAD_TYPE, VERIFICATION_THREAD_TYPE_METADATA_KEY } from
 
 const CASE_REVIEW_REMINDER_INTERVAL_MS = 15 * 60 * 1000;
 const CASE_REVIEW_REMINDER_MAX_VISIBLE_CASES = 10;
-const CASE_REVIEW_DIGEST_MESSAGE_MAX_LENGTH = 3500;
+const CASE_REVIEW_DIGEST_MESSAGE_MAX_LENGTH = 1900;
 const CASE_REVIEW_DIGEST_CONTINUED_HEADING = 'Case review reminder continued';
 
 export interface ICaseReviewReminderService {
@@ -127,7 +127,6 @@ export class CaseReviewReminderService implements ICaseReviewReminderService {
 
       if (digestSent) {
         adminDigestSentAt = now;
-        await this.stampAdminDigestSent(server.guild_id, now);
       }
     }
 
@@ -204,13 +203,21 @@ export class CaseReviewReminderService implements ICaseReviewReminderService {
           allowedMentions: this.presentationBuilder.createAdminAllowedMentions(roleIds),
           components: [this.createDigestActionRow(server.guild_id)],
         });
+        await this.stampAdminDigestSent(server.guild_id, now);
         continue;
       }
 
-      await channel.send({
-        content: messages[index],
-        allowedMentions: this.presentationBuilder.createAdminAllowedMentions([]),
-      });
+      await channel
+        .send({
+          content: messages[index],
+          allowedMentions: this.presentationBuilder.createAdminAllowedMentions([]),
+        })
+        .catch((error) => {
+          console.warn(
+            `Failed to send continuation case review digest for guild ${server.guild_id}:`,
+            error
+          );
+        });
     }
 
     return messages.length > 0;

--- a/src/services/CaseReviewReminderService.ts
+++ b/src/services/CaseReviewReminderService.ts
@@ -24,6 +24,8 @@ import { REPORT_REVIEW_THREAD_TYPE, VERIFICATION_THREAD_TYPE_METADATA_KEY } from
 
 const CASE_REVIEW_REMINDER_INTERVAL_MS = 15 * 60 * 1000;
 const CASE_REVIEW_REMINDER_MAX_VISIBLE_CASES = 10;
+const CASE_REVIEW_DIGEST_MESSAGE_MAX_LENGTH = 3500;
+const CASE_REVIEW_DIGEST_CONTINUED_HEADING = 'Case review reminder continued';
 
 export interface ICaseReviewReminderService {
   start(): void;
@@ -116,42 +118,16 @@ export class CaseReviewReminderService implements ICaseReviewReminderService {
       staleCases.length > 0 &&
       this.shouldSendDigest(lastAdminDigestAt, now, settings.repeatHours)
     ) {
-      const channel = await this.configService.getAdminChannel(server.guild_id);
-      if (channel) {
-        const digestPlans = new Map(
-          pendingCases.map((event) => [
-            event.id,
-            buildCaseReminderPlan(event, settings, now, {
-              lastAdminDigestAt: now,
-              supportsUserReminder: this.isUserFacingSupportCase(event),
-            }),
-          ])
-        );
-        const roleIds = this.presentationBuilder.getCaseNotificationRoleIds(server);
-        await channel.send({
-          content: this.buildReminderMessage(
-            server.guild_id,
-            channel.id,
-            this.sortPendingCasesForDigest(pendingCases, digestPlans),
-            digestPlans,
-            now,
-            this.presentationBuilder.formatRoleMentions(roleIds)
-          ),
-          allowedMentions: this.presentationBuilder.createAdminAllowedMentions(roleIds),
-          components: [this.createDigestActionRow(server.guild_id)],
-        });
-
-        adminDigestSentAt = now;
-        try {
-          await this.configService.updateServerSettings(server.guild_id, {
-            [CASE_REVIEW_DIGEST_LAST_SENT_AT_SETTING_KEY]: now.toISOString(),
-          });
-        } catch (error) {
-          console.error(
-            `Failed to stamp case review digest metadata for ${server.guild_id}:`,
-            error
-          );
+      const digestSent = await this.sendAdminDigest(server, pendingCases, settings, now).catch(
+        (error) => {
+          console.warn(`Failed to send case review digest for guild ${server.guild_id}:`, error);
+          return false;
         }
+      );
+
+      if (digestSent) {
+        adminDigestSentAt = now;
+        await this.stampAdminDigestSent(server.guild_id, now);
       }
     }
 
@@ -191,27 +167,101 @@ export class CaseReviewReminderService implements ICaseReviewReminderService {
     });
   }
 
-  private buildReminderMessage(
+  private async sendAdminDigest(
+    server: Server,
+    pendingCases: VerificationEvent[],
+    settings: ReturnType<typeof getCaseReviewReminderSettings>,
+    now: Date
+  ): Promise<boolean> {
+    const channel = await this.configService.getAdminChannel(server.guild_id);
+    if (!channel) {
+      return false;
+    }
+
+    const digestPlans = new Map(
+      pendingCases.map((event) => [
+        event.id,
+        buildCaseReminderPlan(event, settings, now, {
+          lastAdminDigestAt: now,
+          supportsUserReminder: this.isUserFacingSupportCase(event),
+        }),
+      ])
+    );
+    const roleIds = this.presentationBuilder.getCaseNotificationRoleIds(server);
+    const messages = this.buildReminderMessages(
+      server.guild_id,
+      channel.id,
+      this.sortPendingCasesForDigest(pendingCases, digestPlans),
+      digestPlans,
+      now,
+      this.presentationBuilder.formatRoleMentions(roleIds)
+    );
+
+    for (let index = 0; index < messages.length; index += 1) {
+      if (index === 0) {
+        await channel.send({
+          content: messages[index],
+          allowedMentions: this.presentationBuilder.createAdminAllowedMentions(roleIds),
+          components: [this.createDigestActionRow(server.guild_id)],
+        });
+        continue;
+      }
+
+      await channel.send({
+        content: messages[index],
+        allowedMentions: this.presentationBuilder.createAdminAllowedMentions([]),
+      });
+    }
+
+    return messages.length > 0;
+  }
+
+  private async stampAdminDigestSent(guildId: string, now: Date): Promise<void> {
+    try {
+      await this.configService.updateServerSettings(guildId, {
+        [CASE_REVIEW_DIGEST_LAST_SENT_AT_SETTING_KEY]: now.toISOString(),
+      });
+    } catch (error) {
+      console.error(`Failed to stamp case review digest metadata for ${guildId}:`, error);
+    }
+  }
+
+  private buildReminderMessages(
     guildId: string,
     adminChannelId: string,
     events: VerificationEvent[],
     plans: Map<string, CaseReminderPlan>,
     now: Date,
     heading = 'Case review reminder'
-  ): string {
+  ): string[] {
+    return this.splitDigestLines(
+      this.buildReminderMessageLines(guildId, adminChannelId, events, plans, now, heading)
+    );
+  }
+
+  private buildReminderMessageLines(
+    guildId: string,
+    adminChannelId: string,
+    events: VerificationEvent[],
+    plans: Map<string, CaseReminderPlan>,
+    now: Date,
+    heading = 'Case review reminder'
+  ): string[] {
     const groupedEvents = this.groupEventsByFreshness(events, plans);
     const staleCount = groupedEvents.stale.length;
     const veryStaleCount = groupedEvents.very_stale.length;
     const lines = [
-      heading,
       `There ${events.length === 1 ? 'is' : 'are'} ${events.length} pending case${events.length === 1 ? '' : 's'} needing review: ${groupedEvents.fresh.length} fresh, ${staleCount} stale, ${veryStaleCount} very stale.`,
     ];
+    if (heading) {
+      lines.unshift(heading);
+    }
 
     let remainingVisibleCases = CASE_REVIEW_REMINDER_MAX_VISIBLE_CASES;
 
     remainingVisibleCases = this.appendCaseGroup(
       lines,
-      'Very stale - final manual check recommended',
+      'Very stale - awaiting moderator review',
       groupedEvents.very_stale,
       plans,
       guildId,
@@ -246,10 +296,46 @@ export class CaseReviewReminderService implements ICaseReviewReminderService {
 
     lines.push(
       '',
-      `User-facing support reminders are sent every ${SUPPORT_THREAD_REMINDER_INTERVAL_HOURS}h until the very-stale threshold, then moderators should make a final manual call.`
+      `User-facing support reminders are sent every ${SUPPORT_THREAD_REMINDER_INTERVAL_HOURS}h until the very-stale threshold. Very stale cases remain pending for moderator review.`
     );
 
-    return lines.join('\n');
+    return lines;
+  }
+
+  private splitDigestLines(lines: string[]): string[] {
+    const messages: string[] = [];
+    let currentLines: string[] = [];
+
+    for (const line of lines) {
+      const candidateLines = [...currentLines, line];
+      if (
+        currentLines.length > 0 &&
+        candidateLines.join('\n').length > CASE_REVIEW_DIGEST_MESSAGE_MAX_LENGTH
+      ) {
+        messages.push(currentLines.join('\n'));
+        currentLines = [CASE_REVIEW_DIGEST_CONTINUED_HEADING];
+      }
+
+      if (currentLines.length === 1 && currentLines[0] === CASE_REVIEW_DIGEST_CONTINUED_HEADING) {
+        if (line === '') {
+          continue;
+        }
+
+        const continuedCandidate = [...currentLines, line].join('\n');
+        if (continuedCandidate.length > CASE_REVIEW_DIGEST_MESSAGE_MAX_LENGTH) {
+          messages.push(currentLines.join('\n'));
+          currentLines = [];
+        }
+      }
+
+      currentLines.push(line);
+    }
+
+    if (currentLines.length > 0) {
+      messages.push(currentLines.join('\n'));
+    }
+
+    return messages;
   }
 
   private groupEventsByFreshness(
@@ -327,10 +413,10 @@ export class CaseReviewReminderService implements ICaseReviewReminderService {
     }
     if (plan.userRemindersComplete) {
       if (plan.userReminderLimit === 0) {
-        return 'user reminder window closed; final manual check recommended';
+        return 'user reminder window closed; awaiting moderator review';
       }
 
-      return `user reminders sent ${plan.userReminderCount}/${plan.userReminderLimit}; final manual check recommended`;
+      return `user reminders sent ${plan.userReminderCount}/${plan.userReminderLimit}; awaiting moderator review`;
     }
     if (plan.nextUserReminderAt) {
       return `next user reminder ${this.formatTimestamp(plan.nextUserReminderAt)} (${plan.userReminderCount}/${plan.userReminderLimit} sent)`;


### PR DESCRIPTION
[AGENT]

## What / Why

Fixes case review reminder passes getting blocked when a large admin digest exceeds Discord's message length limit. Large digests now split across whole-line message chunks, and user-facing verification-thread reminders continue even if the admin digest send fails.

Also softens very-stale copy from final manual-call language to pending moderator-review language.

## Linked issues

None.

## How to test

Targeted local checks passed for the reminder service split/failure behavior.

## Risk / rollout

Low-risk reminder formatting change. First digest message still carries role mentions and action buttons; continuation messages are no-ping text-only messages.

## AI Review Packet (fresh-context friendly)

- Primary goal: prevent oversized admin digests from blocking stale user reminder pings.
- Non-goals: change reminder scheduling, case eligibility, or Discord thread creation behavior.
- Key files changed: `src/services/CaseReviewReminderService.ts`, `src/__tests__/unit/CaseReviewReminderService.unit.test.ts`.
- Invariants this PR must preserve: only the first digest message pings admin/case roles; user reminders still only ping the target user in user-facing verification threads.
- Manual test notes: not manually tested in Discord.
- Questions for reviewers: none.

## Merge checklist

- [ ] All PR review threads resolved (or explicitly addressed)
