### PR TITLE
Add moderation integrity audit

### DIFF
--- a/src/__tests__/unit/CommandHandler.catalog.unit.test.ts
+++ b/src/__tests__/unit/CommandHandler.catalog.unit.test.ts
@@ -138,8 +138,18 @@ describe('CommandHandler command catalog (unit)', () => {
       PermissionFlagsBits.ManageGuild.toString()
     );
     expect(auditCommand.options.map((option: any) => option.name)).toEqual([
+      'integrity',
       'ignore-detection',
       'restore-detection',
+    ]);
+    const integritySubcommand = auditCommand.options.find(
+      (option: any) => option.name === 'integrity'
+    );
+    expect(integritySubcommand.options.map((option: any) => option.name)).toEqual([
+      'scope',
+      'days',
+      'limit',
+      'user',
     ]);
   });
 

--- a/src/__tests__/unit/CommandHandler.moderation.unit.test.ts
+++ b/src/__tests__/unit/CommandHandler.moderation.unit.test.ts
@@ -18,6 +18,69 @@ const confirmLastSlashCommand = async (interaction: any): Promise<void> => {
 };
 
 describe('CommandHandler moderation commands (unit)', () => {
+  it('handles /audit integrity as a read-only ephemeral report', async () => {
+    const auditGuild = jest.fn().mockResolvedValue({
+      guildId: 'guild-1',
+      checkedAt: new Date('2026-01-01T00:00:00.000Z'),
+      scope: 'all',
+      days: 30,
+      limit: 50,
+      candidateCounts: {
+        pendingCases: 1,
+        recentResolvedCases: 1,
+        restrictedMembers: 0,
+        activeRoleQuarantines: 0,
+        queueItems: 0,
+      },
+      findings: [
+        {
+          severity: 'error',
+          code: 'resolved_case_missing_admin_action',
+          subject: 'case ver-1',
+          detail: 'Resolved case has no durable admin action row.',
+          userId: 'user-1',
+          verificationEventId: 'ver-1',
+        },
+      ],
+    });
+    const { handler } = buildHandler({ integrityAuditService: { auditGuild } });
+
+    const guild = { id: 'guild-1' } as any;
+    const interaction = {
+      commandName: 'audit',
+      guild,
+      channelId: 'channel-1',
+      user: { id: 'admin-1' },
+      memberPermissions: {
+        has: jest.fn((permission: bigint) => permission === PermissionFlagsBits.ManageGuild),
+      },
+      options: {
+        getSubcommand: jest.fn().mockReturnValue('integrity'),
+        getString: jest.fn((name: string) => (name === 'scope' ? 'all' : null)),
+        getInteger: jest.fn((name: string) => (name === 'days' ? 30 : null)),
+        getUser: jest.fn().mockReturnValue(null),
+      },
+      deferReply: jest.fn().mockResolvedValue(undefined),
+      editReply: jest.fn().mockResolvedValue(undefined),
+    } as any;
+
+    await handler.handleSlashCommand(interaction);
+
+    expect(interaction.deferReply).toHaveBeenCalledWith({ flags: MessageFlags.Ephemeral });
+    expect(auditGuild).toHaveBeenCalledWith(guild, {
+      scope: 'all',
+      days: 30,
+      limit: null,
+      userId: undefined,
+    });
+    expect(interaction.editReply).toHaveBeenCalledWith({
+      content: expect.stringContaining('Moderation integrity audit complete'),
+    });
+    expect(interaction.editReply).toHaveBeenCalledWith({
+      content: expect.stringContaining('resolved_case_missing_admin_action'),
+    });
+  });
+
   it('handles /audit ignore-detection for users with Manage Server permission', async () => {
     const excludeDetectionFromAccounting = jest.fn().mockResolvedValue({ id: 'det-1' });
     const { handler, securityActionService } = buildHandler({ excludeDetectionFromAccounting });

--- a/src/__tests__/unit/IntegrityAuditService.unit.test.ts
+++ b/src/__tests__/unit/IntegrityAuditService.unit.test.ts
@@ -327,4 +327,71 @@ describe('IntegrityAuditService (unit)', () => {
     expect(findingCodes).not.toContain('restricted_member_role_missing');
     expect(findingCodes).not.toContain('restricted_member_resolved_status');
   });
+
+  it('emits live fetch failures once for users in multiple audit categories', async () => {
+    const candidates = buildCandidates({
+      restrictedMembers: [
+        {
+          server_id: 'guild-1',
+          user_id: 'user-restricted',
+          join_date: baseDate,
+          is_restricted: true,
+          last_verified_at: null,
+          last_message_at: null,
+          verification_status: VerificationStatus.PENDING,
+          last_status_change: baseDate,
+          created_by: null,
+          updated_by: null,
+        },
+      ],
+      activeRoleQuarantineSnapshots: [
+        {
+          id: 'snapshot-1',
+          server_id: 'guild-1',
+          user_id: 'user-restricted',
+          verification_event_id: null,
+          status: RoleQuarantineSnapshotStatus.ACTIVE,
+          mode: 'automatic',
+          original_role_ids: ['role-a'],
+          planned_role_ids: [],
+          removed_role_ids: ['role-a'],
+          restored_role_ids: [],
+          skipped_roles: [],
+          failed_removals: [],
+          failed_restores: [],
+          created_at: baseDate,
+          updated_at: baseDate,
+          restored_at: null,
+          restored_by: null,
+          metadata: {},
+        },
+      ],
+    });
+    const repository: IIntegrityAuditRepository = {
+      listCandidates: jest.fn().mockResolvedValue(candidates),
+    };
+    const service = new IntegrityAuditService(
+      { channels: { fetch: jest.fn() } } as any,
+      {
+        getServerConfig: jest.fn().mockResolvedValue({
+          restricted_role_id: 'restricted-role-1',
+          settings: {},
+        }),
+      } as any,
+      repository
+    );
+    const guild = {
+      id: 'guild-1',
+      members: { fetch: jest.fn(async () => Promise.reject(new Error('member api down'))) },
+      bans: { fetch: jest.fn(async () => Promise.reject(new Error('ban api down'))) },
+    } as unknown as Guild;
+
+    const report = await service.auditGuild(guild, { scope: 'restricted', days: 30, limit: 50 });
+    const findingCodes = report.findings.map((finding) => finding.code);
+
+    expect(guild.members.fetch).toHaveBeenCalledTimes(1);
+    expect(guild.bans.fetch).toHaveBeenCalledTimes(1);
+    expect(findingCodes.filter((code) => code === 'member_fetch_failed')).toHaveLength(1);
+    expect(findingCodes.filter((code) => code === 'ban_fetch_failed')).toHaveLength(1);
+  });
 });

--- a/src/__tests__/unit/IntegrityAuditService.unit.test.ts
+++ b/src/__tests__/unit/IntegrityAuditService.unit.test.ts
@@ -1,0 +1,217 @@
+import { Guild } from 'discord.js';
+import { IntegrityAuditService } from '../../services/IntegrityAuditService';
+import {
+  IntegrityAuditCandidates,
+  IIntegrityAuditRepository,
+} from '../../repositories/IntegrityAuditRepository';
+import {
+  AdminActionType,
+  ModerationQueueItemType,
+  RoleQuarantineSnapshotStatus,
+  VerificationStatus,
+} from '../../repositories/types';
+
+const baseDate = new Date('2026-01-01T00:00:00.000Z');
+
+function buildCandidates(
+  overrides: Partial<IntegrityAuditCandidates> = {}
+): IntegrityAuditCandidates {
+  return {
+    pendingVerificationEvents: [],
+    recentResolvedVerificationEvents: [],
+    restrictedMembers: [],
+    activeRoleQuarantineSnapshots: [],
+    moderationQueueItems: [],
+    ...overrides,
+  };
+}
+
+describe('IntegrityAuditService (unit)', () => {
+  it('reports live Discord drift and missing durable rows without mutating state', async () => {
+    const candidates = buildCandidates({
+      pendingVerificationEvents: [
+        {
+          id: 'pending-1',
+          server_id: 'guild-1',
+          user_id: 'user-pending',
+          detection_event_id: null,
+          thread_id: 'thread-1',
+          private_evidence_thread_id: null,
+          notification_channel_id: 'notify-channel-1',
+          notification_message_id: 'notify-message-1',
+          status: VerificationStatus.PENDING,
+          created_at: baseDate,
+          updated_at: baseDate,
+          resolved_at: null,
+          resolved_by: null,
+          notes: null,
+          metadata: {},
+          admin_actions: [],
+          moderation_outcomes: [],
+        },
+      ],
+      recentResolvedVerificationEvents: [
+        {
+          id: 'resolved-1',
+          server_id: 'guild-1',
+          user_id: 'user-resolved',
+          detection_event_id: null,
+          thread_id: 'thread-2',
+          private_evidence_thread_id: null,
+          notification_channel_id: 'notify-channel-1',
+          notification_message_id: 'notify-message-2',
+          status: VerificationStatus.BANNED,
+          created_at: baseDate,
+          updated_at: baseDate,
+          resolved_at: baseDate,
+          resolved_by: 'admin-1',
+          notes: null,
+          metadata: {},
+          admin_actions: [
+            {
+              id: 'action-1',
+              server_id: 'guild-1',
+              user_id: 'user-resolved',
+              admin_id: 'admin-1',
+              verification_event_id: 'resolved-1',
+              detection_event_id: null,
+              action_type: AdminActionType.OPEN_CASE,
+              action_at: baseDate,
+              previous_status: null,
+              new_status: VerificationStatus.PENDING,
+              notes: null,
+              metadata: {},
+            },
+          ],
+          moderation_outcomes: [],
+        },
+      ],
+      restrictedMembers: [
+        {
+          server_id: 'guild-1',
+          user_id: 'user-restricted',
+          join_date: baseDate,
+          is_restricted: true,
+          last_verified_at: null,
+          last_message_at: null,
+          verification_status: VerificationStatus.PENDING,
+          last_status_change: baseDate,
+          created_by: null,
+          updated_by: null,
+        },
+      ],
+      activeRoleQuarantineSnapshots: [
+        {
+          id: 'snapshot-1',
+          server_id: 'guild-1',
+          user_id: 'user-restricted',
+          verification_event_id: null,
+          status: RoleQuarantineSnapshotStatus.ACTIVE,
+          mode: 'automatic',
+          original_role_ids: ['role-a'],
+          planned_role_ids: [],
+          removed_role_ids: ['role-a'],
+          restored_role_ids: [],
+          skipped_roles: [],
+          failed_removals: [],
+          failed_restores: [],
+          created_at: baseDate,
+          updated_at: baseDate,
+          restored_at: null,
+          restored_by: null,
+          metadata: {},
+        },
+      ],
+      moderationQueueItems: [
+        {
+          id: 'queue-1',
+          server_id: 'guild-1',
+          user_id: 'user-pending',
+          item_type: ModerationQueueItemType.CASE_MIRROR,
+          verification_event_id: 'resolved-1',
+          detection_event_id: null,
+          report_intake_id: null,
+          source_thread_id: null,
+          queue_channel_id: 'queue-channel-1',
+          queue_message_id: 'missing-message-1',
+          last_source_message_id: null,
+          last_notified_at: null,
+          created_at: baseDate,
+          updated_at: baseDate,
+          metadata: {},
+          verification_event_status: VerificationStatus.BANNED,
+        },
+      ],
+    });
+    const repository: IIntegrityAuditRepository = {
+      listCandidates: jest.fn().mockResolvedValue(candidates),
+    };
+    const service = new IntegrityAuditService(
+      {
+        channels: {
+          fetch: jest.fn(async (channelId: string) => ({
+            id: channelId,
+            messages: {
+              fetch: jest.fn(async (messageId: string) => {
+                if (messageId === 'missing-message-1') {
+                  throw { code: 10008, message: 'Unknown Message' };
+                }
+                return { id: messageId };
+              }),
+            },
+          })),
+        },
+      } as any,
+      {
+        getServerConfig: jest.fn().mockResolvedValue({
+          restricted_role_id: 'restricted-role-1',
+          settings: { moderation_queue_channel_id: 'queue-channel-1' },
+        }),
+      } as any,
+      repository
+    );
+    const guild = {
+      id: 'guild-1',
+      members: {
+        fetch: jest.fn(async (userId: string) => {
+          if (userId === 'user-pending') {
+            throw { code: 10007, message: 'Unknown Member' };
+          }
+          return {
+            id: userId,
+            roles: { cache: { has: jest.fn().mockReturnValue(false) } },
+          };
+        }),
+      },
+      bans: {
+        fetch: jest.fn(async (userId: string) => {
+          if (userId === 'user-pending') {
+            return { user: { id: userId } };
+          }
+          throw { code: 10026, message: 'Unknown Ban' };
+        }),
+      },
+    } as unknown as Guild;
+
+    const report = await service.auditGuild(guild, { scope: 'all', days: 30, limit: 50 });
+
+    expect(repository.listCandidates).toHaveBeenCalledWith({
+      serverId: 'guild-1',
+      since: expect.any(Date),
+      limit: 50,
+      userId: undefined,
+    });
+    expect(report.findings.map((finding) => finding.code)).toEqual(
+      expect.arrayContaining([
+        'pending_case_user_banned',
+        'pending_case_member_missing',
+        'resolved_case_missing_admin_action',
+        'resolved_case_missing_moderation_outcome',
+        'banned_case_not_in_ban_list',
+        'restricted_member_role_missing',
+        'queue_case_mirror_not_pending',
+        'queue_message_missing',
+      ])
+    );
+  });
+});

--- a/src/__tests__/unit/IntegrityAuditService.unit.test.ts
+++ b/src/__tests__/unit/IntegrityAuditService.unit.test.ts
@@ -394,4 +394,128 @@ describe('IntegrityAuditService (unit)', () => {
     expect(findingCodes.filter((code) => code === 'member_fetch_failed')).toHaveLength(1);
     expect(findingCodes.filter((code) => code === 'ban_fetch_failed')).toHaveLength(1);
   });
+
+  it('does not expect restricted roles for unrestricted pending cases', async () => {
+    const candidates = buildCandidates({
+      pendingVerificationEvents: [
+        {
+          id: 'pending-open-case-1',
+          server_id: 'guild-1',
+          user_id: 'user-open-case',
+          detection_event_id: null,
+          thread_id: null,
+          private_evidence_thread_id: null,
+          notification_channel_id: null,
+          notification_message_id: null,
+          status: VerificationStatus.PENDING,
+          created_at: baseDate,
+          updated_at: baseDate,
+          resolved_at: null,
+          resolved_by: null,
+          notes: null,
+          metadata: {},
+          admin_actions: [],
+          moderation_outcomes: [],
+        },
+      ],
+    });
+    const repository: IIntegrityAuditRepository = {
+      listCandidates: jest.fn().mockResolvedValue(candidates),
+    };
+    const service = new IntegrityAuditService(
+      { channels: { fetch: jest.fn() } } as any,
+      {
+        getServerConfig: jest.fn().mockResolvedValue({
+          restricted_role_id: 'restricted-role-1',
+          settings: {},
+        }),
+      } as any,
+      repository
+    );
+    const guild = {
+      id: 'guild-1',
+      members: {
+        fetch: jest.fn(async (userId: string) => ({
+          id: userId,
+          roles: { cache: { has: jest.fn().mockReturnValue(false) } },
+        })),
+      },
+      bans: { fetch: jest.fn(async () => Promise.reject({ code: 10026 })) },
+    } as unknown as Guild;
+
+    const report = await service.auditGuild(guild, { scope: 'cases', days: 30, limit: 50 });
+
+    expect(report.findings.map((finding) => finding.code)).not.toContain(
+      'pending_case_restricted_role_missing'
+    );
+  });
+
+  it('uses restricted-member role findings instead of duplicate pending-case findings under all scope', async () => {
+    const candidates = buildCandidates({
+      pendingVerificationEvents: [
+        {
+          id: 'pending-restricted-1',
+          server_id: 'guild-1',
+          user_id: 'user-restricted',
+          detection_event_id: null,
+          thread_id: null,
+          private_evidence_thread_id: null,
+          notification_channel_id: null,
+          notification_message_id: null,
+          status: VerificationStatus.PENDING,
+          created_at: baseDate,
+          updated_at: baseDate,
+          resolved_at: null,
+          resolved_by: null,
+          notes: null,
+          metadata: {},
+          admin_actions: [],
+          moderation_outcomes: [],
+        },
+      ],
+      restrictedMembers: [
+        {
+          server_id: 'guild-1',
+          user_id: 'user-restricted',
+          join_date: baseDate,
+          is_restricted: true,
+          last_verified_at: null,
+          last_message_at: null,
+          verification_status: VerificationStatus.PENDING,
+          last_status_change: baseDate,
+          created_by: null,
+          updated_by: null,
+        },
+      ],
+    });
+    const repository: IIntegrityAuditRepository = {
+      listCandidates: jest.fn().mockResolvedValue(candidates),
+    };
+    const service = new IntegrityAuditService(
+      { channels: { fetch: jest.fn() } } as any,
+      {
+        getServerConfig: jest.fn().mockResolvedValue({
+          restricted_role_id: 'restricted-role-1',
+          settings: {},
+        }),
+      } as any,
+      repository
+    );
+    const guild = {
+      id: 'guild-1',
+      members: {
+        fetch: jest.fn(async (userId: string) => ({
+          id: userId,
+          roles: { cache: { has: jest.fn().mockReturnValue(false) } },
+        })),
+      },
+      bans: { fetch: jest.fn(async () => Promise.reject({ code: 10026 })) },
+    } as unknown as Guild;
+
+    const report = await service.auditGuild(guild, { scope: 'all', days: 30, limit: 50 });
+    const findingCodes = report.findings.map((finding) => finding.code);
+
+    expect(findingCodes).not.toContain('pending_case_restricted_role_missing');
+    expect(findingCodes).toContain('restricted_member_role_missing');
+  });
 });

--- a/src/__tests__/unit/IntegrityAuditService.unit.test.ts
+++ b/src/__tests__/unit/IntegrityAuditService.unit.test.ts
@@ -6,6 +6,8 @@ import {
 } from '../../repositories/IntegrityAuditRepository';
 import {
   AdminActionType,
+  ModerationOutcomeSource,
+  ModerationOutcomeType,
   ModerationQueueItemType,
   RoleQuarantineSnapshotStatus,
   VerificationStatus,
@@ -213,5 +215,116 @@ describe('IntegrityAuditService (unit)', () => {
         'queue_message_missing',
       ])
     );
+  });
+
+  it('does not require admin actions for externally resolved cases with durable outcomes', async () => {
+    const candidates = buildCandidates({
+      recentResolvedVerificationEvents: [
+        {
+          id: 'external-ban-1',
+          server_id: 'guild-1',
+          user_id: 'user-external-ban',
+          detection_event_id: null,
+          thread_id: null,
+          private_evidence_thread_id: null,
+          notification_channel_id: null,
+          notification_message_id: null,
+          status: VerificationStatus.BANNED,
+          created_at: baseDate,
+          updated_at: baseDate,
+          resolved_at: baseDate,
+          resolved_by: 'native-mod-1',
+          notes: null,
+          metadata: { moderation_outcome_source: ModerationOutcomeSource.NATIVE_DISCORD },
+          admin_actions: [],
+          moderation_outcomes: [
+            {
+              id: 'outcome-1',
+              server_id: 'guild-1',
+              user_id: 'user-external-ban',
+              detection_event_id: null,
+              verification_event_id: 'external-ban-1',
+              outcome_type: ModerationOutcomeType.BANNED,
+              source: ModerationOutcomeSource.NATIVE_DISCORD,
+              actor_id: 'native-mod-1',
+              reason: null,
+              occurred_at: baseDate,
+              created_at: baseDate,
+              metadata: {},
+            },
+          ],
+        },
+      ],
+    });
+    const repository: IIntegrityAuditRepository = {
+      listCandidates: jest.fn().mockResolvedValue(candidates),
+    };
+    const service = new IntegrityAuditService(
+      { channels: { fetch: jest.fn() } } as any,
+      {
+        getServerConfig: jest.fn().mockResolvedValue({ restricted_role_id: null, settings: {} }),
+      } as any,
+      repository
+    );
+    const guild = {
+      id: 'guild-1',
+      members: { fetch: jest.fn(async () => ({ roles: { cache: { has: jest.fn() } } })) },
+      bans: { fetch: jest.fn(async (userId: string) => ({ user: { id: userId } })) },
+    } as unknown as Guild;
+
+    const report = await service.auditGuild(guild, { scope: 'cases', days: 30, limit: 50 });
+
+    expect(report.findings.map((finding) => finding.code)).not.toContain(
+      'resolved_case_missing_admin_action'
+    );
+    expect(report.findings.map((finding) => finding.code)).not.toContain(
+      'resolved_case_missing_moderation_outcome'
+    );
+  });
+
+  it('ignores banned restricted member rows because ban records keep that marker', async () => {
+    const candidates = buildCandidates({
+      restrictedMembers: [
+        {
+          server_id: 'guild-1',
+          user_id: 'user-banned',
+          join_date: baseDate,
+          is_restricted: true,
+          last_verified_at: null,
+          last_message_at: null,
+          verification_status: VerificationStatus.BANNED,
+          last_status_change: baseDate,
+          created_by: null,
+          updated_by: null,
+        },
+      ],
+    });
+    const repository: IIntegrityAuditRepository = {
+      listCandidates: jest.fn().mockResolvedValue(candidates),
+    };
+    const service = new IntegrityAuditService(
+      { channels: { fetch: jest.fn() } } as any,
+      {
+        getServerConfig: jest.fn().mockResolvedValue({
+          restricted_role_id: 'restricted-role-1',
+          settings: {},
+        }),
+      } as any,
+      repository
+    );
+    const guild = {
+      id: 'guild-1',
+      members: { fetch: jest.fn() },
+      bans: { fetch: jest.fn() },
+    } as unknown as Guild;
+
+    const report = await service.auditGuild(guild, { scope: 'restricted', days: 30, limit: 50 });
+
+    expect(guild.members.fetch).not.toHaveBeenCalled();
+    expect(guild.bans.fetch).not.toHaveBeenCalled();
+    const findingCodes = report.findings.map((finding) => finding.code);
+    expect(findingCodes).not.toContain('restricted_member_missing');
+    expect(findingCodes).not.toContain('restricted_member_role_missing');
+    expect(findingCodes).not.toContain('restricted_member_resolved_status');
   });
 });

--- a/src/__tests__/unit/commandHandlerTestHarness.ts
+++ b/src/__tests__/unit/commandHandlerTestHarness.ts
@@ -38,6 +38,7 @@ export type HandlerOverrides = Partial<{
   restrictedRoleLockdownService: any;
   reportIntakeService: any;
   moderationQueueService: any;
+  integrityAuditService: any;
   client: any;
 }>;
 
@@ -182,7 +183,8 @@ export const buildHandler = (overrides: HandlerOverrides = {}) => {
       setupDiagnosticsService,
       overrides.restrictedRoleLockdownService,
       overrides.reportIntakeService,
-      overrides.moderationQueueService
+      overrides.moderationQueueService,
+      overrides.integrityAuditService
     ),
     client,
     userModerationService,
@@ -190,5 +192,6 @@ export const buildHandler = (overrides: HandlerOverrides = {}) => {
     configService,
     securityActionService,
     setupDiagnosticsService,
+    integrityAuditService: overrides.integrityAuditService,
   };
 };

--- a/src/controllers/CommandHandler.ts
+++ b/src/controllers/CommandHandler.ts
@@ -43,6 +43,7 @@ import { TestCommandHandler } from './TestCommandHandler';
 import { isUserInstallReportingEnabled } from '../utils/userInstallReporting';
 import { IReportIntakeService } from '../services/ReportIntakeService';
 import { IModerationQueueService } from '../services/ModerationQueueService';
+import { IIntegrityAuditService } from '../services/IntegrityAuditService';
 import { canModerateReportIntake } from '../utils/reportIntakeStaffAuthorization';
 import { buildAdminGuildSetupUrl } from '../utils/publicWebLinks';
 import 'reflect-metadata';
@@ -123,7 +124,10 @@ export class CommandHandler implements ICommandHandler {
     reportIntakeService?: IReportIntakeService,
     @inject(TYPES.ModerationQueueService)
     @optional()
-    moderationQueueService?: IModerationQueueService
+    moderationQueueService?: IModerationQueueService,
+    @inject(TYPES.IntegrityAuditService)
+    @optional()
+    integrityAuditService?: IIntegrityAuditService
   ) {
     this.client = client;
     this.configService = configService;
@@ -157,7 +161,8 @@ export class CommandHandler implements ICommandHandler {
       this.configService,
       userModerationService,
       securityActionService,
-      (interaction) => this.replyGuildInstallRequired(interaction)
+      (interaction) => this.replyGuildInstallRequired(interaction),
+      integrityAuditService
     );
     this.reportCommandHandler = new ReportCommandHandler(
       reportSubmissionService,

--- a/src/controllers/EventHandler.ts
+++ b/src/controllers/EventHandler.ts
@@ -41,6 +41,7 @@ import {
 import { IReportIntakeService } from '../services/ReportIntakeService';
 import { IReportIntakeAgentService } from '../services/ReportIntakeAgentService';
 import { ICaseReviewReminderService } from '../services/CaseReviewReminderService';
+import { isDiscordUnknownBanError } from '../utils/discordErrors';
 import {
   IMessageContextRepository,
   MESSAGE_CONTEXT_PREVIEW_MAX_LENGTH,
@@ -60,7 +61,6 @@ const MESSAGE_CONTEXT_PRUNE_INTERVAL_MS = 60 * 60 * 1000;
 const SETUP_NUDGE_SUPPRESSION_MS = 7 * 24 * 60 * 60 * 1000;
 const SETUP_WARNING_VALIDATION_PRECHECK_MS = 5 * 60 * 1000;
 const SETUP_WARNING_LAST_FINGERPRINT_SETTING_KEY = 'setup_warning_last_fingerprint';
-const DISCORD_UNKNOWN_BAN_ERROR_CODE = 10026;
 const DISCORD_MEMBER_REMOVE_AUDIT_WINDOW_MS = 60 * 1000;
 
 type SetupNudgeSource = 'audit_log_installer' | 'owner';
@@ -612,7 +612,7 @@ export class EventHandler implements IEventHandler {
       const existingBan = await member.guild.bans.fetch(member.id);
       return !existingBan;
     } catch (error) {
-      if (this.isUnknownBanError(error)) {
+      if (isDiscordUnknownBanError(error)) {
         return true;
       }
 
@@ -622,15 +622,6 @@ export class EventHandler implements IEventHandler {
       );
       return false;
     }
-  }
-
-  private isUnknownBanError(error: unknown): boolean {
-    return (
-      typeof error === 'object' &&
-      error !== null &&
-      'code' in error &&
-      (error as { code?: unknown }).code === DISCORD_UNKNOWN_BAN_ERROR_CODE
-    );
   }
 
   private async resolveObservedBanOptions(ban: GuildBan): Promise<ObservedDiscordBanOptions> {

--- a/src/controllers/ModerationCommandHandler.ts
+++ b/src/controllers/ModerationCommandHandler.ts
@@ -6,6 +6,11 @@ import {
   PermissionFlagsBits,
 } from 'discord.js';
 import { IConfigService } from '../config/ConfigService';
+import {
+  IIntegrityAuditService,
+  IntegrityAuditFinding,
+  IntegrityAuditReport,
+} from '../services/IntegrityAuditService';
 import { ISecurityActionService } from '../services/SecurityActionService';
 import { IUserModerationService } from '../services/UserModerationService';
 import { getDetectionResponseSettings } from '../utils/detectionResponseSettings';
@@ -13,12 +18,15 @@ import { requestSlashCommandConfirmation } from '../utils/slashCommandConfirmati
 
 type ReplyGuildInstallRequired = (interaction: ChatInputCommandInteraction) => Promise<void>;
 
+const AUDIT_INTEGRITY_RESPONSE_MAX_LENGTH = 1900;
+
 export class ModerationCommandHandler {
   public constructor(
     private readonly configService: IConfigService,
     private readonly userModerationService: IUserModerationService,
     private readonly securityActionService: ISecurityActionService,
-    private readonly replyGuildInstallRequired: ReplyGuildInstallRequired
+    private readonly replyGuildInstallRequired: ReplyGuildInstallRequired,
+    private readonly integrityAuditService?: IIntegrityAuditService
   ) {}
 
   public async handleBanCommand(interaction: ChatInputCommandInteraction): Promise<void> {
@@ -121,6 +129,11 @@ export class ModerationCommandHandler {
     }
 
     const subcommand = interaction.options.getSubcommand(true);
+    if (subcommand === 'integrity') {
+      await this.handleIntegrityAuditCommand(interaction, guild);
+      return;
+    }
+
     const detectionEventId = interaction.options.getString('detection-id', true).trim();
     const reason = interaction.options.getString('reason')?.trim() || undefined;
 
@@ -242,5 +255,80 @@ export class ModerationCommandHandler {
         ? await guild.members.fetchMe().catch(() => null)
         : null);
     return botMember?.permissions.has(PermissionFlagsBits.BanMembers) ?? false;
+  }
+
+  private async handleIntegrityAuditCommand(
+    interaction: ChatInputCommandInteraction,
+    guild: Guild
+  ): Promise<void> {
+    if (!this.integrityAuditService) {
+      await interaction.reply({
+        content: 'Integrity audit is not available in this runtime.',
+        flags: MessageFlags.Ephemeral,
+      });
+      return;
+    }
+
+    await interaction.deferReply({ flags: MessageFlags.Ephemeral });
+
+    try {
+      const report = await this.integrityAuditService.auditGuild(guild, {
+        scope: interaction.options.getString('scope'),
+        days: interaction.options.getInteger('days'),
+        limit: interaction.options.getInteger('limit'),
+        userId: interaction.options.getUser('user')?.id,
+      });
+
+      await interaction.editReply({ content: this.formatIntegrityAuditReport(report) });
+    } catch (error) {
+      console.error(`Failed to run integrity audit for guild ${guild.id}:`, error);
+      await interaction.editReply({
+        content: 'Failed to run the integrity audit. No repair actions were applied.',
+      });
+    }
+  }
+
+  private formatIntegrityAuditReport(report: IntegrityAuditReport): string {
+    const severityCounts = this.countFindingsBySeverity(report.findings);
+    const lines = [
+      'Moderation integrity audit complete. No repair actions were applied.',
+      `Scope: ${report.scope}; lookback: ${report.days} days; limit: ${report.limit}${report.userId ? `; user: <@${report.userId}>` : ''}.`,
+      `Checked: ${report.candidateCounts.pendingCases} pending cases, ${report.candidateCounts.recentResolvedCases} recent resolved cases, ${report.candidateCounts.restrictedMembers} restricted members, ${report.candidateCounts.activeRoleQuarantines} active role quarantines, ${report.candidateCounts.queueItems} queue items.`,
+      `Findings: ${severityCounts.error} errors, ${severityCounts.warning} warnings, ${severityCounts.info} info.`,
+    ];
+
+    if (report.findings.length === 0) {
+      lines.push('No integrity findings found for the selected scope.');
+      return lines.join('\n');
+    }
+
+    lines.push('', 'Top findings:');
+    for (const finding of report.findings.slice(0, 12)) {
+      lines.push(this.formatIntegrityFinding(finding));
+    }
+    if (report.findings.length > 12) {
+      lines.push(`...and ${report.findings.length - 12} more findings.`);
+    }
+
+    const response = lines.join('\n');
+    return response.length <= AUDIT_INTEGRITY_RESPONSE_MAX_LENGTH
+      ? response
+      : `${response.slice(0, AUDIT_INTEGRITY_RESPONSE_MAX_LENGTH - 3)}...`;
+  }
+
+  private formatIntegrityFinding(finding: IntegrityAuditFinding): string {
+    return `- [${finding.severity}] ${finding.code}: ${finding.subject} - ${finding.detail}`;
+  }
+
+  private countFindingsBySeverity(
+    findings: IntegrityAuditFinding[]
+  ): Record<'error' | 'warning' | 'info', number> {
+    return findings.reduce(
+      (counts, finding) => ({
+        ...counts,
+        [finding.severity]: counts[finding.severity] + 1,
+      }),
+      { error: 0, warning: 0, info: 0 }
+    );
   }
 }

--- a/src/controllers/commandDefinitions.ts
+++ b/src/controllers/commandDefinitions.ts
@@ -22,6 +22,12 @@ import {
 import { MAX_REPORT_AI_MAX_IMAGE_BYTES, MAX_REPORT_AI_MAX_IMAGES } from '../utils/reportAiSettings';
 import { USER_REPORT_REASON_MAX_LENGTH } from '../utils/userReportSettings';
 import { MAX_VERIFICATION_AI_THREAD_ANALYSIS_MESSAGE_LIMIT } from '../utils/verificationThreadAnalysisSettings';
+import {
+  INTEGRITY_AUDIT_MAX_DAYS,
+  INTEGRITY_AUDIT_MAX_LIMIT,
+  INTEGRITY_AUDIT_MIN_DAYS,
+  INTEGRITY_AUDIT_MIN_LIMIT,
+} from '../utils/integrityAuditSettings';
 
 export const REPORT_USER_CONTEXT_COMMAND_NAME = 'Report User';
 export const REPORT_MESSAGE_CONTEXT_COMMAND_NAME = 'Report Message';
@@ -911,7 +917,47 @@ const baseApplicationCommandBuilders = [
     .setContexts(InteractionContextType.Guild),
   new SlashCommandBuilder()
     .setName('audit')
-    .setDescription('Audit detection accounting')
+    .setDescription('Audit moderation accounting and live state')
+    .addSubcommand((subcommand) =>
+      subcommand
+        .setName('integrity')
+        .setDescription('Read-only audit of Discord and database moderation state')
+        .addStringOption((option) =>
+          option
+            .setName('scope')
+            .setDescription('Audit area to check')
+            .setRequired(false)
+            .addChoices(
+              { name: 'All checks', value: 'all' },
+              { name: 'Cases', value: 'cases' },
+              { name: 'Restricted members', value: 'restricted' },
+              { name: 'Queue', value: 'queue' }
+            )
+        )
+        .addIntegerOption((option) =>
+          option
+            .setName('days')
+            .setDescription(
+              `Resolved-case lookback window (${INTEGRITY_AUDIT_MIN_DAYS}-${INTEGRITY_AUDIT_MAX_DAYS} days)`
+            )
+            .setRequired(false)
+            .setMinValue(INTEGRITY_AUDIT_MIN_DAYS)
+            .setMaxValue(INTEGRITY_AUDIT_MAX_DAYS)
+        )
+        .addIntegerOption((option) =>
+          option
+            .setName('limit')
+            .setDescription(
+              `Maximum rows to inspect per category (${INTEGRITY_AUDIT_MIN_LIMIT}-${INTEGRITY_AUDIT_MAX_LIMIT})`
+            )
+            .setRequired(false)
+            .setMinValue(INTEGRITY_AUDIT_MIN_LIMIT)
+            .setMaxValue(INTEGRITY_AUDIT_MAX_LIMIT)
+        )
+        .addUserOption((option) =>
+          option.setName('user').setDescription('Limit audit to one user').setRequired(false)
+        )
+    )
     .addSubcommand((subcommand) =>
       subcommand
         .setName('ignore-detection')

--- a/src/di/container.ts
+++ b/src/di/container.ts
@@ -72,6 +72,10 @@ import {
   ModerationQueueRepository,
 } from '../repositories/ModerationQueueRepository';
 import {
+  IIntegrityAuditRepository,
+  IntegrityAuditRepository,
+} from '../repositories/IntegrityAuditRepository';
+import {
   IReportCandidateService,
   ReportCandidateService,
 } from '../services/ReportCandidateService';
@@ -97,6 +101,7 @@ import {
   RoleQuarantineSnapshotRepository,
 } from '../repositories/RoleQuarantineSnapshotRepository';
 import { IRoleQuarantineService, RoleQuarantineService } from '../services/RoleQuarantineService';
+import { IIntegrityAuditService, IntegrityAuditService } from '../services/IntegrityAuditService';
 // Initialize container
 const container = new Container();
 
@@ -194,6 +199,10 @@ function configureRepositories(container: Container): void {
   container
     .bind<IRoleQuarantineSnapshotRepository>(TYPES.RoleQuarantineSnapshotRepository)
     .to(RoleQuarantineSnapshotRepository)
+    .inSingletonScope();
+  container
+    .bind<IIntegrityAuditRepository>(TYPES.IntegrityAuditRepository)
+    .to(IntegrityAuditRepository)
     .inSingletonScope();
 
   // Add more repository bindings as they're refactored
@@ -304,6 +313,11 @@ function configureServices(container: Container): void {
   container
     .bind<IRoleQuarantineService>(TYPES.RoleQuarantineService)
     .to(RoleQuarantineService)
+    .inSingletonScope();
+
+  container
+    .bind<IIntegrityAuditService>(TYPES.IntegrityAuditService)
+    .to(IntegrityAuditService)
     .inSingletonScope();
 }
 

--- a/src/di/symbols.ts
+++ b/src/di/symbols.ts
@@ -29,6 +29,7 @@ export const TYPES = {
   ModerationOutcomeService: Symbol.for('ModerationOutcomeService'),
   ModerationQueueService: Symbol.for('ModerationQueueService'),
   RoleQuarantineService: Symbol.for('RoleQuarantineService'),
+  IntegrityAuditService: Symbol.for('IntegrityAuditService'),
 
   // Repositories
   BaseRepository: Symbol.for('BaseRepository'),
@@ -42,6 +43,7 @@ export const TYPES = {
   ModerationOutcomeRepository: Symbol.for('ModerationOutcomeRepository'),
   ModerationQueueRepository: Symbol.for('ModerationQueueRepository'),
   RoleQuarantineSnapshotRepository: Symbol.for('RoleQuarantineSnapshotRepository'),
+  IntegrityAuditRepository: Symbol.for('IntegrityAuditRepository'),
 
   // External dependencies
   DiscordClient: Symbol.for('DiscordClient'),

--- a/src/repositories/IntegrityAuditRepository.ts
+++ b/src/repositories/IntegrityAuditRepository.ts
@@ -1,0 +1,175 @@
+import { inject, injectable } from 'inversify';
+import {
+  moderation_queue_item_type,
+  Prisma,
+  PrismaClient,
+  role_quarantine_snapshot_status,
+  verification_status,
+} from '../db/prisma';
+import { TYPES } from '../di/symbols';
+import {
+  AdminAction,
+  ModerationOutcome,
+  ModerationQueueItem,
+  ModerationQueueItemType,
+  RoleQuarantineSnapshot,
+  RoleQuarantineSnapshotStatus,
+  ServerMember,
+  VerificationEvent,
+  VerificationStatus,
+} from './types';
+import { RepositoryError } from './BaseRepository';
+
+export interface IntegrityAuditVerificationEvent extends VerificationEvent {
+  readonly admin_actions: AdminAction[];
+  readonly moderation_outcomes: ModerationOutcome[];
+}
+
+export interface IntegrityAuditModerationQueueItem extends ModerationQueueItem {
+  readonly verification_event_status: VerificationStatus | null;
+}
+
+export interface IntegrityAuditCandidateQuery {
+  readonly serverId: string;
+  readonly since: Date;
+  readonly limit: number;
+  readonly userId?: string;
+}
+
+export interface IntegrityAuditCandidates {
+  readonly pendingVerificationEvents: IntegrityAuditVerificationEvent[];
+  readonly recentResolvedVerificationEvents: IntegrityAuditVerificationEvent[];
+  readonly restrictedMembers: ServerMember[];
+  readonly activeRoleQuarantineSnapshots: RoleQuarantineSnapshot[];
+  readonly moderationQueueItems: IntegrityAuditModerationQueueItem[];
+}
+
+export interface IIntegrityAuditRepository {
+  listCandidates(query: IntegrityAuditCandidateQuery): Promise<IntegrityAuditCandidates>;
+}
+
+type ModerationQueueItemWithVerification = ModerationQueueItem & {
+  verification_events?: { status: VerificationStatus } | null;
+};
+
+@injectable()
+export class IntegrityAuditRepository implements IIntegrityAuditRepository {
+  public constructor(@inject(TYPES.PrismaClient) private readonly prisma: PrismaClient) {}
+
+  public async listCandidates(
+    query: IntegrityAuditCandidateQuery
+  ): Promise<IntegrityAuditCandidates> {
+    try {
+      const userFilter = query.userId ? { user_id: query.userId } : {};
+      const verificationWhere: Prisma.verification_eventsWhereInput = {
+        server_id: query.serverId,
+        ...userFilter,
+      };
+
+      const [
+        pendingVerificationEvents,
+        recentResolvedVerificationEvents,
+        restrictedMembers,
+        activeRoleQuarantineSnapshots,
+        moderationQueueItems,
+      ] = await Promise.all([
+        this.prisma.verification_events.findMany({
+          where: {
+            ...verificationWhere,
+            status: VerificationStatus.PENDING as verification_status,
+          },
+          include: { admin_actions: true, moderation_outcomes: true },
+          orderBy: [{ updated_at: 'asc' }, { created_at: 'asc' }],
+          take: query.limit,
+        }),
+        this.prisma.verification_events.findMany({
+          where: {
+            ...verificationWhere,
+            status: {
+              in: [
+                VerificationStatus.VERIFIED,
+                VerificationStatus.BANNED,
+                VerificationStatus.KICKED,
+                VerificationStatus.CLOSED_NO_ACTION,
+              ] as verification_status[],
+            },
+            OR: [
+              { resolved_at: { gte: query.since } },
+              { updated_at: { gte: query.since } },
+              { created_at: { gte: query.since } },
+            ],
+          },
+          include: { admin_actions: true, moderation_outcomes: true },
+          orderBy: [{ resolved_at: 'desc' }, { updated_at: 'desc' }],
+          take: query.limit,
+        }),
+        this.prisma.server_members.findMany({
+          where: {
+            server_id: query.serverId,
+            is_restricted: true,
+            ...userFilter,
+          },
+          orderBy: { last_status_change: 'asc' },
+          take: query.limit,
+        }),
+        this.prisma.role_quarantine_snapshots.findMany({
+          where: {
+            server_id: query.serverId,
+            status: RoleQuarantineSnapshotStatus.ACTIVE as role_quarantine_snapshot_status,
+            ...userFilter,
+          },
+          orderBy: { created_at: 'asc' },
+          take: query.limit,
+        }),
+        this.prisma.moderation_queue_items.findMany({
+          where: {
+            server_id: query.serverId,
+            ...(query.userId ? { user_id: query.userId } : {}),
+            item_type: {
+              in: [
+                ModerationQueueItemType.CASE_MIRROR,
+                ModerationQueueItemType.OBSERVED_ALERT_MIRROR,
+                ModerationQueueItemType.SUPPORT_THREAD_ATTENTION,
+                ModerationQueueItemType.REPORT_THREAD_ATTENTION,
+              ] as moderation_queue_item_type[],
+            },
+          },
+          include: { verification_events: { select: { status: true } } },
+          orderBy: [{ updated_at: 'asc' }, { created_at: 'asc' }],
+          take: query.limit,
+        }),
+      ]);
+
+      return {
+        pendingVerificationEvents: pendingVerificationEvents as IntegrityAuditVerificationEvent[],
+        recentResolvedVerificationEvents:
+          recentResolvedVerificationEvents as IntegrityAuditVerificationEvent[],
+        restrictedMembers: restrictedMembers as ServerMember[],
+        activeRoleQuarantineSnapshots: activeRoleQuarantineSnapshots as RoleQuarantineSnapshot[],
+        moderationQueueItems: (moderationQueueItems as ModerationQueueItemWithVerification[]).map(
+          (item) => ({
+            ...item,
+            verification_event_status: item.verification_events?.status ?? null,
+          })
+        ),
+      };
+    } catch (error) {
+      this.handleError(error, 'listIntegrityAuditCandidates');
+    }
+  }
+
+  private handleError(error: unknown, operation: string): never {
+    console.error(`Repository error during ${operation}:`, error);
+
+    if (error instanceof Prisma.PrismaClientKnownRequestError) {
+      throw new RepositoryError(
+        `Database error during ${operation}: ${error.message} (Code: ${error.code})`,
+        error
+      );
+    }
+    if (error instanceof Error) {
+      throw new RepositoryError(`Unexpected error during ${operation}: ${error.message}`, error);
+    }
+    throw new RepositoryError(`Unknown error during ${operation}`, error);
+  }
+}

--- a/src/repositories/IntegrityAuditRepository.ts
+++ b/src/repositories/IntegrityAuditRepository.ts
@@ -107,6 +107,7 @@ export class IntegrityAuditRepository implements IIntegrityAuditRepository {
           where: {
             server_id: query.serverId,
             is_restricted: true,
+            verification_status: { not: VerificationStatus.BANNED as verification_status },
             ...userFilter,
           },
           orderBy: { last_status_change: 'asc' },

--- a/src/services/IntegrityAuditService.ts
+++ b/src/services/IntegrityAuditService.ts
@@ -139,6 +139,7 @@ export class IntegrityAuditService implements IIntegrityAuditService {
     });
     const findings: IntegrityAuditFinding[] = [];
     const liveUsers = await this.inspectLiveUsers(guild, this.collectUserIds(candidates, scope));
+    const restrictedMemberIds = this.collectRestrictedMemberIds(candidates.restrictedMembers);
     this.addLiveUserFetchFindings(liveUsers, findings);
 
     if (this.includesCaseChecks(scope)) {
@@ -146,6 +147,8 @@ export class IntegrityAuditService implements IIntegrityAuditService {
         candidates.pendingVerificationEvents,
         liveUsers,
         serverConfig.restricted_role_id,
+        restrictedMemberIds,
+        !this.includesRestrictedChecks(scope),
         findings
       );
       this.auditResolvedCases(candidates.recentResolvedVerificationEvents, liveUsers, findings);
@@ -191,6 +194,8 @@ export class IntegrityAuditService implements IIntegrityAuditService {
     cases: IntegrityAuditVerificationEvent[],
     liveUsers: Map<string, LiveUserState>,
     restrictedRoleId: string | null,
+    restrictedMemberIds: ReadonlySet<string>,
+    includeRestrictedRoleFindings: boolean,
     findings: IntegrityAuditFinding[]
   ): Promise<void> {
     for (const verificationEvent of cases) {
@@ -219,7 +224,9 @@ export class IntegrityAuditService implements IIntegrityAuditService {
       }
 
       if (
+        includeRestrictedRoleFindings &&
         restrictedRoleId &&
+        restrictedMemberIds.has(verificationEvent.user_id) &&
         liveUser?.member.status === 'found' &&
         !liveUser.member.value.roles.cache.has(restrictedRoleId)
       ) {
@@ -546,6 +553,16 @@ export class IntegrityAuditService implements IIntegrityAuditService {
       }
       for (const snapshot of candidates.activeRoleQuarantineSnapshots) {
         userIds.add(snapshot.user_id);
+      }
+    }
+    return userIds;
+  }
+
+  private collectRestrictedMemberIds(members: ServerMember[]): Set<string> {
+    const userIds = new Set<string>();
+    for (const member of members) {
+      if (member.is_restricted && this.shouldAuditRestrictedMember(member)) {
+        userIds.add(member.user_id);
       }
     }
     return userIds;

--- a/src/services/IntegrityAuditService.ts
+++ b/src/services/IntegrityAuditService.ts
@@ -1,0 +1,696 @@
+import { Client, Guild, GuildBan, GuildMember } from 'discord.js';
+import { inject, injectable } from 'inversify';
+import { IConfigService } from '../config/ConfigService';
+import { TYPES } from '../di/symbols';
+import {
+  IIntegrityAuditRepository,
+  IntegrityAuditCandidates,
+  IntegrityAuditModerationQueueItem,
+  IntegrityAuditVerificationEvent,
+} from '../repositories/IntegrityAuditRepository';
+import {
+  ModerationQueueItemType,
+  RoleQuarantineSnapshot,
+  ServerMember,
+  VerificationStatus,
+} from '../repositories/types';
+import {
+  DISCORD_UNKNOWN_BAN_ERROR_CODE,
+  DISCORD_UNKNOWN_CHANNEL_ERROR_CODE,
+  DISCORD_UNKNOWN_MEMBER_ERROR_CODE,
+  DISCORD_UNKNOWN_MESSAGE_ERROR_CODE,
+  formatDiscordFetchError,
+  isDiscordErrorCode,
+} from '../utils/discordErrors';
+import {
+  clampIntegrityAuditDays,
+  clampIntegrityAuditLimit,
+  IntegrityAuditScope,
+  normalizeIntegrityAuditScope,
+} from '../utils/integrityAuditSettings';
+import { getModerationQueueSettings } from '../utils/moderationQueueSettings';
+import {
+  getResolutionAdminActionType,
+  getResolutionModerationOutcomeType,
+  isResolvedVerificationStatus,
+} from '../utils/verificationResolution';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const ERROR_DETAIL_MAX_LENGTH = 180;
+
+export type IntegrityAuditFindingSeverity = 'error' | 'warning' | 'info';
+
+export interface IntegrityAuditOptions {
+  readonly scope?: string | null;
+  readonly days?: number | null;
+  readonly limit?: number | null;
+  readonly userId?: string;
+}
+
+export interface IntegrityAuditFinding {
+  readonly severity: IntegrityAuditFindingSeverity;
+  readonly code: string;
+  readonly subject: string;
+  readonly detail: string;
+  readonly userId?: string;
+  readonly verificationEventId?: string;
+}
+
+export interface IntegrityAuditReport {
+  readonly guildId: string;
+  readonly checkedAt: Date;
+  readonly scope: IntegrityAuditScope;
+  readonly days: number;
+  readonly limit: number;
+  readonly userId?: string;
+  readonly candidateCounts: {
+    readonly pendingCases: number;
+    readonly recentResolvedCases: number;
+    readonly restrictedMembers: number;
+    readonly activeRoleQuarantines: number;
+    readonly queueItems: number;
+  };
+  readonly findings: IntegrityAuditFinding[];
+}
+
+export interface IIntegrityAuditService {
+  auditGuild(guild: Guild, options?: IntegrityAuditOptions): Promise<IntegrityAuditReport>;
+}
+
+interface FetchFound<T> {
+  readonly status: 'found';
+  readonly value: T;
+}
+
+interface FetchMissing {
+  readonly status: 'missing';
+}
+
+interface FetchFailed {
+  readonly status: 'failed';
+  readonly detail: string;
+}
+
+type FetchResult<T> = FetchFound<T> | FetchMissing | FetchFailed;
+
+interface MessageFetchableChannel {
+  readonly id: string;
+  readonly messages: {
+    fetch(messageId: string): Promise<unknown>;
+  };
+}
+
+interface LiveUserState {
+  readonly userId: string;
+  readonly member: FetchResult<GuildMember>;
+  readonly ban: FetchResult<GuildBan>;
+}
+
+@injectable()
+export class IntegrityAuditService implements IIntegrityAuditService {
+  public constructor(
+    @inject(TYPES.DiscordClient) private readonly client: Client,
+    @inject(TYPES.ConfigService) private readonly configService: IConfigService,
+    @inject(TYPES.IntegrityAuditRepository)
+    private readonly integrityAuditRepository: IIntegrityAuditRepository
+  ) {}
+
+  public async auditGuild(
+    guild: Guild,
+    options: IntegrityAuditOptions = {}
+  ): Promise<IntegrityAuditReport> {
+    const scope = normalizeIntegrityAuditScope(options.scope);
+    const days = clampIntegrityAuditDays(options.days);
+    const limit = clampIntegrityAuditLimit(options.limit);
+    const checkedAt = new Date();
+    const since = new Date(checkedAt.getTime() - days * DAY_MS);
+    const serverConfig = await this.configService.getServerConfig(guild.id);
+    const candidates = await this.integrityAuditRepository.listCandidates({
+      serverId: guild.id,
+      since,
+      limit,
+      userId: options.userId,
+    });
+    const findings: IntegrityAuditFinding[] = [];
+    const liveUsers = await this.inspectLiveUsers(guild, this.collectUserIds(candidates, scope));
+
+    if (this.includesCaseChecks(scope)) {
+      await this.auditPendingCases(
+        candidates.pendingVerificationEvents,
+        liveUsers,
+        serverConfig.restricted_role_id,
+        findings
+      );
+      this.auditResolvedCases(candidates.recentResolvedVerificationEvents, liveUsers, findings);
+    }
+
+    if (this.includesRestrictedChecks(scope)) {
+      this.auditRestrictedMembers(
+        candidates.restrictedMembers,
+        liveUsers,
+        serverConfig.restricted_role_id,
+        findings
+      );
+      this.auditRoleQuarantines(candidates.activeRoleQuarantineSnapshots, liveUsers, findings);
+    }
+
+    if (this.includesQueueChecks(scope)) {
+      await this.auditQueueItems(
+        candidates.moderationQueueItems,
+        getModerationQueueSettings(serverConfig.settings).channelId,
+        findings
+      );
+    }
+
+    return {
+      guildId: guild.id,
+      checkedAt,
+      scope,
+      days,
+      limit,
+      userId: options.userId,
+      candidateCounts: {
+        pendingCases: candidates.pendingVerificationEvents.length,
+        recentResolvedCases: candidates.recentResolvedVerificationEvents.length,
+        restrictedMembers: candidates.restrictedMembers.length,
+        activeRoleQuarantines: candidates.activeRoleQuarantineSnapshots.length,
+        queueItems: candidates.moderationQueueItems.length,
+      },
+      findings,
+    };
+  }
+
+  private async auditPendingCases(
+    cases: IntegrityAuditVerificationEvent[],
+    liveUsers: Map<string, LiveUserState>,
+    restrictedRoleId: string | null,
+    findings: IntegrityAuditFinding[]
+  ): Promise<void> {
+    for (const verificationEvent of cases) {
+      const liveUser = liveUsers.get(verificationEvent.user_id);
+      this.addLiveUserFetchFindings(verificationEvent.user_id, liveUser, findings);
+
+      if (liveUser?.ban.status === 'found') {
+        findings.push(
+          this.buildCaseFinding(
+            'error',
+            'pending_case_user_banned',
+            verificationEvent,
+            'User is banned in Discord while the verification case is still pending.'
+          )
+        );
+      }
+
+      if (liveUser?.member.status === 'missing') {
+        findings.push(
+          this.buildCaseFinding(
+            'warning',
+            'pending_case_member_missing',
+            verificationEvent,
+            'User is not currently a guild member; no automatic member-left repair was applied.'
+          )
+        );
+      }
+
+      if (
+        restrictedRoleId &&
+        liveUser?.member.status === 'found' &&
+        !liveUser.member.value.roles.cache.has(restrictedRoleId)
+      ) {
+        findings.push(
+          this.buildCaseFinding(
+            'warning',
+            'pending_case_restricted_role_missing',
+            verificationEvent,
+            'Pending case member does not currently have the configured restricted role.'
+          )
+        );
+      }
+
+      await this.auditCaseThread(verificationEvent, findings);
+      await this.auditNotificationMessage(verificationEvent, findings);
+    }
+  }
+
+  private auditResolvedCases(
+    cases: IntegrityAuditVerificationEvent[],
+    liveUsers: Map<string, LiveUserState>,
+    findings: IntegrityAuditFinding[]
+  ): void {
+    for (const verificationEvent of cases) {
+      if (
+        this.requiresAdminAction(verificationEvent) &&
+        !this.hasExpectedAdminAction(verificationEvent)
+      ) {
+        findings.push(
+          this.buildCaseFinding(
+            'error',
+            'resolved_case_missing_admin_action',
+            verificationEvent,
+            'Resolved case has no matching durable admin action row.'
+          )
+        );
+      }
+
+      if (
+        this.requiresModerationOutcome(verificationEvent) &&
+        !this.hasExpectedOutcome(verificationEvent)
+      ) {
+        findings.push(
+          this.buildCaseFinding(
+            'error',
+            'resolved_case_missing_moderation_outcome',
+            verificationEvent,
+            'Resolved case has no matching durable moderation outcome row.'
+          )
+        );
+      }
+
+      const liveUser = liveUsers.get(verificationEvent.user_id);
+      this.addLiveUserFetchFindings(verificationEvent.user_id, liveUser, findings);
+
+      if (
+        verificationEvent.status === VerificationStatus.BANNED &&
+        liveUser?.ban.status === 'missing'
+      ) {
+        findings.push(
+          this.buildCaseFinding(
+            'warning',
+            'banned_case_not_in_ban_list',
+            verificationEvent,
+            'Case is recorded as banned, but the user is not currently in the Discord ban list.'
+          )
+        );
+      }
+    }
+  }
+
+  private auditRestrictedMembers(
+    members: ServerMember[],
+    liveUsers: Map<string, LiveUserState>,
+    restrictedRoleId: string | null,
+    findings: IntegrityAuditFinding[]
+  ): void {
+    for (const member of members) {
+      const liveUser = liveUsers.get(member.user_id);
+      this.addLiveUserFetchFindings(member.user_id, liveUser, findings);
+
+      if (liveUser?.member.status === 'missing') {
+        findings.push({
+          severity: 'warning',
+          code: 'restricted_member_missing',
+          subject: `member ${member.user_id}`,
+          detail:
+            'Database marks this member restricted, but Discord does not show guild membership.',
+          userId: member.user_id,
+        });
+      }
+
+      if (
+        restrictedRoleId &&
+        liveUser?.member.status === 'found' &&
+        !liveUser.member.value.roles.cache.has(restrictedRoleId)
+      ) {
+        findings.push({
+          severity: 'warning',
+          code: 'restricted_member_role_missing',
+          subject: `member ${member.user_id}`,
+          detail:
+            'Database marks this member restricted, but the configured restricted role is absent.',
+          userId: member.user_id,
+        });
+      }
+
+      if (member.verification_status !== VerificationStatus.PENDING) {
+        findings.push({
+          severity: 'warning',
+          code: 'restricted_member_resolved_status',
+          subject: `member ${member.user_id}`,
+          detail: `Database marks this member restricted while verification_status is ${member.verification_status ?? 'unset'}.`,
+          userId: member.user_id,
+        });
+      }
+    }
+  }
+
+  private auditRoleQuarantines(
+    snapshots: RoleQuarantineSnapshot[],
+    liveUsers: Map<string, LiveUserState>,
+    findings: IntegrityAuditFinding[]
+  ): void {
+    for (const snapshot of snapshots) {
+      const liveUser = liveUsers.get(snapshot.user_id);
+      this.addLiveUserFetchFindings(snapshot.user_id, liveUser, findings);
+
+      if (liveUser?.member.status === 'missing') {
+        findings.push({
+          severity: 'warning',
+          code: 'active_role_quarantine_member_missing',
+          subject: `role quarantine ${snapshot.id}`,
+          detail:
+            'Active role-quarantine snapshot belongs to a user who is not currently a guild member.',
+          userId: snapshot.user_id,
+          verificationEventId: snapshot.verification_event_id ?? undefined,
+        });
+      }
+    }
+  }
+
+  private async auditQueueItems(
+    items: IntegrityAuditModerationQueueItem[],
+    configuredQueueChannelId: string | null,
+    findings: IntegrityAuditFinding[]
+  ): Promise<void> {
+    for (const item of items) {
+      if (configuredQueueChannelId && item.queue_channel_id !== configuredQueueChannelId) {
+        findings.push({
+          severity: 'warning',
+          code: 'queue_item_wrong_channel',
+          subject: `queue item ${item.id}`,
+          detail:
+            'Queue item points at a channel other than the configured moderation queue channel.',
+          userId: item.user_id,
+          verificationEventId: item.verification_event_id ?? undefined,
+        });
+      }
+
+      if (
+        item.item_type === ModerationQueueItemType.CASE_MIRROR &&
+        item.verification_event_status !== VerificationStatus.PENDING
+      ) {
+        findings.push({
+          severity: 'warning',
+          code: 'queue_case_mirror_not_pending',
+          subject: `queue item ${item.id}`,
+          detail: `Case mirror references a ${item.verification_event_status ?? 'missing'} verification event.`,
+          userId: item.user_id,
+          verificationEventId: item.verification_event_id ?? undefined,
+        });
+      }
+
+      if (!item.queue_channel_id || !item.queue_message_id) {
+        findings.push({
+          severity: 'warning',
+          code: 'queue_item_missing_message_pointer',
+          subject: `queue item ${item.id}`,
+          detail: 'Queue item does not have both queue_channel_id and queue_message_id recorded.',
+          userId: item.user_id,
+          verificationEventId: item.verification_event_id ?? undefined,
+        });
+        continue;
+      }
+
+      const message = await this.fetchMessage(item.queue_channel_id, item.queue_message_id);
+      if (message.status === 'missing') {
+        findings.push({
+          severity: 'warning',
+          code: 'queue_message_missing',
+          subject: `queue item ${item.id}`,
+          detail: 'Stored queue message was not found in Discord.',
+          userId: item.user_id,
+          verificationEventId: item.verification_event_id ?? undefined,
+        });
+      } else if (message.status === 'failed') {
+        findings.push({
+          severity: 'warning',
+          code: 'queue_message_fetch_failed',
+          subject: `queue item ${item.id}`,
+          detail: message.detail,
+          userId: item.user_id,
+          verificationEventId: item.verification_event_id ?? undefined,
+        });
+      }
+    }
+  }
+
+  private async auditCaseThread(
+    verificationEvent: IntegrityAuditVerificationEvent,
+    findings: IntegrityAuditFinding[]
+  ): Promise<void> {
+    if (!verificationEvent.thread_id) {
+      findings.push(
+        this.buildCaseFinding(
+          'warning',
+          'pending_case_thread_missing',
+          verificationEvent,
+          'Pending case does not have a stored user-facing thread ID.'
+        )
+      );
+      return;
+    }
+
+    const thread = await this.fetchChannel(verificationEvent.thread_id);
+    if (thread.status === 'missing') {
+      findings.push(
+        this.buildCaseFinding(
+          'warning',
+          'pending_case_thread_not_found',
+          verificationEvent,
+          'Stored user-facing case thread was not found in Discord.'
+        )
+      );
+    } else if (thread.status === 'failed') {
+      findings.push(
+        this.buildCaseFinding(
+          'warning',
+          'pending_case_thread_fetch_failed',
+          verificationEvent,
+          thread.detail
+        )
+      );
+    }
+  }
+
+  private async auditNotificationMessage(
+    verificationEvent: IntegrityAuditVerificationEvent,
+    findings: IntegrityAuditFinding[]
+  ): Promise<void> {
+    if (!verificationEvent.notification_channel_id || !verificationEvent.notification_message_id) {
+      findings.push(
+        this.buildCaseFinding(
+          'warning',
+          'pending_case_notification_pointer_missing',
+          verificationEvent,
+          'Pending case does not have both notification channel and message IDs recorded.'
+        )
+      );
+      return;
+    }
+
+    const message = await this.fetchMessage(
+      verificationEvent.notification_channel_id,
+      verificationEvent.notification_message_id
+    );
+    if (message.status === 'missing') {
+      findings.push(
+        this.buildCaseFinding(
+          'warning',
+          'pending_case_notification_not_found',
+          verificationEvent,
+          'Stored admin notification message was not found in Discord.'
+        )
+      );
+    } else if (message.status === 'failed') {
+      findings.push(
+        this.buildCaseFinding(
+          'warning',
+          'pending_case_notification_fetch_failed',
+          verificationEvent,
+          message.detail
+        )
+      );
+    }
+  }
+
+  private async inspectLiveUsers(
+    guild: Guild,
+    userIds: Set<string>
+  ): Promise<Map<string, LiveUserState>> {
+    const liveUsers = new Map<string, LiveUserState>();
+    for (const userId of userIds) {
+      liveUsers.set(userId, {
+        userId,
+        member: await this.fetchGuildMember(guild, userId),
+        ban: await this.fetchGuildBan(guild, userId),
+      });
+    }
+    return liveUsers;
+  }
+
+  private collectUserIds(
+    candidates: IntegrityAuditCandidates,
+    scope: IntegrityAuditScope
+  ): Set<string> {
+    const userIds = new Set<string>();
+    if (this.includesCaseChecks(scope)) {
+      for (const verificationEvent of candidates.pendingVerificationEvents) {
+        userIds.add(verificationEvent.user_id);
+      }
+      for (const verificationEvent of candidates.recentResolvedVerificationEvents) {
+        userIds.add(verificationEvent.user_id);
+      }
+    }
+    if (this.includesRestrictedChecks(scope)) {
+      for (const member of candidates.restrictedMembers) {
+        userIds.add(member.user_id);
+      }
+      for (const snapshot of candidates.activeRoleQuarantineSnapshots) {
+        userIds.add(snapshot.user_id);
+      }
+    }
+    return userIds;
+  }
+
+  private async fetchGuildMember(guild: Guild, userId: string): Promise<FetchResult<GuildMember>> {
+    try {
+      return { status: 'found', value: await guild.members.fetch(userId) };
+    } catch (error) {
+      if (isDiscordErrorCode(error, DISCORD_UNKNOWN_MEMBER_ERROR_CODE)) {
+        return { status: 'missing' };
+      }
+      return { status: 'failed', detail: formatDiscordFetchError(error, ERROR_DETAIL_MAX_LENGTH) };
+    }
+  }
+
+  private async fetchGuildBan(guild: Guild, userId: string): Promise<FetchResult<GuildBan>> {
+    try {
+      return { status: 'found', value: await guild.bans.fetch(userId) };
+    } catch (error) {
+      if (isDiscordErrorCode(error, DISCORD_UNKNOWN_BAN_ERROR_CODE)) {
+        return { status: 'missing' };
+      }
+      return { status: 'failed', detail: formatDiscordFetchError(error, ERROR_DETAIL_MAX_LENGTH) };
+    }
+  }
+
+  private async fetchChannel(channelId: string): Promise<FetchResult<unknown>> {
+    try {
+      const channel = await this.client.channels.fetch(channelId);
+      return channel ? { status: 'found', value: channel } : { status: 'missing' };
+    } catch (error) {
+      if (isDiscordErrorCode(error, DISCORD_UNKNOWN_CHANNEL_ERROR_CODE)) {
+        return { status: 'missing' };
+      }
+      return { status: 'failed', detail: formatDiscordFetchError(error, ERROR_DETAIL_MAX_LENGTH) };
+    }
+  }
+
+  private async fetchMessage(channelId: string, messageId: string): Promise<FetchResult<unknown>> {
+    const channel = await this.fetchChannel(channelId);
+    if (channel.status !== 'found') {
+      return channel;
+    }
+    if (!this.hasMessageFetcher(channel.value)) {
+      return {
+        status: 'failed',
+        detail: 'Stored channel cannot fetch messages or is not a message channel.',
+      };
+    }
+
+    try {
+      const message = await channel.value.messages.fetch(messageId);
+      return message ? { status: 'found', value: message } : { status: 'missing' };
+    } catch (error) {
+      if (isDiscordErrorCode(error, DISCORD_UNKNOWN_MESSAGE_ERROR_CODE)) {
+        return { status: 'missing' };
+      }
+      return { status: 'failed', detail: formatDiscordFetchError(error, ERROR_DETAIL_MAX_LENGTH) };
+    }
+  }
+
+  private hasMessageFetcher(channel: unknown): channel is MessageFetchableChannel {
+    if (!channel || typeof channel !== 'object' || !('messages' in channel)) {
+      return false;
+    }
+    const messages = (channel as { messages?: unknown }).messages;
+    return Boolean(
+      messages &&
+      typeof messages === 'object' &&
+      typeof (messages as { fetch?: unknown }).fetch === 'function'
+    );
+  }
+
+  private addLiveUserFetchFindings(
+    userId: string,
+    liveUser: LiveUserState | undefined,
+    findings: IntegrityAuditFinding[]
+  ): void {
+    if (!liveUser) {
+      return;
+    }
+    if (liveUser.member.status === 'failed') {
+      findings.push({
+        severity: 'warning',
+        code: 'member_fetch_failed',
+        subject: `member ${userId}`,
+        detail: liveUser.member.detail,
+        userId,
+      });
+    }
+    if (liveUser.ban.status === 'failed') {
+      findings.push({
+        severity: 'warning',
+        code: 'ban_fetch_failed',
+        subject: `member ${userId}`,
+        detail: liveUser.ban.detail,
+        userId,
+      });
+    }
+  }
+
+  private buildCaseFinding(
+    severity: IntegrityAuditFindingSeverity,
+    code: string,
+    verificationEvent: IntegrityAuditVerificationEvent,
+    detail: string
+  ): IntegrityAuditFinding {
+    return {
+      severity,
+      code,
+      subject: `case ${verificationEvent.id}`,
+      detail,
+      userId: verificationEvent.user_id,
+      verificationEventId: verificationEvent.id,
+    };
+  }
+
+  private requiresAdminAction(verificationEvent: IntegrityAuditVerificationEvent): boolean {
+    return isResolvedVerificationStatus(verificationEvent.status);
+  }
+
+  private requiresModerationOutcome(verificationEvent: IntegrityAuditVerificationEvent): boolean {
+    return isResolvedVerificationStatus(verificationEvent.status);
+  }
+
+  private hasExpectedOutcome(verificationEvent: IntegrityAuditVerificationEvent): boolean {
+    if (!isResolvedVerificationStatus(verificationEvent.status)) {
+      return false;
+    }
+
+    const expectedOutcome = getResolutionModerationOutcomeType(verificationEvent.status);
+    return verificationEvent.moderation_outcomes.some(
+      (outcome) => outcome.outcome_type === expectedOutcome
+    );
+  }
+
+  private hasExpectedAdminAction(verificationEvent: IntegrityAuditVerificationEvent): boolean {
+    if (!isResolvedVerificationStatus(verificationEvent.status)) {
+      return false;
+    }
+
+    const expectedAction = getResolutionAdminActionType(verificationEvent.status);
+    return verificationEvent.admin_actions.some((action) => action.action_type === expectedAction);
+  }
+
+  private includesCaseChecks(scope: IntegrityAuditScope): boolean {
+    return scope === 'all' || scope === 'cases';
+  }
+
+  private includesRestrictedChecks(scope: IntegrityAuditScope): boolean {
+    return scope === 'all' || scope === 'restricted';
+  }
+
+  private includesQueueChecks(scope: IntegrityAuditScope): boolean {
+    return scope === 'all' || scope === 'queue';
+  }
+}

--- a/src/services/IntegrityAuditService.ts
+++ b/src/services/IntegrityAuditService.ts
@@ -139,6 +139,7 @@ export class IntegrityAuditService implements IIntegrityAuditService {
     });
     const findings: IntegrityAuditFinding[] = [];
     const liveUsers = await this.inspectLiveUsers(guild, this.collectUserIds(candidates, scope));
+    this.addLiveUserFetchFindings(liveUsers, findings);
 
     if (this.includesCaseChecks(scope)) {
       await this.auditPendingCases(
@@ -194,7 +195,6 @@ export class IntegrityAuditService implements IIntegrityAuditService {
   ): Promise<void> {
     for (const verificationEvent of cases) {
       const liveUser = liveUsers.get(verificationEvent.user_id);
-      this.addLiveUserFetchFindings(verificationEvent.user_id, liveUser, findings);
 
       if (liveUser?.ban.status === 'found') {
         findings.push(
@@ -273,7 +273,6 @@ export class IntegrityAuditService implements IIntegrityAuditService {
       }
 
       const liveUser = liveUsers.get(verificationEvent.user_id);
-      this.addLiveUserFetchFindings(verificationEvent.user_id, liveUser, findings);
 
       if (
         verificationEvent.status === VerificationStatus.BANNED &&
@@ -303,7 +302,6 @@ export class IntegrityAuditService implements IIntegrityAuditService {
       }
 
       const liveUser = liveUsers.get(member.user_id);
-      this.addLiveUserFetchFindings(member.user_id, liveUser, findings);
 
       if (liveUser?.member.status === 'missing') {
         findings.push({
@@ -350,7 +348,6 @@ export class IntegrityAuditService implements IIntegrityAuditService {
   ): void {
     for (const snapshot of snapshots) {
       const liveUser = liveUsers.get(snapshot.user_id);
-      this.addLiveUserFetchFindings(snapshot.user_id, liveUser, findings);
 
       if (liveUser?.member.status === 'missing') {
         findings.push({
@@ -624,30 +621,28 @@ export class IntegrityAuditService implements IIntegrityAuditService {
   }
 
   private addLiveUserFetchFindings(
-    userId: string,
-    liveUser: LiveUserState | undefined,
+    liveUsers: Map<string, LiveUserState>,
     findings: IntegrityAuditFinding[]
   ): void {
-    if (!liveUser) {
-      return;
-    }
-    if (liveUser.member.status === 'failed') {
-      findings.push({
-        severity: 'warning',
-        code: 'member_fetch_failed',
-        subject: `member ${userId}`,
-        detail: liveUser.member.detail,
-        userId,
-      });
-    }
-    if (liveUser.ban.status === 'failed') {
-      findings.push({
-        severity: 'warning',
-        code: 'ban_fetch_failed',
-        subject: `member ${userId}`,
-        detail: liveUser.ban.detail,
-        userId,
-      });
+    for (const [userId, liveUser] of liveUsers) {
+      if (liveUser.member.status === 'failed') {
+        findings.push({
+          severity: 'warning',
+          code: 'member_fetch_failed',
+          subject: `member ${userId}`,
+          detail: liveUser.member.detail,
+          userId,
+        });
+      }
+      if (liveUser.ban.status === 'failed') {
+        findings.push({
+          severity: 'warning',
+          code: 'ban_fetch_failed',
+          subject: `member ${userId}`,
+          detail: liveUser.ban.detail,
+          userId,
+        });
+      }
     }
   }
 

--- a/src/services/IntegrityAuditService.ts
+++ b/src/services/IntegrityAuditService.ts
@@ -9,6 +9,7 @@ import {
   IntegrityAuditVerificationEvent,
 } from '../repositories/IntegrityAuditRepository';
 import {
+  ModerationOutcomeSource,
   ModerationQueueItemType,
   RoleQuarantineSnapshot,
   ServerMember,
@@ -37,6 +38,11 @@ import {
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 const ERROR_DETAIL_MAX_LENGTH = 180;
+const ADMIN_ACTION_EXEMPT_RESOLUTION_SOURCES = new Set<unknown>([
+  ModerationOutcomeSource.NATIVE_DISCORD,
+  ModerationOutcomeSource.EXTERNAL_BOT,
+  ModerationOutcomeSource.UNKNOWN_EXTERNAL,
+]);
 
 export type IntegrityAuditFindingSeverity = 'error' | 'warning' | 'info';
 
@@ -292,6 +298,10 @@ export class IntegrityAuditService implements IIntegrityAuditService {
     findings: IntegrityAuditFinding[]
   ): void {
     for (const member of members) {
+      if (!this.shouldAuditRestrictedMember(member)) {
+        continue;
+      }
+
       const liveUser = liveUsers.get(member.user_id);
       this.addLiveUserFetchFindings(member.user_id, liveUser, findings);
 
@@ -532,6 +542,9 @@ export class IntegrityAuditService implements IIntegrityAuditService {
     }
     if (this.includesRestrictedChecks(scope)) {
       for (const member of candidates.restrictedMembers) {
+        if (!this.shouldAuditRestrictedMember(member)) {
+          continue;
+        }
         userIds.add(member.user_id);
       }
       for (const snapshot of candidates.activeRoleQuarantineSnapshots) {
@@ -655,7 +668,10 @@ export class IntegrityAuditService implements IIntegrityAuditService {
   }
 
   private requiresAdminAction(verificationEvent: IntegrityAuditVerificationEvent): boolean {
-    return isResolvedVerificationStatus(verificationEvent.status);
+    return (
+      isResolvedVerificationStatus(verificationEvent.status) &&
+      !this.hasAdminActionExemptResolutionSource(verificationEvent)
+    );
   }
 
   private requiresModerationOutcome(verificationEvent: IntegrityAuditVerificationEvent): boolean {
@@ -680,6 +696,43 @@ export class IntegrityAuditService implements IIntegrityAuditService {
 
     const expectedAction = getResolutionAdminActionType(verificationEvent.status);
     return verificationEvent.admin_actions.some((action) => action.action_type === expectedAction);
+  }
+
+  private hasAdminActionExemptResolutionSource(
+    verificationEvent: IntegrityAuditVerificationEvent
+  ): boolean {
+    if (
+      this.isAdminActionExemptResolutionSource(this.getMetadataResolutionSource(verificationEvent))
+    ) {
+      return true;
+    }
+    if (!isResolvedVerificationStatus(verificationEvent.status)) {
+      return false;
+    }
+
+    const expectedOutcome = getResolutionModerationOutcomeType(verificationEvent.status);
+    return verificationEvent.moderation_outcomes.some(
+      (outcome) =>
+        outcome.outcome_type === expectedOutcome &&
+        this.isAdminActionExemptResolutionSource(outcome.source)
+    );
+  }
+
+  private getMetadataResolutionSource(verificationEvent: IntegrityAuditVerificationEvent): unknown {
+    const metadata = verificationEvent.metadata;
+    if (!metadata || typeof metadata !== 'object' || Array.isArray(metadata)) {
+      return undefined;
+    }
+
+    return (metadata as { moderation_outcome_source?: unknown }).moderation_outcome_source;
+  }
+
+  private isAdminActionExemptResolutionSource(source: unknown): boolean {
+    return ADMIN_ACTION_EXEMPT_RESOLUTION_SOURCES.has(source);
+  }
+
+  private shouldAuditRestrictedMember(member: ServerMember): boolean {
+    return member.verification_status !== VerificationStatus.BANNED;
   }
 
   private includesCaseChecks(scope: IntegrityAuditScope): boolean {

--- a/src/services/UserModerationService.ts
+++ b/src/services/UserModerationService.ts
@@ -31,6 +31,11 @@ import {
   RoleQuarantineRestoreResult,
 } from './RoleQuarantineService';
 import { appendVerificationActionFailure } from '../utils/verificationActionFailures';
+import {
+  getResolutionAdminActionType,
+  getResolutionModerationOutcomeType,
+  ResolvedVerificationStatus,
+} from '../utils/verificationResolution';
 
 /**
  * Interface for the UserModerationService
@@ -658,16 +663,7 @@ export class UserModerationService implements IUserModerationService {
     target: ModerationTarget,
     verificationEvent: VerificationEvent,
     previousStatus: VerificationStatus,
-    newStatus:
-      | VerificationStatus.VERIFIED
-      | VerificationStatus.BANNED
-      | VerificationStatus.KICKED
-      | VerificationStatus.CLOSED_NO_ACTION,
-    actionType:
-      | AdminActionType.VERIFY
-      | AdminActionType.BAN
-      | AdminActionType.KICK
-      | AdminActionType.CLOSE_NO_ACTION,
+    newStatus: ResolvedVerificationStatus,
     moderator: User,
     strictNotification: boolean,
     options: {
@@ -676,6 +672,8 @@ export class UserModerationService implements IUserModerationService {
       metadata?: Record<string, unknown>;
     } = {}
   ): Promise<void> {
+    const actionType = getResolutionAdminActionType(newStatus);
+
     await this.threadManager.resolveVerificationThread(verificationEvent, newStatus, moderator.id);
 
     const logged = await this.notificationManager.logActionToMessage(
@@ -999,7 +997,6 @@ export class UserModerationService implements IUserModerationService {
           resolvedEvent.event,
           resolvedEvent.previousStatus,
           VerificationStatus.VERIFIED,
-          AdminActionType.VERIFY,
           moderator,
           resolvedEvent.event.id === verificationEvent.id,
           {
@@ -1012,7 +1009,7 @@ export class UserModerationService implements IUserModerationService {
 
       await this.tryRecordModerationOutcomes(
         this.getModerationTarget(member),
-        ModerationOutcomeType.VERIFIED,
+        getResolutionModerationOutcomeType(VerificationStatus.VERIFIED),
         ModerationOutcomeSource.DRASIL,
         resolvedEvents.map((resolvedEvent) => resolvedEvent.event),
         {
@@ -1107,7 +1104,6 @@ export class UserModerationService implements IUserModerationService {
             resolvedEvent.event,
             resolvedEvent.previousStatus,
             VerificationStatus.BANNED,
-            AdminActionType.BAN,
             moderator,
             resolvedEvent.event.id === verificationEvent?.id,
             {
@@ -1125,7 +1121,7 @@ export class UserModerationService implements IUserModerationService {
 
       await this.tryRecordModerationOutcomes(
         this.getModerationTarget(member),
-        ModerationOutcomeType.BANNED,
+        getResolutionModerationOutcomeType(VerificationStatus.BANNED),
         ModerationOutcomeSource.DRASIL,
         resolvedEvents.map((resolvedEvent) => resolvedEvent.event),
         {
@@ -1202,7 +1198,6 @@ export class UserModerationService implements IUserModerationService {
             resolvedEvent.event,
             resolvedEvent.previousStatus,
             VerificationStatus.KICKED,
-            AdminActionType.KICK,
             moderator,
             resolvedEvent.event.id === verificationEvent?.id,
             {
@@ -1221,7 +1216,7 @@ export class UserModerationService implements IUserModerationService {
 
       await this.tryRecordModerationOutcomes(
         this.getModerationTarget(member),
-        ModerationOutcomeType.KICKED,
+        getResolutionModerationOutcomeType(VerificationStatus.KICKED),
         ModerationOutcomeSource.DRASIL,
         resolvedEvents.map((resolvedEvent) => resolvedEvent.event),
         {
@@ -1337,7 +1332,6 @@ export class UserModerationService implements IUserModerationService {
             resolvedEvent.event,
             resolvedEvent.previousStatus,
             VerificationStatus.BANNED,
-            AdminActionType.BAN,
             moderator,
             Boolean(resolvedEvent.event.notification_message_id) &&
               resolvedEvent.event.id === resolvedEvents[0]?.event.id,
@@ -1351,7 +1345,7 @@ export class UserModerationService implements IUserModerationService {
 
         await this.tryRecordModerationOutcomes(
           target,
-          ModerationOutcomeType.BANNED,
+          getResolutionModerationOutcomeType(VerificationStatus.BANNED),
           ModerationOutcomeSource.DRASIL,
           resolvedEvents.map((resolvedEvent) => resolvedEvent.event),
           {
@@ -1475,7 +1469,6 @@ export class UserModerationService implements IUserModerationService {
             resolvedEvent.event,
             resolvedEvent.previousStatus,
             VerificationStatus.BANNED,
-            AdminActionType.BAN,
             moderator,
             resolvedEvent.event.id === resolvedEvents[0].event.id,
             {
@@ -1493,7 +1486,7 @@ export class UserModerationService implements IUserModerationService {
 
       await this.tryRecordModerationOutcomes(
         target,
-        ModerationOutcomeType.BANNED,
+        getResolutionModerationOutcomeType(VerificationStatus.BANNED),
         ModerationOutcomeSource.MIGRATION_OR_SYNC,
         resolvedEvents.map((resolvedEvent) => resolvedEvent.event),
         {
@@ -1657,7 +1650,6 @@ export class UserModerationService implements IUserModerationService {
           resolvedEvent.event,
           resolvedEvent.previousStatus,
           VerificationStatus.CLOSED_NO_ACTION,
-          AdminActionType.CLOSE_NO_ACTION,
           moderator,
           Boolean(resolvedEvent.event.notification_message_id) &&
             resolvedEvent.event.id === resolvedEvents[0].event.id,
@@ -1673,7 +1665,7 @@ export class UserModerationService implements IUserModerationService {
 
       await this.tryRecordModerationOutcomes(
         target,
-        ModerationOutcomeType.CLOSED_NO_ACTION,
+        getResolutionModerationOutcomeType(VerificationStatus.CLOSED_NO_ACTION),
         ModerationOutcomeSource.DRASIL,
         resolvedEvents.map((resolvedEvent) => resolvedEvent.event),
         {
@@ -1802,7 +1794,7 @@ export class UserModerationService implements IUserModerationService {
           username: user.username,
           accountCreatedAt: this.getUserAccountCreatedAt(user),
         },
-        ModerationOutcomeType.BANNED,
+        getResolutionModerationOutcomeType(VerificationStatus.BANNED),
         options.source,
         resolvedEvents.map((resolvedEvent) => resolvedEvent.event),
         {
@@ -1906,7 +1898,7 @@ export class UserModerationService implements IUserModerationService {
 
       await this.tryRecordModerationOutcomes(
         this.getModerationTarget(member),
-        ModerationOutcomeType.KICKED,
+        getResolutionModerationOutcomeType(VerificationStatus.KICKED),
         options.source,
         resolvedEvents.map((resolvedEvent) => resolvedEvent.event),
         {
@@ -1945,7 +1937,7 @@ export class UserModerationService implements IUserModerationService {
       (await this.moderationOutcomeService?.findLatestOutcomeByType(
         serverId,
         userId,
-        ModerationOutcomeType.KICKED
+        getResolutionModerationOutcomeType(VerificationStatus.KICKED)
       )) ?? null
     );
   }

--- a/src/utils/discordErrors.ts
+++ b/src/utils/discordErrors.ts
@@ -1,0 +1,27 @@
+export const DISCORD_UNKNOWN_CHANNEL_ERROR_CODE = 10003;
+export const DISCORD_UNKNOWN_MEMBER_ERROR_CODE = 10007;
+export const DISCORD_UNKNOWN_MESSAGE_ERROR_CODE = 10008;
+export const DISCORD_UNKNOWN_BAN_ERROR_CODE = 10026;
+
+export function getDiscordErrorCode(error: unknown): number | string | undefined {
+  return error && typeof error === 'object' && 'code' in error
+    ? (error as { code?: number | string }).code
+    : undefined;
+}
+
+export function isDiscordErrorCode(error: unknown, code: number): boolean {
+  return getDiscordErrorCode(error) === code;
+}
+
+export function isDiscordUnknownBanError(error: unknown): boolean {
+  return isDiscordErrorCode(error, DISCORD_UNKNOWN_BAN_ERROR_CODE);
+}
+
+export function formatDiscordFetchError(error: unknown, maxLength = 180): string {
+  const code = getDiscordErrorCode(error);
+  const message = error instanceof Error ? error.message : String(error);
+  const detail = code
+    ? `Discord fetch failed (${code}): ${message}`
+    : `Discord fetch failed: ${message}`;
+  return detail.length <= maxLength ? detail : `${detail.slice(0, maxLength - 3)}...`;
+}

--- a/src/utils/integrityAuditSettings.ts
+++ b/src/utils/integrityAuditSettings.ts
@@ -1,0 +1,34 @@
+export const INTEGRITY_AUDIT_DEFAULT_DAYS = 30;
+export const INTEGRITY_AUDIT_MIN_DAYS = 1;
+export const INTEGRITY_AUDIT_MAX_DAYS = 365;
+export const INTEGRITY_AUDIT_DEFAULT_LIMIT = 50;
+export const INTEGRITY_AUDIT_MIN_LIMIT = 1;
+export const INTEGRITY_AUDIT_MAX_LIMIT = 250;
+
+export const INTEGRITY_AUDIT_SCOPES = ['all', 'cases', 'restricted', 'queue'] as const;
+
+export type IntegrityAuditScope = (typeof INTEGRITY_AUDIT_SCOPES)[number];
+
+export function normalizeIntegrityAuditScope(
+  value: string | null | undefined
+): IntegrityAuditScope {
+  return INTEGRITY_AUDIT_SCOPES.includes(value as IntegrityAuditScope)
+    ? (value as IntegrityAuditScope)
+    : 'all';
+}
+
+export function clampIntegrityAuditDays(value: number | null | undefined): number {
+  if (typeof value !== 'number' || !Number.isInteger(value)) {
+    return INTEGRITY_AUDIT_DEFAULT_DAYS;
+  }
+
+  return Math.min(Math.max(value, INTEGRITY_AUDIT_MIN_DAYS), INTEGRITY_AUDIT_MAX_DAYS);
+}
+
+export function clampIntegrityAuditLimit(value: number | null | undefined): number {
+  if (typeof value !== 'number' || !Number.isInteger(value)) {
+    return INTEGRITY_AUDIT_DEFAULT_LIMIT;
+  }
+
+  return Math.min(Math.max(value, INTEGRITY_AUDIT_MIN_LIMIT), INTEGRITY_AUDIT_MAX_LIMIT);
+}

--- a/src/utils/verificationResolution.ts
+++ b/src/utils/verificationResolution.ts
@@ -1,0 +1,46 @@
+import { AdminActionType, ModerationOutcomeType, VerificationStatus } from '../repositories/types';
+
+export type ResolvedVerificationStatus =
+  | VerificationStatus.VERIFIED
+  | VerificationStatus.BANNED
+  | VerificationStatus.KICKED
+  | VerificationStatus.CLOSED_NO_ACTION;
+
+export function isResolvedVerificationStatus(
+  status: VerificationStatus
+): status is ResolvedVerificationStatus {
+  return (
+    status === VerificationStatus.VERIFIED ||
+    status === VerificationStatus.BANNED ||
+    status === VerificationStatus.KICKED ||
+    status === VerificationStatus.CLOSED_NO_ACTION
+  );
+}
+
+export function getResolutionAdminActionType(status: ResolvedVerificationStatus): AdminActionType {
+  switch (status) {
+    case VerificationStatus.VERIFIED:
+      return AdminActionType.VERIFY;
+    case VerificationStatus.BANNED:
+      return AdminActionType.BAN;
+    case VerificationStatus.KICKED:
+      return AdminActionType.KICK;
+    case VerificationStatus.CLOSED_NO_ACTION:
+      return AdminActionType.CLOSE_NO_ACTION;
+  }
+}
+
+export function getResolutionModerationOutcomeType(
+  status: ResolvedVerificationStatus
+): ModerationOutcomeType {
+  switch (status) {
+    case VerificationStatus.VERIFIED:
+      return ModerationOutcomeType.VERIFIED;
+    case VerificationStatus.BANNED:
+      return ModerationOutcomeType.BANNED;
+    case VerificationStatus.KICKED:
+      return ModerationOutcomeType.KICKED;
+    case VerificationStatus.CLOSED_NO_ACTION:
+      return ModerationOutcomeType.CLOSED_NO_ACTION;
+  }
+}


### PR DESCRIPTION
[AGENT]

Closes #156.

Adds a read-only `/audit integrity` path for moderators to compare stored moderation state with Discord live state.

Includes:
- bounded candidate read model for pending and resolved cases, restricted members, role quarantine snapshots, and queue items
- Discord member, ban, thread, notification-message, and queue-message checks that report fetch/API failures as findings
- shared resolution and Discord error helpers reused by existing moderation/event code

Notes:
- Report-only; no repair path or scheduler added.
- Missing guild members are findings only.
