### PR TITLE
Enable manual case kick by default

### DIFF
--- a/src/__tests__/unit/InteractionHandler.unit.test.ts
+++ b/src/__tests__/unit/InteractionHandler.unit.test.ts
@@ -367,12 +367,6 @@ describe('InteractionHandler (unit)', () => {
     });
   };
 
-  const enableCaseKickActions = (): void => {
-    (configService.getServerConfig as jest.Mock).mockResolvedValue({
-      settings: { [MODERATOR_KICK_ACTION_ENABLED_SETTING_KEY]: true },
-    });
-  };
-
   const enableObservedKickActions = (): void => {
     (configService.getServerConfig as jest.Mock).mockResolvedValue({
       settings: { [OBSERVED_ACTION_KICK_ENABLED_SETTING_KEY]: true },
@@ -651,8 +645,7 @@ describe('InteractionHandler (unit)', () => {
     );
   });
 
-  it('shows case kick action to kick-only moderators when enabled', async () => {
-    enableCaseKickActions();
+  it('shows case kick action to kick-only moderators by default', async () => {
     const activeCase = buildVerificationEvent('ver-1', 'user-1');
     verificationEventRepository.findActiveByUserAndServer.mockResolvedValue(activeCase);
     verificationEventRepository.findByUserAndServer.mockResolvedValue([activeCase]);
@@ -1398,8 +1391,7 @@ describe('InteractionHandler (unit)', () => {
     });
   });
 
-  it('handles case kick button when case kick policy is enabled', async () => {
-    enableCaseKickActions();
+  it('handles case kick button by default', async () => {
     const handler = new InteractionHandler(
       client,
       notificationManager,
@@ -1430,6 +1422,9 @@ describe('InteractionHandler (unit)', () => {
   });
 
   it('blocks confirmed case kick when the case kick policy is disabled', async () => {
+    (configService.getServerConfig as jest.Mock).mockResolvedValue({
+      settings: { [MODERATOR_KICK_ACTION_ENABLED_SETTING_KEY]: false },
+    });
     const handler = new InteractionHandler(
       client,
       notificationManager,

--- a/src/__tests__/unit/detectionResponseSettings.unit.test.ts
+++ b/src/__tests__/unit/detectionResponseSettings.unit.test.ts
@@ -15,7 +15,7 @@ describe('detectionResponseSettings (unit)', () => {
     expect(settings.automaticDetectionExemptModerators).toBe(true);
     expect(settings.observedActionBanRequiresReason).toBe(false);
     expect(settings.moderatorBanActionEnabled).toBe(true);
-    expect(settings.moderatorKickActionEnabled).toBe(false);
+    expect(settings.moderatorKickActionEnabled).toBe(true);
     expect(settings.observedActionKickEnabled).toBe(false);
     expect(settings.messageDetectionAutoKickEnabled).toBe(false);
     expect(settings.joinDetectionAutoKickEnabled).toBe(false);
@@ -23,13 +23,18 @@ describe('detectionResponseSettings (unit)', () => {
     expect(settings.autoKickMinConfidenceThreshold).toBe(95);
   });
 
-  it('defaults new configs to restrict with moderator ban actions', () => {
+  it('defaults new configs to restrict with manual case actions enabled', () => {
     const settings = getDetectionResponseSettings({});
 
     expect(settings.mode).toBe('restrict');
     expect(settings.messageMode).toBe('restrict');
     expect(settings.joinMode).toBe('restrict');
     expect(settings.moderatorBanActionEnabled).toBe(true);
+    expect(settings.moderatorKickActionEnabled).toBe(true);
+    expect(settings.observedActionKickEnabled).toBe(false);
+    expect(settings.messageDetectionAutoKickEnabled).toBe(false);
+    expect(settings.joinDetectionAutoKickEnabled).toBe(false);
+    expect(settings.reportIntakeAutoKickEnabled).toBe(false);
   });
 
   it('maps legacy auto_restrict=false configs to notify_only', () => {
@@ -105,6 +110,14 @@ describe('detectionResponseSettings (unit)', () => {
     expect(settings.messageDetectionAutoKickEnabled).toBe(true);
     expect(settings.joinDetectionAutoKickEnabled).toBe(true);
     expect(settings.reportIntakeAutoKickEnabled).toBe(true);
+  });
+
+  it('allows moderator kick actions to be explicitly disabled', () => {
+    const settings = getDetectionResponseSettings({
+      moderator_kick_action_enabled: false,
+    });
+
+    expect(settings.moderatorKickActionEnabled).toBe(false);
   });
 
   it('allows moderator automatic detection exemption to be disabled', () => {

--- a/src/utils/detectionResponseSettings.ts
+++ b/src/utils/detectionResponseSettings.ts
@@ -29,7 +29,7 @@ export type DetectionResponseEvent = 'message' | 'join';
 
 export const DEFAULT_DETECTION_RESPONSE_MODE: DetectionResponseMode = 'restrict';
 export const DEFAULT_MODERATOR_BAN_ACTION_ENABLED = true;
-export const DEFAULT_MODERATOR_KICK_ACTION_ENABLED = false;
+export const DEFAULT_MODERATOR_KICK_ACTION_ENABLED = true;
 export const DEFAULT_OBSERVED_ACTION_KICK_ENABLED = false;
 export const DEFAULT_MESSAGE_DETECTION_AUTO_KICK_ENABLED = false;
 export const DEFAULT_JOIN_DETECTION_AUTO_KICK_ENABLED = false;


### PR DESCRIPTION
[AGENT]

Fixes manual case Kick visibility after PR #151 by defaulting the case-level moderator kick action to enabled, matching the existing manual ban action behavior. Observed-alert kicks and all auto-kick gates remain disabled by default.

This should make Kick appear in the Discord case Other Actions menu for in-server pending cases when the moderator and bot both have Kick Members permission.