### PR TITLE
[AGENT] Surface case repair failures and bound role intake

### DIFF
--- a/src/__tests__/unit/RoleIntakeProcessor.unit.test.ts
+++ b/src/__tests__/unit/RoleIntakeProcessor.unit.test.ts
@@ -1,5 +1,6 @@
 import { Guild, GuildMember, Role, User } from 'discord.js';
 import { VerificationStatus } from '../../repositories/types';
+import type { AdminCaseResult } from '../../services/SecurityActionService';
 import { RoleIntakeProcessor } from '../../services/RoleIntakeProcessor';
 
 const buildMember = (guildId: string, userId: string, bot = false): GuildMember =>
@@ -157,6 +158,56 @@ describe('RoleIntakeProcessor (unit)', () => {
       member,
       moderator,
       expect.objectContaining({ action: 'restrict' })
+    );
+  });
+
+  it('records a failure and continues when one role intake member times out', async () => {
+    const guildId = 'guild-role-intake-timeout';
+    const hangingMember = buildMember(guildId, 'user-hangs');
+    const okMember = buildMember(guildId, 'user-ok');
+    const role = buildRole(guildId, [hangingMember, okMember]);
+    const verificationEventRepository = {
+      findActiveByUserAndServer: jest.fn().mockResolvedValue(null),
+    };
+    const openAdminCase = jest.fn((member: GuildMember): Promise<AdminCaseResult> => {
+      if (member.id === hangingMember.id) {
+        return new Promise<AdminCaseResult>(() => undefined);
+      }
+
+      return Promise.resolve({
+        opened: true,
+        restrictionAttempted: false,
+        restricted: false,
+      });
+    });
+    const onProgress = jest.fn();
+    const processor = new RoleIntakeProcessor(verificationEventRepository, openAdminCase);
+
+    const result = await processor.intakeRoleMembers({
+      role,
+      moderator,
+      action: 'open_case',
+      execute: true,
+      delayMs: 0,
+      memberTimeoutMs: 1,
+      onProgress,
+    });
+
+    expect(result.opened).toBe(1);
+    expect(result.failed).toBe(1);
+    expect(result.failures).toEqual([
+      expect.objectContaining({
+        userId: hangingMember.id,
+        message: expect.stringContaining('did not finish'),
+      }),
+    ]);
+    expect(openAdminCase).toHaveBeenCalledTimes(2);
+    expect(onProgress).toHaveBeenCalledTimes(2);
+    expect(onProgress).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        completedMembers: 2,
+        result: expect.objectContaining({ opened: 1, failed: 1 }),
+      })
     );
   });
 });

--- a/src/__tests__/unit/SecurityActionService.unit.test.ts
+++ b/src/__tests__/unit/SecurityActionService.unit.test.ts
@@ -768,6 +768,56 @@ describe('SecurityActionService (unit)', () => {
     }
   });
 
+  it('records a thread warning when active case repair still cannot add the user', async () => {
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+    const guildId = 'guild-case-repair-still-fails';
+    const userId = 'user-case-repair-still-fails';
+    const member = buildMember(guildId, userId);
+    const verificationEvent = await verificationEventRepository.createFromDetection(
+      null,
+      guildId,
+      userId,
+      VerificationStatus.PENDING
+    );
+    verificationEvent.thread_id = 'thread-1';
+    await verificationEventRepository.update(verificationEvent.id, verificationEvent);
+    threadManager.repairVerificationThread.mockRejectedValueOnce(
+      new Error('Failed to add flagged user to verification thread: Missing Access')
+    );
+
+    try {
+      const result = await buildService().repairActiveCase(member);
+      const updatedCase = await verificationEventRepository.findById(verificationEvent.id);
+
+      expect(result).toMatchObject({
+        repaired: false,
+        verificationEventId: verificationEvent.id,
+        threadId: null,
+        userAdded: false,
+      });
+      expect(result.message).toContain('Missing Access');
+      expect(getVerificationActionFailures(updatedCase?.metadata)).toEqual([
+        expect.objectContaining({
+          action: 'thread',
+          message: 'Failed to add flagged user to verification thread: Missing Access',
+        }),
+      ]);
+      expect(notificationManager.updateNotificationButtons).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: verificationEvent.id,
+          metadata: expect.objectContaining({
+            [VERIFICATION_ACTION_FAILURES_METADATA_KEY]: [
+              expect.objectContaining({ action: 'thread' }),
+            ],
+          }),
+        }),
+        VerificationStatus.PENDING
+      );
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+
   it('refreshes the latest resolved case notification from stored state', async () => {
     const member = buildMember('guild-1', 'user-refresh');
     const pendingEvent = await verificationEventRepository.createFromDetection(

--- a/src/controllers/CaseCommandHandler.ts
+++ b/src/controllers/CaseCommandHandler.ts
@@ -7,7 +7,11 @@ import {
   Role,
 } from 'discord.js';
 import { IConfigService } from '../config/ConfigService';
-import { AdminCaseAction, ISecurityActionService } from '../services/SecurityActionService';
+import {
+  AdminCaseAction,
+  ISecurityActionService,
+  RoleIntakeProgress,
+} from '../services/SecurityActionService';
 import { requestSlashCommandConfirmation } from '../utils/slashCommandConfirmations';
 
 type ReplyGuildInstallRequired = (interaction: ChatInputCommandInteraction) => Promise<void>;
@@ -317,6 +321,7 @@ export class CaseCommandHandler {
     execute: boolean,
     limit: number | undefined
   ): Promise<void> {
+    let lastProgressUpdateAt = 0;
     try {
       const result = await this.securityActionService.intakeRoleMembers({
         role,
@@ -325,6 +330,25 @@ export class CaseCommandHandler {
         action,
         execute,
         limit,
+        onProgress: execute
+          ? async (progress): Promise<void> => {
+              const now = Date.now();
+              const shouldUpdate =
+                progress.completedMembers === 1 ||
+                progress.completedMembers === progress.result.processed ||
+                progress.completedMembers % 5 === 0 ||
+                now - lastProgressUpdateAt > 15_000;
+              if (!shouldUpdate) {
+                return;
+              }
+
+              lastProgressUpdateAt = now;
+              await interaction.editReply({
+                content: this.formatRoleIntakeProgress(progress),
+                allowedMentions: { parse: [] },
+              });
+            }
+          : undefined,
       });
 
       await interaction.editReply({
@@ -383,5 +407,18 @@ export class CaseCommandHandler {
     }
 
     return lines.join('\n');
+  }
+
+  private formatRoleIntakeProgress(progress: RoleIntakeProgress): string {
+    const result = progress.result;
+    return [
+      `Executing role intake for ${result.roleName} (${result.roleId})`,
+      `Batch: ${result.batchId}`,
+      `Action: ${result.action}`,
+      `Progress: ${progress.completedMembers}/${result.processed} selected members processed`,
+      `Cases opened: ${result.opened}`,
+      `Skipped active cases: ${result.skippedActiveCases}`,
+      `Failures: ${result.failed}`,
+    ].join('\n');
   }
 }

--- a/src/controllers/InteractionHandler.ts
+++ b/src/controllers/InteractionHandler.ts
@@ -1407,8 +1407,9 @@ export class InteractionHandler implements IInteractionHandler {
       });
     } catch (error) {
       console.error('Error repairing active case:', error);
+      const message = error instanceof Error && error.message ? error.message : 'Unknown error';
       await interaction.followUp({
-        content: 'An error occurred while repairing the active case.',
+        content: `An error occurred while repairing the active case: ${message}`,
         flags: MessageFlags.Ephemeral,
       });
     }

--- a/src/services/RoleIntakeProcessor.ts
+++ b/src/services/RoleIntakeProcessor.ts
@@ -200,6 +200,7 @@ export class RoleIntakeProcessor {
     try {
       return await Promise.race([operation, timeoutPromise]);
     } finally {
+      void operation.catch(() => undefined);
       if (timeout) {
         clearTimeout(timeout);
       }

--- a/src/services/RoleIntakeProcessor.ts
+++ b/src/services/RoleIntakeProcessor.ts
@@ -3,9 +3,13 @@ import type { IVerificationEventRepository } from '../repositories/VerificationE
 import type {
   AdminCaseOptions,
   AdminCaseResult,
+  RoleIntakeFailure,
   RoleIntakeOptions,
+  RoleIntakeProgress,
   RoleIntakeResult,
 } from './SecurityActionService';
+
+const DEFAULT_ROLE_INTAKE_MEMBER_TIMEOUT_MS = 60_000;
 
 type OpenAdminCase = (
   member: GuildMember,
@@ -21,6 +25,13 @@ interface RoleIntakeMemberSelection {
   skippedOverLimit: number;
 }
 
+interface RoleIntakeMemberResult {
+  opened: number;
+  skippedActiveCases: number;
+  failed: number;
+  failures: RoleIntakeFailure[];
+}
+
 export class RoleIntakeProcessor {
   public constructor(
     private readonly verificationEventRepository: Pick<
@@ -34,6 +45,10 @@ export class RoleIntakeProcessor {
     const batchId = `role-intake-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
     const limit = Math.max(1, Math.min(options.limit ?? 250, 250));
     const delayMs = Math.max(0, options.delayMs ?? 250);
+    const memberTimeoutMs = Math.max(
+      1,
+      options.memberTimeoutMs ?? DEFAULT_ROLE_INTAKE_MEMBER_TIMEOUT_MS
+    );
     const memberSelection = await this.selectRoleMembersForIntake(options.role, limit);
     const { selectedMembers } = memberSelection;
     const result: RoleIntakeResult = {
@@ -53,45 +68,15 @@ export class RoleIntakeProcessor {
       failures: [],
     };
 
+    let completedMembers = 0;
     for (const member of selectedMembers) {
-      const activeCase = await this.verificationEventRepository.findActiveByUserAndServer(
-        member.id,
-        member.guild.id
-      );
-      if (activeCase && options.action !== 'restrict') {
-        result.skippedActiveCases += 1;
-        continue;
-      }
-
-      if (!options.execute) {
-        continue;
-      }
-
       try {
-        const caseResult = await this.openAdminCase(member, options.moderator, {
-          action: options.action,
-          reason: options.reason,
-          metadata: {
-            type: 'admin_role_intake',
-            bulk_intake: true,
-            batchId,
-            sourceRoleId: options.role.id,
-            sourceRoleName: options.role.name,
-          },
-        });
-        if (caseResult.opened) {
-          result.opened += 1;
-          if (options.action === 'restrict' && !caseResult.restricted) {
-            result.failed += 1;
-            result.failures.push({
-              userId: member.id,
-              message: 'Case opened but restriction failed',
-            });
-          }
-        } else {
-          result.failed += 1;
-          result.failures.push({ userId: member.id, message: 'Case flow returned false' });
-        }
+        const memberResult = await this.withTimeout(
+          this.processSelectedMember(options, member, batchId),
+          memberTimeoutMs,
+          `Role intake for ${member.id}`
+        );
+        this.applyMemberResult(result, memberResult);
       } catch (error) {
         result.failed += 1;
         result.failures.push({
@@ -100,12 +85,125 @@ export class RoleIntakeProcessor {
         });
       }
 
+      completedMembers += 1;
+      await this.reportProgress(options, result, completedMembers);
+
       if (delayMs > 0) {
         await this.sleep(delayMs);
       }
     }
 
     return result;
+  }
+
+  private async processSelectedMember(
+    options: RoleIntakeOptions,
+    member: GuildMember,
+    batchId: string
+  ): Promise<RoleIntakeMemberResult> {
+    const memberResult: RoleIntakeMemberResult = {
+      opened: 0,
+      skippedActiveCases: 0,
+      failed: 0,
+      failures: [],
+    };
+
+    const activeCase = await this.verificationEventRepository.findActiveByUserAndServer(
+      member.id,
+      member.guild.id
+    );
+    if (activeCase && options.action !== 'restrict') {
+      memberResult.skippedActiveCases += 1;
+      return memberResult;
+    }
+
+    if (!options.execute) {
+      return memberResult;
+    }
+
+    const caseResult = await this.openAdminCase(member, options.moderator, {
+      action: options.action,
+      reason: options.reason,
+      metadata: {
+        type: 'admin_role_intake',
+        bulk_intake: true,
+        batchId,
+        sourceRoleId: options.role.id,
+        sourceRoleName: options.role.name,
+      },
+    });
+    if (caseResult.opened) {
+      memberResult.opened += 1;
+      if (options.action === 'restrict' && !caseResult.restricted) {
+        memberResult.failed += 1;
+        memberResult.failures.push({
+          userId: member.id,
+          message: 'Case opened but restriction failed',
+        });
+      }
+      return memberResult;
+    }
+
+    memberResult.failed += 1;
+    memberResult.failures.push({ userId: member.id, message: 'Case flow returned false' });
+    return memberResult;
+  }
+
+  private applyMemberResult(result: RoleIntakeResult, memberResult: RoleIntakeMemberResult): void {
+    result.opened += memberResult.opened;
+    result.skippedActiveCases += memberResult.skippedActiveCases;
+    result.failed += memberResult.failed;
+    result.failures.push(...memberResult.failures);
+  }
+
+  private async reportProgress(
+    options: RoleIntakeOptions,
+    result: RoleIntakeResult,
+    completedMembers: number
+  ): Promise<void> {
+    if (!options.onProgress) {
+      return;
+    }
+
+    const progress: RoleIntakeProgress = {
+      result: {
+        ...result,
+        failures: [...result.failures],
+      },
+      completedMembers,
+    };
+
+    try {
+      await options.onProgress(progress);
+    } catch (error) {
+      console.warn(`Failed to publish role intake progress for batch ${result.batchId}:`, error);
+    }
+  }
+
+  private async withTimeout<T>(
+    operation: Promise<T>,
+    timeoutMs: number,
+    description: string
+  ): Promise<T> {
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+    const timeoutPromise = new Promise<T>((_, reject) => {
+      timeout = setTimeout(() => {
+        reject(
+          new Error(
+            `${description} did not finish within ${Math.ceil(timeoutMs / 1000)}s; it may still complete in the background.`
+          )
+        );
+      }, timeoutMs);
+      timeout.unref();
+    });
+
+    try {
+      return await Promise.race([operation, timeoutPromise]);
+    } finally {
+      if (timeout) {
+        clearTimeout(timeout);
+      }
+    }
   }
 
   private async selectRoleMembersForIntake(

--- a/src/services/SecurityActionService.ts
+++ b/src/services/SecurityActionService.ts
@@ -247,6 +247,8 @@ export interface RoleIntakeOptions {
   execute: boolean;
   limit?: number;
   delayMs?: number;
+  memberTimeoutMs?: number;
+  onProgress?: (progress: RoleIntakeProgress) => Promise<void> | void;
 }
 
 export interface RoleIntakeFailure {
@@ -269,6 +271,11 @@ export interface RoleIntakeResult {
   skippedOverLimit: number;
   failed: number;
   failures: RoleIntakeFailure[];
+}
+
+export interface RoleIntakeProgress {
+  result: RoleIntakeResult;
+  completedMembers: number;
 }
 
 /**
@@ -1714,12 +1721,58 @@ export class SecurityActionService implements ISecurityActionService {
       repairCase = await this.tryRestrictUser(member, activeCase);
     }
 
-    const threadRepair = await this.threadManager.repairVerificationThread(member, repairCase);
+    let threadRepair: VerificationThreadRepairResult;
+    try {
+      threadRepair = await this.threadManager.repairVerificationThread(member, repairCase);
+    } catch (error) {
+      console.error(`Failed to repair active case thread for ${member.user.tag}:`, error);
+      repairCase = await this.recordVerificationActionFailure(repairCase, 'thread', error);
+
+      try {
+        await this.notificationManager.updateNotificationButtons(
+          repairCase,
+          VerificationStatus.PENDING
+        );
+      } catch (notificationError) {
+        console.error(
+          `Failed to update notification for failed case repair ${repairCase.id}; continuing repair flow:`,
+          notificationError
+        );
+      }
+
+      return {
+        repaired: false,
+        message: `Could not create or repair the verification thread for ${member.user.tag}: ${this.formatActionFailureMessage(error)}`,
+        verificationEventId: repairCase.id,
+        threadId: null,
+        threadCreated: false,
+        userAdded: false,
+        promptSent: false,
+        promptAlreadyPresent: false,
+      };
+    }
     if (!threadRepair.threadId) {
+      const error = new Error(
+        `Could not create or repair the verification thread for ${member.user.tag}.`
+      );
+      repairCase = await this.recordVerificationActionFailure(repairCase, 'thread', error);
+
+      try {
+        await this.notificationManager.updateNotificationButtons(
+          repairCase,
+          VerificationStatus.PENDING
+        );
+      } catch (notificationError) {
+        console.error(
+          `Failed to update notification for failed case repair ${repairCase.id}; continuing repair flow:`,
+          notificationError
+        );
+      }
+
       return {
         ...threadRepair,
         repaired: false,
-        message: `Could not create or repair the verification thread for ${member.user.tag}.`,
+        message: error.message,
         verificationEventId: repairCase.id,
       };
     }


### PR DESCRIPTION
[AGENT]

## Summary

- Record and surface active-case repair thread failures instead of returning a generic repair error.
- Add progress updates while role intake execute runs through selected members.
- Bound each role-intake member unit with a timeout and clarify that timed-out side effects may still complete in the background.

## Context

Checked against the latest merged PRs on `main`: #147 first-message GPT routing and #148 reminder digest overflow do not overlap these touched paths. #146 role quarantine is already in the base; the timeout messaging accounts for restriction/quarantine side effects that cannot be cancelled once started.

## Validation

Local PR gate passed: `npm run format:check`; `npm run check`.
