### PR TITLE
Unify moderation alert lifecycle embeds

### DIFF
--- a/src/__tests__/integration/SecurityActionService.integration.test.ts
+++ b/src/__tests__/integration/SecurityActionService.integration.test.ts
@@ -110,6 +110,7 @@ describeIntegration('SecurityActionService (integration)', () => {
       liftRestriction: jest.fn().mockResolvedValue(true),
       verifyUser: jest.fn().mockResolvedValue(true),
       banUser: jest.fn().mockResolvedValue(true),
+      banUserById: jest.fn().mockResolvedValue(true),
       syncAlreadyBannedUser: jest.fn().mockResolvedValue(1),
       closeCaseNoAction: jest.fn().mockResolvedValue(1),
       recordObservedDiscordBan: jest.fn().mockResolvedValue(0),

--- a/src/__tests__/unit/InteractionHandler.unit.test.ts
+++ b/src/__tests__/unit/InteractionHandler.unit.test.ts
@@ -207,6 +207,7 @@ describe('InteractionHandler (unit)', () => {
       liftRestriction: jest.fn().mockResolvedValue(true),
       verifyUser: jest.fn().mockResolvedValue(true),
       banUser: jest.fn().mockResolvedValue(true),
+      banUserById: jest.fn().mockResolvedValue(true),
       syncAlreadyBannedUser: jest.fn().mockResolvedValue(1),
       closeCaseNoAction: jest.fn().mockResolvedValue(1),
       recordObservedDiscordBan: jest.fn().mockResolvedValue(0),
@@ -244,6 +245,7 @@ describe('InteractionHandler (unit)', () => {
       openObservedDetectionCase: jest.fn().mockResolvedValue(true),
       restrictObservedDetection: jest.fn().mockResolvedValue(true),
       banObservedDetection: jest.fn().mockResolvedValue(true),
+      banObservedDetectionById: jest.fn().mockResolvedValue(true),
       dismissObservedDetection: jest.fn().mockResolvedValue(true),
       undoObservedDetectionAction: jest.fn().mockResolvedValue(AdminActionType.DISMISS),
       excludeDetectionFromAccounting: jest.fn().mockResolvedValue({} as any),
@@ -791,6 +793,48 @@ describe('InteractionHandler (unit)', () => {
     });
   });
 
+  it('shows ban-by-id and close actions for a departed pending case', async () => {
+    const verificationEvent = {
+      ...buildVerificationEvent('ver-left', 'user-1'),
+      metadata: { membership_state: 'left_or_removed' },
+    };
+    verificationEventRepository.findActiveByUserAndServer.mockResolvedValue(verificationEvent);
+    verificationEventRepository.findByUserAndServer.mockResolvedValue([verificationEvent]);
+    (client.guilds.fetch as jest.Mock).mockResolvedValue({
+      bans: { fetch: jest.fn().mockRejectedValue({ code: 10026 }) },
+      members: {
+        me: { permissions: { has: jest.fn().mockReturnValue(true) } },
+        fetch: jest.fn().mockResolvedValue(buildMember('guild-1', 'admin-1')),
+      },
+    });
+
+    const handler = new InteractionHandler(
+      client,
+      notificationManager,
+      userModerationService,
+      securityActionService,
+      configService,
+      verificationEventRepository,
+      threadManager,
+      adminActionRepository,
+      buildNoIssueSetupDiagnosticsService()
+    );
+    const interaction = buildInteraction('admin_actions:menu:case:user-1', 'guild-1', {
+      id: 'admin-1',
+    } as User);
+    grantInteractionPermissions(interaction);
+
+    await handler.handleButtonInteraction(interaction);
+
+    const reply = (interaction.reply as jest.Mock).mock.calls[0][0];
+    const renderedComponents = JSON.stringify(reply.components);
+    expect(reply.content).toContain('Membership: left or removed');
+    expect(renderedComponents).toContain('Ban by ID');
+    expect(renderedComponents).toContain('Close No Action');
+    expect(renderedComponents).not.toContain('Verify User');
+    expect(renderedComponents).not.toContain('Restrict User');
+  });
+
   it('handles thread button and creates a verification thread', async () => {
     const verificationEvent: VerificationEvent = {
       id: 'ver-1',
@@ -1062,6 +1106,52 @@ describe('InteractionHandler (unit)', () => {
     expect(interaction.editReply).toHaveBeenCalledWith({
       content: 'User <@user-1> has been banned from the server.',
     });
+  });
+
+  it('submits verifier ban modal by ID when the member left', async () => {
+    enableModeratorBanActions();
+    (client.guilds.fetch as jest.Mock).mockResolvedValue({
+      id: 'guild-1',
+      members: {
+        me: { permissions: { has: jest.fn().mockReturnValue(true) } },
+        fetch: jest.fn().mockRejectedValue(new Error('Unknown Member')),
+      },
+    });
+    const handler = new InteractionHandler(
+      client,
+      notificationManager,
+      userModerationService,
+      securityActionService,
+      configService,
+      verificationEventRepository,
+      threadManager,
+      adminActionRepository
+    );
+    const interaction = {
+      customId: 'verification:ban_modal:user-left',
+      guildId: 'guild-1',
+      user: { id: 'admin-1' } as User,
+      fields: {
+        getTextInputValue: jest.fn(() => 'ban after leave'),
+      },
+      deferReply: jest.fn().mockResolvedValue(undefined),
+      editReply: jest.fn().mockResolvedValue(undefined),
+      reply: jest.fn().mockResolvedValue(undefined),
+      followUp: jest.fn().mockResolvedValue(undefined),
+      replied: false,
+      deferred: false,
+    } as unknown as ModalSubmitInteraction;
+    grantOnlyBanMembersPermission(interaction);
+
+    await handler.handleModalSubmit(interaction);
+
+    expect(userModerationService.banUser).not.toHaveBeenCalled();
+    expect(userModerationService.banUserById).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'guild-1' }),
+      'user-left',
+      'ban after leave',
+      interaction.user
+    );
   });
 
   it('submits verifier ban modal with the default reason when notes are blank', async () => {

--- a/src/__tests__/unit/NotificationManager.unit.test.ts
+++ b/src/__tests__/unit/NotificationManager.unit.test.ts
@@ -669,7 +669,7 @@ describe('NotificationManager (unit)', () => {
     });
   });
 
-  it('keeps undo controls after marking an observed false positive', async () => {
+  it('updates presentation and keeps admin actions after marking an observed false positive', async () => {
     const detectionEvent = await detectionRepository.create({
       server_id: 'guild-1',
       user_id: 'user-1',
@@ -681,7 +681,11 @@ describe('NotificationManager (unit)', () => {
     });
     const message: MockMessage = {
       id: 'message-1',
-      embeds: [new EmbedBuilder().setTitle('Observed suspicious activity')],
+      embeds: [
+        new EmbedBuilder()
+          .setTitle('Observed suspicious activity')
+          .addFields({ name: 'User ID', value: 'user-1' }),
+      ],
       edit: jest.fn().mockResolvedValue(undefined),
     };
     adminChannel.messages.fetch.mockResolvedValue(message as unknown as Message<true>);
@@ -694,17 +698,17 @@ describe('NotificationManager (unit)', () => {
     await manager.markObservedDetectionActionTaken(
       detectionEvent.id,
       'marked this detection as a false positive',
-      { id: 'admin-1' } as User
+      { id: 'admin-1' } as User,
+      AdminActionType.FALSE_POSITIVE
     );
 
-    const editArgs = message.edit.mock.calls[0][0] as { components: unknown[] };
-    expect(extractLabels(editArgs.components)).toEqual([
-      'Open Case',
-      'Restrict',
-      'Ban...',
-      'Dismiss',
-      'Other Actions',
-    ]);
+    const editArgs = message.edit.mock.calls[0][0] as {
+      components: unknown[];
+      embeds: EmbedBuilder[];
+    };
+    expect(extractLabels(editArgs.components)).toEqual(['Other Actions']);
+    expect(editArgs.embeds[0].data.title).toBe('Observed Alert Marked False Positive');
+    expect(editArgs.embeds[0].data.color).toBe(0x00ff00);
   });
 
   it('restores observed action buttons after undo', async () => {

--- a/src/__tests__/unit/NotificationPresentationBuilder.unit.test.ts
+++ b/src/__tests__/unit/NotificationPresentationBuilder.unit.test.ts
@@ -197,6 +197,27 @@ describe('NotificationPresentationBuilder (unit)', () => {
     );
   });
 
+  it('fronts departed membership when rendering pending case notifications', () => {
+    const embed = builder.createSuspiciousUserEmbed(
+      buildMember(),
+      buildDetectionResult(),
+      buildVerificationEvent({
+        metadata: {
+          membership_state: 'left_or_removed',
+          member_left_at: '2026-01-05T00:00:00.000Z',
+        },
+      }),
+      []
+    );
+
+    expect(embed.data.title).toBe('Member Left Server');
+    expect(embed.data.color).toBe(0xffc107);
+    expect(embed.data.description).toContain(
+      'left or was removed while this case is still pending'
+    );
+    expect(getField(embed, 'Membership')).toContain('Left or removed at <t:1767571200:F>');
+  });
+
   it('clears stale handled presentation when refreshing a pending case', () => {
     const embed = new EmbedBuilder()
       .setTitle('Case Handled: Verified')
@@ -294,6 +315,43 @@ describe('NotificationPresentationBuilder (unit)', () => {
     expect(observedButtons[5]).toMatchObject({
       url: 'https://drasilbot.com/admin/guild/guild-1/cases',
     });
+  });
+
+  it('uses departed-case admin notification rows with ban-by-id actions', () => {
+    const rows = builder.createAdminNotificationActionRows('user-1', {
+      guildId: 'guild-1',
+      verificationEventId: 'ver-1',
+      verificationStatus: VerificationStatus.PENDING,
+      caseMembershipState: 'left_or_removed',
+    });
+    const buttons = rows.flatMap(
+      (row) => row.toJSON().components as Array<{ label?: string; custom_id?: string }>
+    );
+
+    expect(buttons.map((button) => button.label)).toEqual([
+      'History',
+      'Ban by ID...',
+      'Close',
+      'Other Actions',
+    ]);
+    expect(buttons.map((button) => button.custom_id)).toEqual([
+      'history_user-1',
+      'ban_user-1',
+      'close_user-1',
+      'admin_actions:m:c:user-1',
+    ]);
+  });
+
+  it('collapses observed action rows after an observed alert is actioned', () => {
+    const rows = builder.createObservedActionRows('user-1', 'det-1', 'guild-1', {
+      actioned: true,
+    });
+    const buttons = rows.flatMap(
+      (row) => row.toJSON().components as Array<{ label?: string; custom_id?: string }>
+    );
+
+    expect(buttons.map((button) => button.label)).toEqual(['Other Actions']);
+    expect(buttons[0].custom_id).toBe('admin_actions:m:o:user-1:det-1');
   });
 
   it('uses resolved-case admin notification rows after a case is handled', () => {

--- a/src/__tests__/unit/SecurityActionService.unit.test.ts
+++ b/src/__tests__/unit/SecurityActionService.unit.test.ts
@@ -119,6 +119,7 @@ describe('SecurityActionService (unit)', () => {
       liftRestriction: jest.fn().mockResolvedValue(true),
       verifyUser: jest.fn().mockResolvedValue(true),
       banUser: jest.fn().mockResolvedValue(true),
+      banUserById: jest.fn().mockResolvedValue(true),
       syncAlreadyBannedUser: jest.fn().mockResolvedValue(1),
       closeCaseNoAction: jest.fn().mockResolvedValue(1),
       recordObservedDiscordBan: jest.fn().mockResolvedValue(0),
@@ -2194,6 +2195,59 @@ describe('SecurityActionService (unit)', () => {
     expect(notificationManager.markObservedDetectionActionTaken).toHaveBeenCalledWith(
       detectionEvent.id,
       'opened a verification case',
+      moderator,
+      AdminActionType.OPEN_CASE
+    );
+  });
+
+  it('converts an observed alert notification into the case notification when opening a case', async () => {
+    const guildId = 'guild-observed-adopt';
+    const userId = 'user-observed-adopt';
+    const moderator = { id: 'admin-observed' } as User;
+    const member = buildMember(guildId, userId);
+    const detectionEvent = await detectionEventsRepository.create({
+      server_id: guildId,
+      user_id: userId,
+      detection_type: DetectionType.SUSPICIOUS_CONTENT,
+      confidence: 0.88,
+      reasons: ['Suspicious content'],
+      detected_at: new Date(),
+      metadata: {
+        content: 'free discord nitro',
+        observed_notification_channel_id: 'alerts-channel',
+        observed_notification_message_id: 'observed-message',
+        observed_evidence_thread_id: 'observed-evidence-thread',
+      },
+    });
+    notificationManager.upsertSuspiciousUserNotification.mockImplementation(
+      async (_member, _detectionResult, verificationEvent) =>
+        ({
+          id: verificationEvent.notification_message_id ?? 'new-message',
+          channelId: verificationEvent.notification_channel_id ?? 'new-channel',
+        }) as Message
+    );
+
+    await buildService().openObservedDetectionCase(member, detectionEvent.id, moderator);
+
+    const [verificationEvent] = await verificationEventRepository.findByUserAndServer(
+      userId,
+      guildId
+    );
+    expect(verificationEvent).toEqual(
+      expect.objectContaining({
+        notification_channel_id: 'alerts-channel',
+        notification_message_id: 'observed-message',
+        private_evidence_thread_id: 'observed-evidence-thread',
+        metadata: expect.objectContaining({
+          case_origin: 'observed_alert',
+          observed_detection_event_id: detectionEvent.id,
+        }),
+      })
+    );
+    expect(notificationManager.markObservedDetectionActionTaken).not.toHaveBeenCalled();
+    expect(notificationManager.logActionToMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ notification_message_id: 'observed-message' }),
+      AdminActionType.OPEN_CASE,
       moderator
     );
   });
@@ -2300,7 +2354,8 @@ describe('SecurityActionService (unit)', () => {
     expect(notificationManager.markObservedDetectionActionTaken).toHaveBeenCalledWith(
       detectionEvent.id,
       'marked this detection as a false positive',
-      moderator
+      moderator,
+      AdminActionType.FALSE_POSITIVE
     );
   });
 
@@ -2798,7 +2853,8 @@ describe('SecurityActionService (unit)', () => {
     expect(notificationManager.markObservedDetectionActionTaken).toHaveBeenCalledWith(
       detectionEvent.id,
       'restricted this user',
-      moderator
+      moderator,
+      AdminActionType.RESTRICT
     );
   });
 
@@ -2917,7 +2973,8 @@ describe('SecurityActionService (unit)', () => {
     expect(notificationManager.markObservedDetectionActionTaken).toHaveBeenCalledWith(
       detectionEvent.id,
       'restricted this user',
-      moderator
+      moderator,
+      AdminActionType.RESTRICT
     );
   });
 
@@ -2954,7 +3011,8 @@ describe('SecurityActionService (unit)', () => {
     expect(notificationManager.markObservedDetectionActionTaken).toHaveBeenCalledWith(
       detectionEvent.id,
       'banned this user',
-      moderator
+      moderator,
+      AdminActionType.BAN
     );
     expect(adminActionService.recordAction).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/src/__tests__/unit/UserModerationService.unit.test.ts
+++ b/src/__tests__/unit/UserModerationService.unit.test.ts
@@ -1537,4 +1537,74 @@ describe('UserModerationService (unit)', () => {
     );
     consoleError.mockRestore();
   });
+
+  it('bans by ID and resolves pending cases after the member leaves', async () => {
+    const guildId = 'guild-ban-by-id';
+    const userId = 'user-ban-by-id';
+    const moderator = { id: 'mod-ban' } as User;
+    const targetUser = {
+      id: userId,
+      tag: 'left-user#0001',
+      username: 'left-user',
+      createdTimestamp: new Date('2026-01-01T00:00:00Z').getTime(),
+    } as User;
+    const guild = {
+      id: guildId,
+      client: { users: { fetch: jest.fn().mockResolvedValue(targetUser) } },
+      bans: { create: jest.fn().mockResolvedValue({}) },
+    } as unknown as Guild;
+
+    await serverRepository.getOrCreateServer(guildId);
+    await userRepository.getOrCreateUser(userId, 'left-user');
+
+    const detectionEvent = await detectionEventsRepository.create({
+      server_id: guildId,
+      user_id: userId,
+      detection_type: DetectionType.SUSPICIOUS_CONTENT,
+      confidence: 0.8,
+      reasons: ['Initial detection'],
+      detected_at: new Date(),
+    });
+    const verificationEvent = await verificationEventRepository.createFromDetection(
+      detectionEvent.id,
+      guildId,
+      userId,
+      VerificationStatus.PENDING
+    );
+
+    const service = new UserModerationService(
+      serverMemberRepository,
+      notificationManager,
+      roleManager,
+      verificationEventRepository,
+      adminActionService,
+      threadManager,
+      undefined,
+      moderationOutcomeService
+    );
+
+    await expect(
+      service.banUserById(guild, userId, 'banned after leave', moderator, detectionEvent.id)
+    ).resolves.toBe(true);
+
+    expect(guild.bans.create).toHaveBeenCalledWith(targetUser, { reason: 'banned after leave' });
+    const updatedEvent = await verificationEventRepository.findById(verificationEvent.id);
+    expect(updatedEvent?.status).toBe(VerificationStatus.BANNED);
+    expect(updatedEvent?.metadata).toEqual(
+      expect.objectContaining({
+        membership_state: 'left_or_removed',
+        banned_by_id_at: expect.any(String),
+      })
+    );
+    const outcomes = await moderationOutcomeRepository.findByUserAndServer(userId, guildId);
+    expect(outcomes).toHaveLength(1);
+    expect(outcomes[0]).toEqual(
+      expect.objectContaining({
+        outcome_type: ModerationOutcomeType.BANNED,
+        source: ModerationOutcomeSource.DRASIL,
+        verification_event_id: verificationEvent.id,
+        detection_event_id: detectionEvent.id,
+      })
+    );
+  });
 });

--- a/src/__tests__/unit/UserModerationService.unit.test.ts
+++ b/src/__tests__/unit/UserModerationService.unit.test.ts
@@ -242,7 +242,6 @@ describe('UserModerationService (unit)', () => {
       userId,
       VerificationStatus.PENDING
     );
-
     const service = new UserModerationService(
       serverMemberRepository,
       notificationManager,
@@ -598,7 +597,6 @@ describe('UserModerationService (unit)', () => {
       userId,
       VerificationStatus.PENDING
     );
-
     const service = new UserModerationService(
       serverMemberRepository,
       notificationManager,
@@ -1571,6 +1569,12 @@ describe('UserModerationService (unit)', () => {
       userId,
       VerificationStatus.PENDING
     );
+    notificationManager.logActionToMessage.mockResolvedValue(false);
+    (guild.bans.create as jest.Mock).mockImplementation(async () => {
+      const updatedBeforeBan = await verificationEventRepository.findById(verificationEvent.id);
+      expect(updatedBeforeBan?.status).toBe(VerificationStatus.BANNED);
+      return {};
+    });
 
     const service = new UserModerationService(
       serverMemberRepository,

--- a/src/__tests__/unit/commandHandlerTestHarness.ts
+++ b/src/__tests__/unit/commandHandlerTestHarness.ts
@@ -14,6 +14,7 @@ export function restoreUserInstallReportingEnvAfterEach(): void {
 
 export type HandlerOverrides = Partial<{
   banUser: jest.Mock;
+  banUserById: jest.Mock;
   updateServerConfig: jest.Mock;
   updateServerSettings: jest.Mock;
   getCachedServerConfig: jest.Mock;
@@ -43,6 +44,7 @@ export type HandlerOverrides = Partial<{
 export const buildHandler = (overrides: HandlerOverrides = {}) => {
   const userModerationService = {
     banUser: overrides.banUser ?? jest.fn().mockResolvedValue(true),
+    banUserById: overrides.banUserById ?? jest.fn().mockResolvedValue(true),
   } as any;
 
   const configService = {

--- a/src/controllers/InteractionHandler.ts
+++ b/src/controllers/InteractionHandler.ts
@@ -525,11 +525,11 @@ export class InteractionHandler implements IInteractionHandler {
       activeCase?.status === VerificationStatus.PENDING && hasBanMembersPermission
         ? await this.isUserBanned(guildId, parsed.userId)
         : false;
+    const memberLeft = activeCase ? this.hasMemberLeft(activeCase) : false;
     const canBan =
       hasBanMembersPermission && !alreadyBanned && (await this.canUseModeratorBanAction(guildId));
-    const restrictionState = activeCase
-      ? await this.getCaseRestrictionState(guildId, parsed.userId)
-      : null;
+    const restrictionState =
+      activeCase && !memberLeft ? await this.getCaseRestrictionState(guildId, parsed.userId) : null;
 
     const actionButtons: ButtonBuilder[] = [];
     if (hasModerationPermission) {
@@ -539,7 +539,27 @@ export class InteractionHandler implements IInteractionHandler {
     }
 
     if (activeCase?.status === VerificationStatus.PENDING) {
-      if (hasModerationPermission) {
+      if (memberLeft) {
+        if (hasBanMembersPermission && alreadyBanned) {
+          actionButtons.push(
+            this.adminActionButton(parsed, 'sync_ban', 'Sync Existing Ban', ButtonStyle.Danger)
+          );
+        } else if (canBan) {
+          actionButtons.push(
+            this.adminActionButton(parsed, 'ban', 'Ban by ID...', ButtonStyle.Danger)
+          );
+        }
+        if (hasModerationPermission) {
+          actionButtons.push(
+            this.adminActionButton(
+              parsed,
+              'close_no_action',
+              'Close No Action',
+              ButtonStyle.Secondary
+            )
+          );
+        }
+      } else if (hasModerationPermission) {
         actionButtons.push(
           restrictionState === true
             ? this.adminActionButton(
@@ -566,12 +586,12 @@ export class InteractionHandler implements IInteractionHandler {
           );
         }
       }
-      if (alreadyBanned) {
+      if (!memberLeft && alreadyBanned) {
         actionButtons.push(
           this.adminActionButton(parsed, 'sync_ban', 'Sync Existing Ban', ButtonStyle.Danger)
         );
       }
-      if (canBan) {
+      if (!memberLeft && canBan) {
         actionButtons.push(
           this.adminActionButton(parsed, 'ban', 'Ban User...', ButtonStyle.Danger)
         );
@@ -592,7 +612,11 @@ export class InteractionHandler implements IInteractionHandler {
     const userLabel = await this.resolveUserDisplayLabel(guildId, parsed.userId);
     const details = [`Admin actions for ${userLabel}.`];
     if (activeCase?.status === VerificationStatus.PENDING) {
-      details.push(`Restriction: ${this.formatCaseRestrictionState(restrictionState)}.`);
+      details.push(
+        memberLeft
+          ? 'Membership: left or removed. Use Ban by ID if moderation should continue, or Close No Action if no action is needed.'
+          : `Restriction: ${this.formatCaseRestrictionState(restrictionState)}.`
+      );
     }
     const latestCaseLinks = latestCase
       ? this.formatVerificationCaseLinks(guildId, latestCase, adminChannelId)
@@ -990,6 +1014,10 @@ export class InteractionHandler implements IInteractionHandler {
       event.thread_id ? `case: https://discord.com/channels/${guildId}/${event.thread_id}` : null,
       this.formatSourceMessageLink(guildId, event),
     ].filter((value): value is string => Boolean(value));
+  }
+
+  private hasMemberLeft(event: VerificationEvent): boolean {
+    return this.metadataToRecord(event.metadata).membership_state === 'left_or_removed';
   }
 
   private formatSourceMessageLink(guildId: string, event: VerificationEvent): string | null {
@@ -1828,9 +1856,13 @@ export class InteractionHandler implements IInteractionHandler {
 
     try {
       const guild = await this.client.guilds.fetch(interaction.guildId);
-      const member = await guild.members.fetch(userId);
+      const member = await guild.members.fetch(userId).catch(() => null);
 
-      await this.userModerationService.banUser(member, banReason, interaction.user);
+      if (member) {
+        await this.userModerationService.banUser(member, banReason, interaction.user);
+      } else {
+        await this.userModerationService.banUserById(guild, userId, banReason, interaction.user);
+      }
 
       await interaction.editReply({
         content: `User <@${userId}> has been banned from the server.`,
@@ -2214,13 +2246,22 @@ export class InteractionHandler implements IInteractionHandler {
 
     const reason = providedReason || OBSERVED_BAN_DEFAULT_REASON;
     try {
-      const member = await this.getObservedTargetMember(interaction.guildId, parsed.userId);
-      const banned = await this.securityActionService.banObservedDetection(
-        member,
-        parsed.detectionEventId,
-        interaction.user,
-        reason
-      );
+      const guild = await this.client.guilds.fetch(interaction.guildId);
+      const member = await guild.members.fetch(parsed.userId).catch(() => null);
+      const banned = member
+        ? await this.securityActionService.banObservedDetection(
+            member,
+            parsed.detectionEventId,
+            interaction.user,
+            reason
+          )
+        : await this.securityActionService.banObservedDetectionById(
+            guild,
+            parsed.userId,
+            parsed.detectionEventId,
+            interaction.user,
+            reason
+          );
       await interaction.reply({
         content: banned
           ? `Banned <@${parsed.userId}>.`

--- a/src/controllers/ModerationCommandHandler.ts
+++ b/src/controllers/ModerationCommandHandler.ts
@@ -64,22 +64,26 @@ export class ModerationCommandHandler {
     }
 
     const member = await guild.members.fetch(targetUser.id).catch(() => null);
-    if (!member) {
-      await interaction.reply({
-        content: `Could not find user ${targetUser.tag} in this server.`,
-        flags: MessageFlags.Ephemeral,
-      });
-      return;
-    }
 
     await requestSlashCommandConfirmation(interaction, {
-      message: `Ban ${targetUser.tag} from this server?`,
-      confirmLabel: 'Ban User',
+      message: member
+        ? `Ban ${targetUser.tag} from this server?`
+        : `Ban ${targetUser.tag} from this server by ID?`,
+      confirmLabel: member ? 'Ban User' : 'Ban by ID',
       confirmStyle: ButtonStyle.Danger,
       execute: async (buttonInteraction) => {
         await buttonInteraction.update({ content: `Banning ${targetUser.tag}...`, components: [] });
         try {
-          await this.userModerationService.banUser(member, reason, interaction.user);
+          if (member) {
+            await this.userModerationService.banUser(member, reason, interaction.user);
+          } else {
+            await this.userModerationService.banUserById(
+              guild,
+              targetUser.id,
+              reason,
+              interaction.user
+            );
+          }
           await buttonInteraction.editReply({ content: `User ${targetUser.tag} has been banned.` });
         } catch (error) {
           console.error('Failed to ban user via command:', error);

--- a/src/services/ModerationQueueService.ts
+++ b/src/services/ModerationQueueService.ts
@@ -375,10 +375,16 @@ export class ModerationQueueService implements IModerationQueueService {
     verificationEvent: VerificationEvent,
     includeBanAction: boolean
   ): QueueMessagePayload {
+    const memberLeft =
+      this.toRecord(verificationEvent.metadata).membership_state === 'left_or_removed';
     const embed = new EmbedBuilder()
-      .setColor(0xf97316)
-      .setTitle('Pending Moderation Case')
-      .setDescription(`<@${verificationEvent.user_id}> has an open case awaiting moderator action.`)
+      .setColor(memberLeft ? 0xffc107 : 0xf97316)
+      .setTitle(memberLeft ? 'Pending Case: Member Left Server' : 'Pending Moderation Case')
+      .setDescription(
+        memberLeft
+          ? `<@${verificationEvent.user_id}> left or was removed while this case is still pending.`
+          : `<@${verificationEvent.user_id}> has an open case awaiting moderator action.`
+      )
       .addFields(
         {
           name: 'User',
@@ -408,6 +414,15 @@ export class ModerationQueueService implements IModerationQueueService {
       embed.addFields({ name: 'Admin Notification', value: notificationLink, inline: false });
     }
 
+    if (memberLeft) {
+      embed.addFields({
+        name: 'Membership',
+        value:
+          'Use Ban by ID if moderation should continue, or Close No Action if no action is needed.',
+        inline: false,
+      });
+    }
+
     return {
       allowedMentions: { parse: [] },
       embeds: [embed],
@@ -417,6 +432,7 @@ export class ModerationQueueService implements IModerationQueueService {
           guildId: verificationEvent.server_id,
           verificationEventId: verificationEvent.id,
           verificationStatus: verificationEvent.status,
+          caseMembershipState: this.presentationBuilder.getCaseMembershipState(verificationEvent),
           includeBanAction,
         }
       ),

--- a/src/services/NotificationManager.ts
+++ b/src/services/NotificationManager.ts
@@ -130,7 +130,8 @@ export interface INotificationManager {
   markObservedDetectionActionTaken(
     detectionEventId: string,
     actionDescription: string,
-    admin: User
+    admin: User,
+    actionType?: AdminActionType
   ): Promise<boolean>;
 
   restoreObservedDetectionActions(
@@ -213,6 +214,7 @@ export class NotificationManager implements INotificationManager {
         guildId: member.guild.id,
         verificationEventId: verificationEvent.id,
         verificationStatus: verificationEvent.status,
+        caseMembershipState: this.presentationBuilder.getCaseMembershipState(verificationEvent),
         includeBanAction: responseSettings.moderatorBanActionEnabled,
       });
 
@@ -339,7 +341,8 @@ export class NotificationManager implements INotificationManager {
   public async markObservedDetectionActionTaken(
     detectionEventId: string,
     actionDescription: string,
-    admin: User
+    admin: User,
+    actionType?: AdminActionType
   ): Promise<boolean> {
     try {
       const detectionEvent = await this.detectionEventsRepository.findById(detectionEventId);
@@ -387,14 +390,15 @@ export class NotificationManager implements INotificationManager {
         updatedEmbed,
         actionDescription,
         admin.id,
-        timestamp
+        timestamp,
+        actionType
       );
 
       const components = this.presentationBuilder.createObservedActionRows(
         detectionEvent.user_id,
         detectionEvent.id,
         detectionEvent.server_id,
-        { includeBanAction: responseSettings.moderatorBanActionEnabled }
+        { includeBanAction: responseSettings.moderatorBanActionEnabled, actioned: true }
       );
 
       await message.edit({
@@ -1008,6 +1012,7 @@ export class NotificationManager implements INotificationManager {
           guildId: verificationEvent.server_id,
           verificationEventId: verificationEvent.id,
           verificationStatus: newStatus,
+          caseMembershipState: this.presentationBuilder.getCaseMembershipState(verificationEvent),
           includeBanAction: responseSettings?.moderatorBanActionEnabled ?? true,
         }
       ),

--- a/src/services/NotificationPresentationBuilder.ts
+++ b/src/services/NotificationPresentationBuilder.ts
@@ -32,7 +32,10 @@ interface AdminActionRowOptions {
   readonly verificationEventId?: string;
   readonly verificationStatus?: VerificationStatus;
   readonly includeBanAction?: boolean;
+  readonly caseMembershipState?: CaseMembershipState;
 }
+
+type CaseMembershipState = 'in_server' | 'left_or_removed' | 'unknown';
 
 interface ThreadAnalysisMetadata {
   analyzedMessageIds?: unknown;
@@ -50,6 +53,11 @@ interface ThreadAnalysisMetadata {
 }
 
 const EMBED_FIELD_VALUE_MAX_LENGTH = 1024;
+const CASE_COLOR_PENDING = 0xff0000;
+const CASE_COLOR_WARNING = 0xffc107;
+const CASE_COLOR_VERIFIED = 0x00ff00;
+const CASE_COLOR_BANNED = 0x000000;
+const CASE_COLOR_CLOSED = 0x808080;
 
 export class NotificationPresentationBuilder {
   public static readonly THREAD_ANALYSIS_FIELD_NAME = 'Thread Analysis';
@@ -74,7 +82,7 @@ export class NotificationPresentationBuilder {
       : 'Unknown';
 
     const signalField = this.formatSignalField(detectionResult);
-    let embedColor = 0xff0000;
+    let embedColor = CASE_COLOR_PENDING;
 
     const reasonsFormatted = detectionResult.reasons.map((reason) => `• ${reason}`).join('\n');
     const countedDetectionEvents = detectionEvents.filter(
@@ -88,24 +96,34 @@ export class NotificationPresentationBuilder {
       member.guild.id
     );
 
+    const membershipPresentation = this.getPendingMembershipPresentation(verificationEvent);
+
     if (verificationEvent.status === VerificationStatus.VERIFIED) {
-      embedColor = 0x00ff00;
+      embedColor = CASE_COLOR_VERIFIED;
     } else if (verificationEvent.status === VerificationStatus.BANNED) {
-      embedColor = 0x000000;
+      embedColor = CASE_COLOR_BANNED;
     } else if (verificationEvent.status === VerificationStatus.CLOSED_NO_ACTION) {
-      embedColor = 0x808080;
+      embedColor = CASE_COLOR_CLOSED;
+    } else if (membershipPresentation) {
+      embedColor = CASE_COLOR_WARNING;
     }
 
     const resolutionPresentation = this.getVerificationResolutionPresentation(verificationEvent);
     const embed = new EmbedBuilder()
       .setColor(embedColor)
-      .setTitle(resolutionPresentation?.title ?? this.getPendingCaseTitle(detectionResult))
+      .setTitle(
+        resolutionPresentation?.title ??
+          membershipPresentation?.title ??
+          this.getPendingCaseTitle(detectionResult, verificationEvent)
+      )
       .setDescription(
         resolutionPresentation
           ? `<@${member.id}> has been handled. No further moderator action is pending.`
-          : countedDetectionEvents.length > 1
-            ? `<@${member.id}> has been flagged as suspicious ${countedDetectionEvents.length} times.`
-            : `<@${member.id}> has been flagged as suspicious.`
+          : membershipPresentation
+            ? membershipPresentation.description
+            : countedDetectionEvents.length > 1
+              ? `<@${member.id}> has been flagged as suspicious ${countedDetectionEvents.length} times.`
+              : `<@${member.id}> has been flagged as suspicious.`
       )
       .setThumbnail(member.user.displayAvatarURL())
       .addFields(
@@ -132,6 +150,7 @@ export class NotificationPresentationBuilder {
       )
       .setTimestamp();
 
+    this.upsertPendingMembershipField(embed, verificationEvent);
     this.upsertLatestResolutionField(embed, verificationEvent);
     this.addOptionalAnalysisFields(embed, detectionResult, detectionEventsNewestFirst);
 
@@ -262,7 +281,15 @@ export class NotificationPresentationBuilder {
     return embed;
   }
 
-  private getPendingCaseTitle(detectionResult: DetectionResult): string {
+  private getPendingCaseTitle(
+    detectionResult: DetectionResult,
+    verificationEvent?: VerificationEvent
+  ): string {
+    const metadata = this.verificationMetadataToRecord(verificationEvent?.metadata);
+    if (metadata.case_origin === 'observed_alert') {
+      return 'Moderation Case Opened';
+    }
+
     if (detectionResult.triggerSource === DetectionType.USER_REPORT) {
       return 'User Report Submitted';
     }
@@ -354,7 +381,11 @@ export class NotificationPresentationBuilder {
     const isPending =
       !options.verificationStatus || options.verificationStatus === VerificationStatus.PENDING;
     const primaryButtons = isPending
-      ? this.createPendingCaseAdminButtons(userId, options.includeBanAction !== false)
+      ? this.createPendingCaseAdminButtons(
+          userId,
+          options.includeBanAction !== false,
+          options.caseMembershipState ?? 'in_server'
+        )
       : [
           this.createCustomButton(`reopen_${userId}`, 'Reopen', ButtonStyle.Primary),
           this.createCustomButton(`history_${userId}`, 'History', ButtonStyle.Secondary),
@@ -385,8 +416,29 @@ export class NotificationPresentationBuilder {
     userId: string,
     detectionEventId: string,
     guildId?: string,
-    options: Pick<AdminActionRowOptions, 'includeBanAction'> = {}
+    options: Pick<AdminActionRowOptions, 'includeBanAction'> & { actioned?: boolean } = {}
   ): ActionRowBuilder<ButtonBuilder>[] {
+    if (options.actioned) {
+      const buttons = [
+        this.createCustomButton(
+          buildObservedAdminActionsCustomId(userId, detectionEventId),
+          'Other Actions',
+          ButtonStyle.Secondary
+        ),
+      ];
+      const webQueueUrl = guildId ? buildAdminCaseQueueUrl(guildId) : null;
+      const rows = [new ActionRowBuilder<ButtonBuilder>().addComponents(...buttons)];
+      if (webQueueUrl) {
+        rows.push(
+          new ActionRowBuilder<ButtonBuilder>().addComponents(
+            this.createLinkButton('Web Queue', webQueueUrl)
+          )
+        );
+      }
+
+      return rows;
+    }
+
     const buttons = [
       this.createCustomButton(
         `observed:open:${userId}:${detectionEventId}`,
@@ -438,8 +490,30 @@ export class NotificationPresentationBuilder {
 
   private createPendingCaseAdminButtons(
     userId: string,
-    includeBanAction: boolean
+    includeBanAction: boolean,
+    caseMembershipState: CaseMembershipState
   ): ButtonBuilder[] {
+    if (caseMembershipState === 'left_or_removed' || caseMembershipState === 'unknown') {
+      const buttons = [
+        this.createCustomButton(`history_${userId}`, 'History', ButtonStyle.Secondary),
+      ];
+
+      if (includeBanAction) {
+        buttons.push(this.createCustomButton(`ban_${userId}`, 'Ban by ID...', ButtonStyle.Danger));
+      }
+
+      buttons.push(
+        this.createCustomButton(`close_${userId}`, 'Close', ButtonStyle.Secondary),
+        this.createCustomButton(
+          buildCaseAdminActionsCustomId(userId),
+          'Other Actions',
+          ButtonStyle.Secondary
+        )
+      );
+
+      return buttons;
+    }
+
     const buttons = [
       this.createCustomButton(`verify_${userId}`, 'Verify', ButtonStyle.Success),
       this.createCustomButton(`restrict_${userId}`, 'Restrict', ButtonStyle.Danger),
@@ -506,8 +580,13 @@ export class NotificationPresentationBuilder {
     embed: EmbedBuilder,
     actionDescription: string,
     adminId: string,
-    timestamp: number
+    timestamp: number,
+    actionType?: AdminActionType
   ): void {
+    if (actionType) {
+      this.applyObservedActionPresentation(embed, actionType);
+    }
+
     const field = {
       name: 'Action Taken',
       value: `<@${adminId}> ${actionDescription} <t:${timestamp}:R>`,
@@ -527,6 +606,7 @@ export class NotificationPresentationBuilder {
     adminId: string,
     timestamp: number
   ): void {
+    this.restoreObservedPendingPresentation(embed);
     const field = {
       name: 'Action Reverted',
       value: `<@${adminId}> ${actionDescription} <t:${timestamp}:R>`,
@@ -625,15 +705,16 @@ export class NotificationPresentationBuilder {
     const actionTaken = this.getResolutionAction(status);
     if (!actionTaken) {
       this.clearResolvedCasePresentation(embed);
+      this.upsertPendingMembershipField(embed, verificationEvent);
       return;
     }
 
     if (status === VerificationStatus.VERIFIED) {
-      embed.setColor(0x00ff00);
+      embed.setColor(CASE_COLOR_VERIFIED);
     } else if (status === VerificationStatus.BANNED) {
-      embed.setColor(0x000000);
+      embed.setColor(CASE_COLOR_BANNED);
     } else if (status === VerificationStatus.CLOSED_NO_ACTION) {
-      embed.setColor(0x808080);
+      embed.setColor(CASE_COLOR_CLOSED);
     }
 
     const resolvedAt = verificationEvent.resolved_at
@@ -669,12 +750,14 @@ export class NotificationPresentationBuilder {
       return;
     }
 
-    embed.setColor(0xff0000);
+    embed.setColor(CASE_COLOR_PENDING);
     embed.setTitle(this.getPendingTitleFromExistingEmbed(embed));
     embed.setDescription(this.getPendingDescriptionFromExistingEmbed(embed));
     embed.setFields(
       ...fields.filter(
-        (field) => field.name !== NotificationPresentationBuilder.RESOLUTION_FIELD_NAME
+        (field) =>
+          field.name !== NotificationPresentationBuilder.RESOLUTION_FIELD_NAME &&
+          field.name !== 'Membership'
       )
     );
   }
@@ -1029,6 +1112,120 @@ export class NotificationPresentationBuilder {
     }
 
     return { ...metadata } as Record<string, unknown>;
+  }
+
+  private verificationMetadataToRecord(
+    metadata: VerificationEvent['metadata'] | undefined
+  ): Record<string, unknown> {
+    if (!metadata || typeof metadata !== 'object' || Array.isArray(metadata)) {
+      return {};
+    }
+
+    return { ...metadata } as Record<string, unknown>;
+  }
+
+  public getCaseMembershipState(verificationEvent: VerificationEvent): CaseMembershipState {
+    const metadata = this.verificationMetadataToRecord(verificationEvent.metadata);
+    return metadata.membership_state === 'left_or_removed' ? 'left_or_removed' : 'in_server';
+  }
+
+  private getPendingMembershipPresentation(
+    verificationEvent: VerificationEvent
+  ): { title: string; description: string; fieldValue: string } | null {
+    if (verificationEvent.status !== VerificationStatus.PENDING) {
+      return null;
+    }
+
+    const metadata = this.verificationMetadataToRecord(verificationEvent.metadata);
+    if (metadata.membership_state !== 'left_or_removed') {
+      return null;
+    }
+
+    const memberLeftAt =
+      typeof metadata.member_left_at === 'string'
+        ? Math.floor(new Date(metadata.member_left_at).getTime() / 1000)
+        : null;
+    const when = memberLeftAt && Number.isFinite(memberLeftAt) ? ` at <t:${memberLeftAt}:F>` : '';
+
+    return {
+      title: 'Member Left Server',
+      description: `<@${verificationEvent.user_id}> left or was removed while this case is still pending. They cannot respond in the verification thread.`,
+      fieldValue: `Left or removed${when}. Use Ban by ID if moderation should continue, or Close No Action if no action is needed.`,
+    };
+  }
+
+  private upsertPendingMembershipField(
+    embed: EmbedBuilder,
+    verificationEvent: VerificationEvent
+  ): void {
+    const membershipPresentation = this.getPendingMembershipPresentation(verificationEvent);
+    const fields = (embed.data.fields ?? []).filter((field) => field.name !== 'Membership');
+
+    if (!membershipPresentation) {
+      embed.setFields(...fields);
+      return;
+    }
+
+    embed.setColor(CASE_COLOR_WARNING);
+    embed.setTitle(membershipPresentation.title);
+    embed.setDescription(membershipPresentation.description);
+    const triggerIndex = fields.findIndex((field) => field.name === 'Trigger');
+    const insertIndex = triggerIndex >= 0 ? triggerIndex : fields.length;
+    fields.splice(insertIndex, 0, {
+      name: 'Membership',
+      value: membershipPresentation.fieldValue,
+      inline: false,
+    });
+    embed.setFields(...fields);
+  }
+
+  private applyObservedActionPresentation(embed: EmbedBuilder, actionType: AdminActionType): void {
+    const userId = embed.data.fields?.find((field) => field.name === 'User ID')?.value;
+    const userReference = userId ? `<@${userId}>` : 'This user';
+
+    switch (actionType) {
+      case AdminActionType.DISMISS:
+        embed.setColor(CASE_COLOR_CLOSED);
+        embed.setTitle('Observed Alert Dismissed');
+        embed.setDescription(
+          `${userReference}'s observed alert was dismissed. No further moderator action is pending for this alert.`
+        );
+        return;
+      case AdminActionType.FALSE_POSITIVE:
+        embed.setColor(CASE_COLOR_VERIFIED);
+        embed.setTitle('Observed Alert Marked False Positive');
+        embed.setDescription(
+          `${userReference}'s observed alert was marked as a false positive. No further moderator action is pending for this alert.`
+        );
+        return;
+      case AdminActionType.BAN:
+        embed.setColor(CASE_COLOR_BANNED);
+        embed.setTitle('Observed Alert Handled: Banned');
+        embed.setDescription(`${userReference} was banned from this observed alert.`);
+        return;
+      case AdminActionType.RESTRICT:
+        embed.setColor(CASE_COLOR_PENDING);
+        embed.setTitle('Moderation Case Opened');
+        embed.setDescription(`${userReference} was restricted and moved into a moderation case.`);
+        return;
+      case AdminActionType.OPEN_CASE:
+        embed.setColor(CASE_COLOR_PENDING);
+        embed.setTitle('Moderation Case Opened');
+        embed.setDescription(`${userReference} was moved into a moderation case.`);
+        return;
+      default:
+        return;
+    }
+  }
+
+  private restoreObservedPendingPresentation(embed: EmbedBuilder): void {
+    const userId = embed.data.fields?.find((field) => field.name === 'User ID')?.value;
+    const userReference = userId ? `<@${userId}>` : 'this user';
+    embed.setColor(CASE_COLOR_WARNING);
+    embed.setTitle('Suspicious Activity Observed');
+    embed.setDescription(
+      `Drasil observed suspicious activity from ${userReference}. No automatic restriction was applied.`
+    );
   }
 
   private formatVerificationActionFailureFieldValue(metadata: unknown): string | null {

--- a/src/services/NotificationPresentationBuilder.ts
+++ b/src/services/NotificationPresentationBuilder.ts
@@ -35,7 +35,7 @@ interface AdminActionRowOptions {
   readonly caseMembershipState?: CaseMembershipState;
 }
 
-type CaseMembershipState = 'in_server' | 'left_or_removed' | 'unknown';
+type CaseMembershipState = 'in_server' | 'left_or_removed';
 
 interface ThreadAnalysisMetadata {
   analyzedMessageIds?: unknown;
@@ -96,16 +96,12 @@ export class NotificationPresentationBuilder {
       member.guild.id
     );
 
-    const membershipPresentation = this.getPendingMembershipPresentation(verificationEvent);
-
     if (verificationEvent.status === VerificationStatus.VERIFIED) {
       embedColor = CASE_COLOR_VERIFIED;
     } else if (verificationEvent.status === VerificationStatus.BANNED) {
       embedColor = CASE_COLOR_BANNED;
     } else if (verificationEvent.status === VerificationStatus.CLOSED_NO_ACTION) {
       embedColor = CASE_COLOR_CLOSED;
-    } else if (membershipPresentation) {
-      embedColor = CASE_COLOR_WARNING;
     }
 
     const resolutionPresentation = this.getVerificationResolutionPresentation(verificationEvent);
@@ -113,17 +109,14 @@ export class NotificationPresentationBuilder {
       .setColor(embedColor)
       .setTitle(
         resolutionPresentation?.title ??
-          membershipPresentation?.title ??
           this.getPendingCaseTitle(detectionResult, verificationEvent)
       )
       .setDescription(
         resolutionPresentation
           ? `<@${member.id}> has been handled. No further moderator action is pending.`
-          : membershipPresentation
-            ? membershipPresentation.description
-            : countedDetectionEvents.length > 1
-              ? `<@${member.id}> has been flagged as suspicious ${countedDetectionEvents.length} times.`
-              : `<@${member.id}> has been flagged as suspicious.`
+          : countedDetectionEvents.length > 1
+            ? `<@${member.id}> has been flagged as suspicious ${countedDetectionEvents.length} times.`
+            : `<@${member.id}> has been flagged as suspicious.`
       )
       .setThumbnail(member.user.displayAvatarURL())
       .addFields(
@@ -493,7 +486,7 @@ export class NotificationPresentationBuilder {
     includeBanAction: boolean,
     caseMembershipState: CaseMembershipState
   ): ButtonBuilder[] {
-    if (caseMembershipState === 'left_or_removed' || caseMembershipState === 'unknown') {
+    if (caseMembershipState === 'left_or_removed') {
       const buttons = [
         this.createCustomButton(`history_${userId}`, 'History', ButtonStyle.Secondary),
       ];

--- a/src/services/SecurityActionService.ts
+++ b/src/services/SecurityActionService.ts
@@ -1,6 +1,7 @@
 import { injectable, inject, optional } from 'inversify';
 import {
   GuildMember,
+  Guild,
   Message,
   Client,
   User,
@@ -150,6 +151,14 @@ export interface ISecurityActionService {
 
   banObservedDetection(
     member: GuildMember,
+    detectionEventId: string,
+    moderator: User,
+    reason: string
+  ): Promise<boolean>;
+
+  banObservedDetectionById(
+    guild: Guild,
+    userId: string,
     detectionEventId: string,
     moderator: User,
     reason: string
@@ -579,6 +588,60 @@ export class SecurityActionService implements ISecurityActionService {
       console.warn(`Failed to refresh user snapshot for case ${verificationEvent.id}:`, error);
       return verificationEvent;
     }
+  }
+
+  private async adoptObservedNotificationForCase(
+    verificationEvent: VerificationEvent,
+    detectionEvent?: DetectionEvent
+  ): Promise<VerificationEvent> {
+    if (!detectionEvent || verificationEvent.notification_message_id) {
+      return verificationEvent;
+    }
+
+    const metadata = this.metadataToRecord(detectionEvent.metadata);
+    const notificationMessageId = metadata.observed_notification_message_id;
+    if (typeof notificationMessageId !== 'string') {
+      return verificationEvent;
+    }
+
+    const notificationChannelId = metadata.observed_notification_channel_id;
+    const observedEvidenceThreadId = metadata.observed_evidence_thread_id;
+    const adoptedMetadata = {
+      ...this.metadataToRecord(verificationEvent.metadata),
+      case_origin: 'observed_alert',
+      observed_detection_event_id: detectionEvent.id,
+    } as VerificationEvent['metadata'];
+    const adoptedEvent = {
+      ...verificationEvent,
+      notification_message_id: notificationMessageId,
+      notification_channel_id:
+        typeof notificationChannelId === 'string' ? notificationChannelId : null,
+      private_evidence_thread_id:
+        typeof observedEvidenceThreadId === 'string'
+          ? observedEvidenceThreadId
+          : verificationEvent.private_evidence_thread_id,
+      metadata: adoptedMetadata,
+    };
+
+    return (
+      (await this.verificationEventRepository.update(verificationEvent.id, {
+        notification_message_id: adoptedEvent.notification_message_id,
+        notification_channel_id: adoptedEvent.notification_channel_id,
+        private_evidence_thread_id: adoptedEvent.private_evidence_thread_id,
+        metadata: adoptedEvent.metadata,
+      })) ?? adoptedEvent
+    );
+  }
+
+  private isObservedNotificationAdopted(
+    verificationEvent: VerificationEvent,
+    detectionEvent: DetectionEvent
+  ): boolean {
+    const metadata = this.metadataToRecord(detectionEvent.metadata);
+    return (
+      typeof metadata.observed_notification_message_id === 'string' &&
+      metadata.observed_notification_message_id === verificationEvent.notification_message_id
+    );
   }
 
   private shouldUseReportReviewThread(): boolean {
@@ -1138,7 +1201,10 @@ export class SecurityActionService implements ISecurityActionService {
       detectionResult,
       undefined,
       false,
-      shouldUseReviewThread
+      shouldUseReviewThread,
+      false,
+      undefined,
+      detectionEvent
     );
 
     const verificationEvent = await this.verificationEventRepository.findActiveByUserAndServer(
@@ -1341,7 +1407,8 @@ export class SecurityActionService implements ISecurityActionService {
     restrictUser = true,
     useReportReviewThread?: boolean,
     entitiesAlreadyEnsured = false,
-    moderator?: User
+    moderator?: User,
+    notificationSourceDetectionEvent?: DetectionEvent
   ): Promise<boolean> {
     const shouldUseReviewThread = useReportReviewThread ?? this.shouldUseReportReviewThread();
 
@@ -1368,6 +1435,10 @@ export class SecurityActionService implements ISecurityActionService {
       let notificationVerificationEvent = await this.refreshVerificationUserSnapshot(
         activeVerificationEvent,
         member
+      );
+      notificationVerificationEvent = await this.adoptObservedNotificationForCase(
+        notificationVerificationEvent,
+        notificationSourceDetectionEvent
       );
       console.log(
         `Active verification ${activeVerificationEvent.id} found for user ${member.user.tag}. Updating notification.`
@@ -1451,6 +1522,10 @@ export class SecurityActionService implements ISecurityActionService {
       VerificationStatus.PENDING
     );
     newVerificationEvent = await this.refreshVerificationUserSnapshot(newVerificationEvent, member);
+    newVerificationEvent = await this.adoptObservedNotificationForCase(
+      newVerificationEvent,
+      notificationSourceDetectionEvent
+    );
 
     const linkedDetectionEvent = await this.detectionEventsRepository.linkToVerificationEvent(
       detectionEventId,
@@ -2259,11 +2334,20 @@ export class SecurityActionService implements ISecurityActionService {
         actionType: AdminActionType.OPEN_CASE,
       });
       actionRecorded = true;
-      await this.notificationManager.markObservedDetectionActionTaken(
-        detectionEvent.id,
-        'opened a verification case',
-        moderator
-      );
+      if (this.isObservedNotificationAdopted(verificationEvent, detectionEvent)) {
+        await this.notificationManager.logActionToMessage(
+          verificationEvent,
+          AdminActionType.OPEN_CASE,
+          moderator
+        );
+      } else {
+        await this.notificationManager.markObservedDetectionActionTaken(
+          detectionEvent.id,
+          'opened a verification case',
+          moderator,
+          AdminActionType.OPEN_CASE
+        );
+      }
       await this.runModerationQueueTask(
         `delete observed alert ${detectionEvent.id} from the live moderation queue`,
         (moderationQueueService) =>
@@ -2323,11 +2407,20 @@ export class SecurityActionService implements ISecurityActionService {
         verificationEvent,
         actionType: AdminActionType.RESTRICT,
       });
-      await this.notificationManager.markObservedDetectionActionTaken(
-        detectionEvent.id,
-        'restricted this user',
-        moderator
-      );
+      if (this.isObservedNotificationAdopted(verificationEvent, detectionEvent)) {
+        await this.notificationManager.logActionToMessage(
+          verificationEvent,
+          AdminActionType.RESTRICT,
+          moderator
+        );
+      } else {
+        await this.notificationManager.markObservedDetectionActionTaken(
+          detectionEvent.id,
+          'restricted this user',
+          moderator,
+          AdminActionType.RESTRICT
+        );
+      }
       await this.runModerationQueueTask(
         `delete observed alert ${detectionEvent.id} from the live moderation queue`,
         (moderationQueueService) =>
@@ -2413,7 +2506,8 @@ export class SecurityActionService implements ISecurityActionService {
       await this.notificationManager.markObservedDetectionActionTaken(
         detectionEvent.id,
         'banned this user',
-        moderator
+        moderator,
+        AdminActionType.BAN
       );
       await this.runModerationQueueTask(
         `delete observed alert ${detectionEvent.id} from the live moderation queue`,
@@ -2424,6 +2518,99 @@ export class SecurityActionService implements ISecurityActionService {
         member,
         'observed detection action completed',
         { action_type: AdminActionType.BAN },
+        {
+          moderatorId: moderator.id,
+          detectionEventId: detectionEvent.id,
+        }
+      );
+      return true;
+    } catch (error) {
+      if (!actionApplied) {
+        await this.releaseDetectionMetadataForObservedAction(
+          detectionEvent,
+          moderator,
+          AdminActionType.BAN
+        );
+      }
+      throw error;
+    }
+  }
+
+  public async banObservedDetectionById(
+    guild: Guild,
+    userId: string,
+    detectionEventId: string,
+    moderator: User,
+    reason: string
+  ): Promise<boolean> {
+    const detectionEvent = await this.getObservedDetectionForUser(
+      guild.id,
+      userId,
+      detectionEventId
+    );
+    if (this.hasObservedAction(detectionEvent)) {
+      return false;
+    }
+    const claimedDetectionEvent = await this.updateDetectionMetadataForObservedAction(
+      detectionEvent,
+      moderator,
+      AdminActionType.BAN
+    );
+    if (!claimedDetectionEvent) {
+      return false;
+    }
+    let actionApplied = false;
+    try {
+      await this.ensureObservedEntitiesExist(guild.id, userId);
+      const activeVerificationEvent =
+        await this.verificationEventRepository.findActiveByUserAndServer(userId, guild.id);
+      const banned = await this.userModerationService.banUserById(
+        guild,
+        userId,
+        reason,
+        moderator,
+        detectionEvent.id
+      );
+      if (!banned) {
+        throw new Error(`Failed to ban user ${userId}`);
+      }
+      actionApplied = true;
+      const actionAlreadyRecorded = await this.hasRecordedObservedAction(
+        guild.id,
+        userId,
+        claimedDetectionEvent.id,
+        AdminActionType.BAN
+      );
+      if (!actionAlreadyRecorded) {
+        const currentVerificationEvent = activeVerificationEvent
+          ? await this.verificationEventRepository.findById(activeVerificationEvent.id)
+          : null;
+        await this.recordObservedAction({
+          serverId: guild.id,
+          userId,
+          moderator,
+          detectionEvent: claimedDetectionEvent,
+          verificationEvent: currentVerificationEvent ?? activeVerificationEvent ?? undefined,
+          actionType: AdminActionType.BAN,
+          notes: reason,
+        });
+      }
+      await this.notificationManager.markObservedDetectionActionTaken(
+        detectionEvent.id,
+        'banned this user by ID',
+        moderator,
+        AdminActionType.BAN
+      );
+      await this.runModerationQueueTask(
+        `delete observed alert ${detectionEvent.id} from the live moderation queue`,
+        (moderationQueueService) =>
+          moderationQueueService.deleteObservedAlertMirror(detectionEvent.id)
+      );
+      void this.productAnalyticsService.captureUserEvent(
+        guild.id,
+        userId,
+        'observed detection action completed',
+        { action_type: AdminActionType.BAN, source_detail: 'ban_by_id' },
         {
           moderatorId: moderator.id,
           detectionEventId: detectionEvent.id,
@@ -2481,7 +2668,8 @@ export class SecurityActionService implements ISecurityActionService {
         actionType === AdminActionType.FALSE_POSITIVE
           ? 'marked this detection as a false positive'
           : 'dismissed this alert',
-        moderator
+        moderator,
+        actionType
       );
       await this.runModerationQueueTask(
         `delete observed alert ${detectionEvent.id} from the live moderation queue`,

--- a/src/services/UserModerationService.ts
+++ b/src/services/UserModerationService.ts
@@ -1139,40 +1139,60 @@ export class UserModerationService implements IUserModerationService {
       const pendingVerificationEvents = verificationEvents.filter(
         (event) => event.status === VerificationStatus.PENDING
       );
+      const resolvedAt = new Date();
+      const resolvedEvents: Array<{
+        event: VerificationEvent;
+        previousEvent: VerificationEvent;
+        previousStatus: VerificationStatus;
+      }> = [];
 
-      await guild.bans.create(targetUser ?? userId, { reason });
+      for (const pendingEvent of pendingVerificationEvents) {
+        const previousStatus = pendingEvent.status;
+        const eventToUpdate = {
+          ...pendingEvent,
+          status: VerificationStatus.BANNED,
+          resolved_by: moderator.id,
+          resolved_at: resolvedAt,
+          notes: reason,
+          metadata: {
+            ...this.metadataToRecord(pendingEvent.metadata),
+            ...(targetUser ? { user_snapshot: this.buildUserSnapshot(targetUser) } : {}),
+            membership_state: 'left_or_removed',
+            banned_by_id_at: resolvedAt.toISOString(),
+          } as VerificationEvent['metadata'],
+        };
+        const updatedEvent = await this.verificationEventRepository.update(
+          pendingEvent.id,
+          eventToUpdate
+        );
+        resolvedEvents.push({
+          event: updatedEvent ?? eventToUpdate,
+          previousEvent: pendingEvent,
+          previousStatus,
+        });
+      }
+
+      try {
+        await guild.bans.create(targetUser ?? userId, { reason });
+      } catch (banError) {
+        for (const resolvedEvent of resolvedEvents) {
+          await this.verificationEventRepository
+            .update(resolvedEvent.previousEvent.id, resolvedEvent.previousEvent)
+            .catch((rollbackError) => {
+              console.warn(
+                `Failed to roll back case ${resolvedEvent.previousEvent.id} after ban by ID failed:`,
+                rollbackError
+              );
+            });
+        }
+
+        throw banError;
+      }
+
       console.log(`Banned user ${targetUser?.tag ?? userId} by ID. Reason: ${reason}`);
       await this.tryAbandonRoleQuarantine(guild.id, userId, 'drasil_ban_by_id', moderator.id);
 
       try {
-        const resolvedAt = new Date();
-        const resolvedEvents: Array<{
-          event: VerificationEvent;
-          previousStatus: VerificationStatus;
-        }> = [];
-
-        for (const pendingEvent of pendingVerificationEvents) {
-          const previousStatus = pendingEvent.status;
-          const eventToUpdate = {
-            ...pendingEvent,
-            status: VerificationStatus.BANNED,
-            resolved_by: moderator.id,
-            resolved_at: resolvedAt,
-            notes: reason,
-            metadata: {
-              ...this.metadataToRecord(pendingEvent.metadata),
-              ...(targetUser ? { user_snapshot: this.buildUserSnapshot(targetUser) } : {}),
-              membership_state: 'left_or_removed',
-              banned_by_id_at: resolvedAt.toISOString(),
-            } as VerificationEvent['metadata'],
-          };
-          const updatedEvent = await this.verificationEventRepository.update(
-            pendingEvent.id,
-            eventToUpdate
-          );
-          resolvedEvents.push({ event: updatedEvent ?? eventToUpdate, previousStatus });
-        }
-
         await this.serverMemberRepository.upsertMember(guild.id, userId, {
           verification_status: VerificationStatus.BANNED,
           is_restricted: true,
@@ -1195,7 +1215,8 @@ export class UserModerationService implements IUserModerationService {
             VerificationStatus.BANNED,
             AdminActionType.BAN,
             moderator,
-            resolvedEvent.event.id === resolvedEvents[0]?.event.id,
+            Boolean(resolvedEvent.event.notification_message_id) &&
+              resolvedEvent.event.id === resolvedEvents[0]?.event.id,
             {
               notes: reason,
               detectionEventId: detectionEventId ?? resolvedEvent.event.detection_event_id,

--- a/src/services/UserModerationService.ts
+++ b/src/services/UserModerationService.ts
@@ -65,6 +65,14 @@ export interface IUserModerationService {
     detectionEventId?: string
   ): Promise<boolean>;
 
+  banUserById(
+    guild: Guild,
+    userId: string,
+    reason: string,
+    moderator: User,
+    detectionEventId?: string
+  ): Promise<boolean>;
+
   /**
    * Synchronizes pending verification cases when Discord already has an existing ban.
    */
@@ -173,6 +181,36 @@ export class UserModerationService implements IUserModerationService {
         `Failed to delete case ${verificationEventId} from the live moderation queue:`,
         error
       );
+    }
+  }
+
+  private async refreshLiveQueueCaseMirror(verificationEvent: VerificationEvent): Promise<void> {
+    if (!this.moderationQueueService) {
+      return;
+    }
+
+    try {
+      await this.moderationQueueService.upsertCaseMirror(verificationEvent);
+    } catch (error) {
+      console.warn(
+        `Failed to refresh case ${verificationEvent.id} in the live moderation queue:`,
+        error
+      );
+    }
+  }
+
+  private async refreshCaseNotification(verificationEvent: VerificationEvent): Promise<void> {
+    if (!verificationEvent.notification_message_id) {
+      return;
+    }
+
+    try {
+      await this.notificationManager.updateNotificationButtons(
+        verificationEvent,
+        verificationEvent.status
+      );
+    } catch (error) {
+      console.warn(`Failed to refresh case notification ${verificationEvent.id}:`, error);
     }
   }
 
@@ -1085,6 +1123,131 @@ export class UserModerationService implements IUserModerationService {
     }
   }
 
+  public async banUserById(
+    guild: Guild,
+    userId: string,
+    reason: string,
+    moderator: User,
+    detectionEventId?: string
+  ): Promise<boolean> {
+    try {
+      const targetUser = await guild.client.users.fetch(userId).catch(() => null);
+      const verificationEvents = await this.verificationEventRepository.findByUserAndServer(
+        userId,
+        guild.id
+      );
+      const pendingVerificationEvents = verificationEvents.filter(
+        (event) => event.status === VerificationStatus.PENDING
+      );
+
+      await guild.bans.create(targetUser ?? userId, { reason });
+      console.log(`Banned user ${targetUser?.tag ?? userId} by ID. Reason: ${reason}`);
+      await this.tryAbandonRoleQuarantine(guild.id, userId, 'drasil_ban_by_id', moderator.id);
+
+      try {
+        const resolvedAt = new Date();
+        const resolvedEvents: Array<{
+          event: VerificationEvent;
+          previousStatus: VerificationStatus;
+        }> = [];
+
+        for (const pendingEvent of pendingVerificationEvents) {
+          const previousStatus = pendingEvent.status;
+          const eventToUpdate = {
+            ...pendingEvent,
+            status: VerificationStatus.BANNED,
+            resolved_by: moderator.id,
+            resolved_at: resolvedAt,
+            notes: reason,
+            metadata: {
+              ...this.metadataToRecord(pendingEvent.metadata),
+              ...(targetUser ? { user_snapshot: this.buildUserSnapshot(targetUser) } : {}),
+              membership_state: 'left_or_removed',
+              banned_by_id_at: resolvedAt.toISOString(),
+            } as VerificationEvent['metadata'],
+          };
+          const updatedEvent = await this.verificationEventRepository.update(
+            pendingEvent.id,
+            eventToUpdate
+          );
+          resolvedEvents.push({ event: updatedEvent ?? eventToUpdate, previousStatus });
+        }
+
+        await this.serverMemberRepository.upsertMember(guild.id, userId, {
+          verification_status: VerificationStatus.BANNED,
+          is_restricted: true,
+          last_status_change: resolvedAt,
+        });
+
+        const target: ModerationTarget = {
+          guildId: guild.id,
+          userId,
+          userTag: targetUser?.tag ?? userId,
+          username: targetUser?.username ?? null,
+          accountCreatedAt: targetUser ? this.getUserAccountCreatedAt(targetUser) : null,
+        };
+
+        for (const resolvedEvent of resolvedEvents) {
+          await this.finalizeResolvedVerificationEvent(
+            target,
+            resolvedEvent.event,
+            resolvedEvent.previousStatus,
+            VerificationStatus.BANNED,
+            AdminActionType.BAN,
+            moderator,
+            resolvedEvent.event.id === resolvedEvents[0]?.event.id,
+            {
+              notes: reason,
+              detectionEventId: detectionEventId ?? resolvedEvent.event.detection_event_id,
+              metadata: { source_detail: 'ban_by_id' },
+            }
+          );
+        }
+
+        await this.tryRecordModerationOutcomes(
+          target,
+          ModerationOutcomeType.BANNED,
+          ModerationOutcomeSource.DRASIL,
+          resolvedEvents.map((resolvedEvent) => resolvedEvent.event),
+          {
+            actorId: moderator.id,
+            reason,
+            detectionEventId:
+              detectionEventId ?? resolvedEvents[0]?.event.detection_event_id ?? null,
+            metadata: this.buildOutcomeMetadata(
+              { source_detail: 'ban_by_id' },
+              targetUser ?? undefined
+            ),
+            recordWithoutVerificationEvent: true,
+          }
+        );
+
+        void this.productAnalyticsService.captureUserEvent(
+          guild.id,
+          userId,
+          'moderation action completed',
+          { action_type: AdminActionType.BAN, source_detail: 'ban_by_id' },
+          {
+            moderatorId: moderator.id,
+            verificationEventId: resolvedEvents[0]?.event.id,
+            detectionEventId:
+              detectionEventId ?? resolvedEvents[0]?.event.detection_event_id ?? undefined,
+          }
+        );
+      } catch (postBanError) {
+        console.error(
+          `Ban by ID succeeded for ${targetUser?.tag ?? userId}, but post-ban updates failed:`,
+          postBanError
+        );
+      }
+
+      return true;
+    } catch (error) {
+      console.error(`Failed to ban user ${userId} by ID:`, error);
+      throw error;
+    }
+  }
+
   public async syncAlreadyBannedUser(
     guild: Guild,
     userId: string,
@@ -1564,7 +1727,10 @@ export class UserModerationService implements IUserModerationService {
           eventToUpdate,
           { touchUpdatedAt: false }
         );
-        markedEvents.push(updatedEvent ?? eventToUpdate);
+        const markedEvent = updatedEvent ?? eventToUpdate;
+        markedEvents.push(markedEvent);
+        await this.refreshCaseNotification(markedEvent);
+        await this.refreshLiveQueueCaseMirror(markedEvent);
       }
 
       await this.tryRecordModerationOutcomes(


### PR DESCRIPTION
[AGENT]

Unifies observed alert and moderation case presentation so observed alerts can become cases without changing Discord surfaces.

Adds departed-member pending case state and Ban by ID flows for departed case and observed alert actions. Also updates notification and live queue buttons so resolved observed alerts collapse to follow-up actions.

Related: #124.

Validation: format, lint, build, and unit tests pass locally. Integration tests were not run locally because no TEST_DATABASE_URL or DATABASE_URL was present.
