### PR TITLE
Add manual intake role trigger and identifier cleanup

### DIFF
--- a/src/__tests__/unit/EventHandler.unit.test.ts
+++ b/src/__tests__/unit/EventHandler.unit.test.ts
@@ -78,6 +78,7 @@ describe('EventHandler (unit)', () => {
         handleSuspiciousJoin: jest.fn(),
         openCaseForSuspiciousMessage: jest.fn(),
         openCaseForSuspiciousJoin: jest.fn(),
+        openAdminCase: jest.fn(),
         recordRejoinAfterKickDetection: jest.fn(),
       }) as any,
       { handleTestCommands: jest.fn(), registerCommands: jest.fn() } as any,
@@ -127,6 +128,26 @@ describe('EventHandler (unit)', () => {
     } as unknown as Message;
   }
 
+  function buildManualIntakeMember(guild: Record<string, unknown>, roleIds: string[]): GuildMember {
+    const roleIdSet = new Set(roleIds);
+    return {
+      id: 'user-1',
+      guild,
+      roles: {
+        cache: {
+          has: jest.fn((roleId: string) => roleIdSet.has(roleId)),
+        },
+        remove: jest.fn().mockResolvedValue(undefined),
+      },
+      user: {
+        id: 'user-1',
+        bot: false,
+        tag: 'test-user#0001',
+        username: 'test-user',
+      },
+    } as unknown as GuildMember;
+  }
+
   it('registers Discord event handlers with current event names', async () => {
     const client = { on: jest.fn(), user: { id: 'bot-1' } };
     const handler = buildHandler({ client });
@@ -136,11 +157,161 @@ describe('EventHandler (unit)', () => {
     expect(client.on).toHaveBeenCalledWith(Events.ClientReady, expect.any(Function));
     expect(client.on).toHaveBeenCalledWith(Events.MessageCreate, expect.any(Function));
     expect(client.on).toHaveBeenCalledWith(Events.GuildMemberAdd, expect.any(Function));
+    expect(client.on).toHaveBeenCalledWith(Events.GuildMemberUpdate, expect.any(Function));
     expect(client.on).toHaveBeenCalledWith(Events.GuildMemberRemove, expect.any(Function));
     expect(client.on).toHaveBeenCalledWith(Events.GuildBanAdd, expect.any(Function));
     expect(client.on).toHaveBeenCalledWith(Events.InteractionCreate, expect.any(Function));
     expect(client.on).toHaveBeenCalledWith(Events.GuildCreate, expect.any(Function));
     expect(client.on).not.toHaveBeenCalledWith('ready', expect.any(Function));
+  });
+
+  it('opens a manual intake case when the configured trigger role remains after the grace period', async () => {
+    jest.useFakeTimers();
+    try {
+      const openAdminCase = jest.fn().mockResolvedValue({
+        opened: true,
+        caseRoleAttempted: true,
+        caseRoleActive: true,
+      });
+      const client = { on: jest.fn(), user: { id: 'bot-1', bot: true } };
+      const role = { id: 'manual-role', name: 'Pending Investigation' };
+      const moderator = { id: 'mod-1', bot: false };
+      const guild = {
+        id: 'guild-1',
+        roles: { cache: new Map([[role.id, role]]), fetch: jest.fn() },
+        members: { fetch: jest.fn() },
+        fetchAuditLogs: jest.fn().mockResolvedValue({
+          entries: [
+            {
+              id: 'audit-1',
+              target: { id: 'user-1' },
+              executor: moderator,
+              createdTimestamp: Date.now(),
+              changes: [{ key: '$add', new: [{ id: role.id, name: role.name }] }],
+            },
+          ],
+        }),
+      };
+      const currentMember = buildManualIntakeMember(guild, [role.id]);
+      (guild.members.fetch as jest.Mock).mockResolvedValue(currentMember);
+      const configService = {
+        initialize: jest.fn().mockResolvedValue(undefined),
+        getCachedServerConfig: jest.fn().mockReturnValue({}),
+        getServerConfig: jest.fn().mockResolvedValue({
+          case_role_id: 'case-role',
+          settings: {
+            manual_intake_enabled: true,
+            manual_intake_role_id: role.id,
+            manual_intake_grace_period_seconds: 0,
+          },
+        }),
+        updateServerConfig: jest.fn().mockResolvedValue({}),
+        updateServerSettings: jest.fn().mockResolvedValue({}),
+      };
+      const handler = buildHandler({
+        client,
+        configService,
+        securityActionService: {
+          handleSuspiciousMessage: jest.fn(),
+          handleSuspiciousJoin: jest.fn(),
+          openCaseForSuspiciousMessage: jest.fn(),
+          openCaseForSuspiciousJoin: jest.fn(),
+          openAdminCase,
+          recordRejoinAfterKickDetection: jest.fn(),
+        },
+      });
+      await handler.setupEventHandlers();
+      const updateHandler = client.on.mock.calls.find(
+        ([event]) => event === Events.GuildMemberUpdate
+      )?.[1];
+
+      await updateHandler?.(
+        buildManualIntakeMember(guild, []),
+        buildManualIntakeMember(guild, [role.id])
+      );
+      await jest.runOnlyPendingTimersAsync();
+
+      expect(openAdminCase).toHaveBeenCalledWith(
+        currentMember,
+        moderator,
+        expect.objectContaining({
+          action: 'open_case',
+          metadata: expect.objectContaining({
+            type: 'manual_role_intake',
+            bulk_intake: false,
+            trigger: 'manual_role_assignment',
+            sourceRoleId: role.id,
+            sourceRoleName: role.name,
+            assignedById: moderator.id,
+          }),
+        })
+      );
+      expect(currentMember.roles.remove).toHaveBeenCalledWith(
+        role.id,
+        'Manual intake trigger role consumed by Drasil'
+      );
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('cancels manual intake when the trigger role is removed during the grace period', async () => {
+    jest.useFakeTimers();
+    try {
+      const openAdminCase = jest.fn();
+      const client = { on: jest.fn(), user: { id: 'bot-1', bot: true } };
+      const role = { id: 'manual-role', name: 'Pending Investigation' };
+      const guild = {
+        id: 'guild-1',
+        roles: { cache: new Map([[role.id, role]]), fetch: jest.fn() },
+        members: { fetch: jest.fn() },
+        fetchAuditLogs: jest.fn(),
+      };
+      const configService = {
+        initialize: jest.fn().mockResolvedValue(undefined),
+        getCachedServerConfig: jest.fn().mockReturnValue({}),
+        getServerConfig: jest.fn().mockResolvedValue({
+          case_role_id: 'case-role',
+          settings: {
+            manual_intake_enabled: true,
+            manual_intake_role_id: role.id,
+            manual_intake_grace_period_seconds: 30,
+          },
+        }),
+        updateServerConfig: jest.fn().mockResolvedValue({}),
+        updateServerSettings: jest.fn().mockResolvedValue({}),
+      };
+      const handler = buildHandler({
+        client,
+        configService,
+        securityActionService: {
+          handleSuspiciousMessage: jest.fn(),
+          handleSuspiciousJoin: jest.fn(),
+          openCaseForSuspiciousMessage: jest.fn(),
+          openCaseForSuspiciousJoin: jest.fn(),
+          openAdminCase,
+          recordRejoinAfterKickDetection: jest.fn(),
+        },
+      });
+      await handler.setupEventHandlers();
+      const updateHandler = client.on.mock.calls.find(
+        ([event]) => event === Events.GuildMemberUpdate
+      )?.[1];
+
+      await updateHandler?.(
+        buildManualIntakeMember(guild, []),
+        buildManualIntakeMember(guild, [role.id])
+      );
+      await updateHandler?.(
+        buildManualIntakeMember(guild, [role.id]),
+        buildManualIntakeMember(guild, [])
+      );
+      await jest.advanceTimersByTimeAsync(30_000);
+
+      expect(openAdminCase).not.toHaveBeenCalled();
+    } finally {
+      jest.useRealTimers();
+    }
   });
 
   it('delegates observed Discord bans with native audit-log source attribution', async () => {

--- a/src/__tests__/unit/NotificationPresentationBuilder.unit.test.ts
+++ b/src/__tests__/unit/NotificationPresentationBuilder.unit.test.ts
@@ -1,4 +1,4 @@
-import { EmbedBuilder, Guild, GuildMember, User } from 'discord.js';
+import { EmbedBuilder, Guild, GuildMember, ThreadChannel, User } from 'discord.js';
 import { NotificationPresentationBuilder } from '../../services/NotificationPresentationBuilder';
 import { DetectionResult } from '../../services/DetectionOrchestrator';
 import {
@@ -13,11 +13,15 @@ import { VERIFICATION_ACTION_FAILURES_METADATA_KEY } from '../../utils/verificat
 const buildMember = (): GuildMember =>
   ({
     id: 'user-1',
+    displayName: 'Server Nick',
+    nickname: 'Server Nick',
     joinedAt: new Date('2026-01-02T00:00:00Z'),
     guild: { id: 'guild-1' } as unknown as Guild,
     user: {
       id: 'user-1',
+      username: 'test-user',
       tag: 'test-user#0001',
+      globalName: 'Global Name',
       createdTimestamp: new Date('2026-01-01T00:00:00Z').getTime(),
       displayAvatarURL: jest.fn().mockReturnValue('https://example.com/avatar.png'),
     } as unknown as User,
@@ -120,6 +124,10 @@ describe('NotificationPresentationBuilder (unit)', () => {
     );
 
     expect(getField(embed, 'Trigger')).toBe('Admin flag: triage');
+    expect(getField(embed, 'User')).toBe(
+      '<@user-1> (Discord username: `test-user`; Display name: `Global Name`; Server nickname: `Server Nick`)'
+    );
+    expect(getField(embed, 'User ID')).toBe('user-1');
     expect(getField(embed, 'Case Threads')).toBe(
       'Verification/review thread: https://discord.com/channels/guild-1/thread-1 status: verified by <@admin-1>\n' +
         'Admin evidence thread: https://discord.com/channels/guild-1/evidence-thread-1'
@@ -419,5 +427,16 @@ describe('NotificationPresentationBuilder (unit)', () => {
       'Observed via admin-opened case: Manual review'
     );
     expect(getField(roleIntakeEmbed, 'Trigger')).toBe('Observed via role intake: new role');
+  });
+
+  it('formats report intake reporter identity with mention and text identifiers', () => {
+    const embed = builder.createReportIntakeStartedEmbed(buildMember(), {
+      id: 'thread-1',
+      url: 'https://discord.com/channels/guild-1/thread-1',
+    } as ThreadChannel);
+
+    expect(getField(embed, 'Reporter')).toBe(
+      '<@user-1> (Discord username: `test-user`; Display name: `Global Name`; Server nickname: `Server Nick`)'
+    );
   });
 });

--- a/src/__tests__/unit/ReportInteractionHandler.unit.test.ts
+++ b/src/__tests__/unit/ReportInteractionHandler.unit.test.ts
@@ -692,7 +692,7 @@ describe('ReportInteractionHandler (unit)', () => {
       submittedById: 'reporter-1',
     });
     expect(interaction.editReply).toHaveBeenCalledWith({
-      content: 'Submitted report for <@user-1> (test-user) (user-1).',
+      content: 'Submitted report for <@user-1> (ID: `user-1`; Discord username: `test-user`).',
     });
   });
 

--- a/src/__tests__/unit/SetupDiagnosticsService.unit.test.ts
+++ b/src/__tests__/unit/SetupDiagnosticsService.unit.test.ts
@@ -225,6 +225,27 @@ describe('SetupDiagnosticsService (unit)', () => {
     expect(report.warningCount).toBeGreaterThanOrEqual(2);
   });
 
+  it('warns when manual intake is configured to use the case role', async () => {
+    const { guild } = buildConfiguredGuild();
+    const configService = {
+      getServerConfig: jest.fn().mockResolvedValue({
+        guild_id: 'guild-1',
+        case_role_id: 'role-1',
+        admin_channel_id: 'admin-channel-1',
+        verification_channel_id: 'verification-channel-1',
+        settings: {
+          manual_intake_enabled: true,
+          manual_intake_role_id: 'role-1',
+        },
+      }),
+    } as any;
+    const service = new SetupDiagnosticsService(configService);
+
+    const report = await service.validateGuildSetup(guild);
+
+    expect(report.issues.map((issue) => issue.code)).toContain('manual-intake-role-is-case-role');
+  });
+
   it('validates setup candidates that create the case role and verification channel', async () => {
     const { guild } = buildConfiguredGuild();
     const configService = {

--- a/src/__tests__/unit/discordUserIdentity.unit.test.ts
+++ b/src/__tests__/unit/discordUserIdentity.unit.test.ts
@@ -1,0 +1,35 @@
+import { formatDiscordUserIdentity, formatInlineIdentifier } from '../../utils/discordUserIdentity';
+
+describe('discordUserIdentity (unit)', () => {
+  it('formats a member with mention, snowflake, and stable text identifiers', () => {
+    expect(
+      formatDiscordUserIdentity({
+        id: '123456789012345678',
+        nickname: 'Server Nick',
+        user: {
+          id: '123456789012345678',
+          username: 'discord.name',
+          globalName: 'Display Name',
+        },
+      })
+    ).toBe(
+      '<@123456789012345678> (ID: `123456789012345678`; Discord username: `discord.name`; Display name: `Display Name`; Server nickname: `Server Nick`)'
+    );
+  });
+
+  it('can omit snowflakes for reporter-style labels', () => {
+    expect(
+      formatDiscordUserIdentity(
+        {
+          id: '123456789012345678',
+          user: { username: 'reporter' },
+        },
+        { includeSnowflake: false }
+      )
+    ).toBe('<@123456789012345678> (Discord username: `reporter`)');
+  });
+
+  it('keeps inline-code formatting intact when names contain backticks', () => {
+    expect(formatInlineIdentifier('name`with`ticks')).toBe("`name'with'ticks`");
+  });
+});

--- a/src/__tests__/unit/manualIntakeSettings.unit.test.ts
+++ b/src/__tests__/unit/manualIntakeSettings.unit.test.ts
@@ -1,0 +1,28 @@
+import {
+  getManualIntakeSettings,
+  MAX_MANUAL_INTAKE_GRACE_PERIOD_SECONDS,
+} from '../../utils/manualIntakeSettings';
+
+describe('manualIntakeSettings (unit)', () => {
+  it('defaults to disabled with a 30 second grace period', () => {
+    expect(getManualIntakeSettings()).toEqual({
+      enabled: false,
+      roleId: null,
+      gracePeriodSeconds: 30,
+    });
+  });
+
+  it('normalizes configured role and clamps the grace period', () => {
+    expect(
+      getManualIntakeSettings({
+        manual_intake_enabled: true,
+        manual_intake_role_id: 'manual-role',
+        manual_intake_grace_period_seconds: 999,
+      })
+    ).toEqual({
+      enabled: true,
+      roleId: 'manual-role',
+      gracePeriodSeconds: MAX_MANUAL_INTAKE_GRACE_PERIOD_SECONDS,
+    });
+  });
+});

--- a/src/controllers/CommandHandler.ts
+++ b/src/controllers/CommandHandler.ts
@@ -410,6 +410,11 @@ export class CommandHandler implements ICommandHandler {
       return;
     }
 
+    if (subcommandGroup === 'manual-intake') {
+      await this.configSubcommandHandler.handleManualIntakeConfigCommand(interaction, guild.id);
+      return;
+    }
+
     if (subcommandGroup === 'report') {
       await this.configSubcommandHandler.handleReportConfigCommand(interaction, guild.id);
       return;

--- a/src/controllers/ConfigSubcommandHandler.ts
+++ b/src/controllers/ConfigSubcommandHandler.ts
@@ -74,6 +74,12 @@ import {
   getModerationQueueSettings,
   MODERATION_QUEUE_CHANNEL_ID_SETTING_KEY,
 } from '../utils/moderationQueueSettings';
+import {
+  getManualIntakeSettings,
+  MANUAL_INTAKE_ENABLED_SETTING_KEY,
+  MANUAL_INTAKE_GRACE_PERIOD_SECONDS_SETTING_KEY,
+  MANUAL_INTAKE_ROLE_ID_SETTING_KEY,
+} from '../utils/manualIntakeSettings';
 import { IModerationQueueService } from '../services/ModerationQueueService';
 import {
   decodeExpectedTopicsInput,
@@ -164,6 +170,19 @@ export class ConfigSubcommandHandler {
 
   private formatReportIntakeSettings(settings: ReturnType<typeof getReportIntakeSettings>): string {
     return [`Confirmed report intake response: \`${settings.confirmedResponseMode}\``].join('\n');
+  }
+
+  private formatManualIntakeSettings(
+    guildId: string,
+    settings: ReturnType<typeof getManualIntakeSettings>
+  ): string {
+    return [
+      `Status: \`${settings.enabled ? 'enabled' : 'disabled'}\``,
+      `Trigger role: ${settings.roleId ? `<@&${settings.roleId}>` : '`none`'}`,
+      `Grace period: \`${settings.gracePeriodSeconds} seconds\``,
+      'Action: `open moderation case and apply case role`',
+      `Guild ID: \`${guildId}\``,
+    ].join('\n');
   }
 
   private formatUserReportSettings(
@@ -480,6 +499,134 @@ export class ConfigSubcommandHandler {
       `Max recommended action: \`${settings.maxAction}\``,
       `Restrict threshold: \`${Math.round(settings.restrictThreshold * 100)}%\``,
     ].join('\n');
+  }
+
+  public async handleManualIntakeConfigCommand(
+    interaction: ChatInputCommandInteraction,
+    guildId: string
+  ): Promise<void> {
+    const subcommand = interaction.options.getSubcommand(true);
+
+    try {
+      switch (subcommand) {
+        case 'view': {
+          const serverConfig = await this.configService.getServerConfig(guildId);
+          const settings = getManualIntakeSettings(serverConfig.settings);
+          await interaction.reply({
+            content:
+              'Current manual intake settings:\n\n' +
+              this.formatManualIntakeSettings(guildId, settings),
+            flags: MessageFlags.Ephemeral,
+            allowedMentions: { parse: [] },
+          });
+          return;
+        }
+
+        case 'set-role': {
+          const role = interaction.options.getRole('role', true);
+          const serverConfig = await this.configService.getServerConfig(guildId);
+          if (role.id === serverConfig.case_role_id) {
+            await interaction.reply({
+              content:
+                'Manual intake needs a separate trigger role. Do not use the configured case role as the intake trigger.',
+              flags: MessageFlags.Ephemeral,
+              allowedMentions: { parse: [] },
+            });
+            return;
+          }
+
+          const updated = await this.configService.updateServerSettings(guildId, {
+            [MANUAL_INTAKE_ROLE_ID_SETTING_KEY]: role.id,
+            [MANUAL_INTAKE_ENABLED_SETTING_KEY]: true,
+          });
+          const settings = getManualIntakeSettings(updated.settings);
+          await interaction.reply({
+            content:
+              `Set manual intake trigger role to <@&${role.id}> and enabled manual intake.\n\n` +
+              this.formatManualIntakeSettings(guildId, settings),
+            flags: MessageFlags.Ephemeral,
+            allowedMentions: { parse: [] },
+          });
+          return;
+        }
+
+        case 'clear-role': {
+          const updated = await this.configService.updateServerSettings(guildId, {
+            [MANUAL_INTAKE_ROLE_ID_SETTING_KEY]: null,
+            [MANUAL_INTAKE_ENABLED_SETTING_KEY]: false,
+          });
+          const settings = getManualIntakeSettings(updated.settings);
+          await interaction.reply({
+            content:
+              'Cleared the manual intake trigger role and disabled manual intake.\n\n' +
+              this.formatManualIntakeSettings(guildId, settings),
+            flags: MessageFlags.Ephemeral,
+            allowedMentions: { parse: [] },
+          });
+          return;
+        }
+
+        case 'enable':
+        case 'disable': {
+          const enabled = subcommand === 'enable';
+          const serverConfig = await this.configService.getServerConfig(guildId);
+          const currentSettings = getManualIntakeSettings(serverConfig.settings);
+          if (enabled && !currentSettings.roleId) {
+            await interaction.reply({
+              content: 'Set a manual intake trigger role before enabling manual intake.',
+              flags: MessageFlags.Ephemeral,
+            });
+            return;
+          }
+
+          const updated = await this.configService.updateServerSettings(guildId, {
+            [MANUAL_INTAKE_ENABLED_SETTING_KEY]: enabled,
+          });
+          const settings = getManualIntakeSettings(updated.settings);
+          await interaction.reply({
+            content:
+              `${enabled ? 'Enabled' : 'Disabled'} manual intake.\n\n` +
+              this.formatManualIntakeSettings(guildId, settings),
+            flags: MessageFlags.Ephemeral,
+            allowedMentions: { parse: [] },
+          });
+          return;
+        }
+
+        case 'set-grace-period': {
+          const seconds = interaction.options.getInteger('seconds', true);
+          const updated = await this.configService.updateServerSettings(guildId, {
+            [MANUAL_INTAKE_GRACE_PERIOD_SECONDS_SETTING_KEY]: seconds,
+          });
+          const settings = getManualIntakeSettings(updated.settings);
+          await interaction.reply({
+            content:
+              'Updated manual intake grace period.\n\n' +
+              this.formatManualIntakeSettings(guildId, settings),
+            flags: MessageFlags.Ephemeral,
+            allowedMentions: { parse: [] },
+          });
+          return;
+        }
+
+        default:
+          await interaction.reply({
+            content: 'Unsupported /config manual-intake subcommand.',
+            flags: MessageFlags.Ephemeral,
+          });
+      }
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+      const errorResponse = {
+        content: `Failed to process manual intake settings: ${errorMessage}`,
+        flags: MessageFlags.Ephemeral,
+      } as const;
+      if (interaction.replied || interaction.deferred) {
+        await interaction.followUp(errorResponse);
+      } else {
+        await interaction.reply(errorResponse);
+      }
+    }
   }
 
   public async handleDetectionConfigCommand(

--- a/src/controllers/EventHandler.ts
+++ b/src/controllers/EventHandler.ts
@@ -10,6 +10,7 @@ import {
   Events,
   MessageFlags,
   PermissionFlagsBits,
+  User,
 } from 'discord.js';
 import * as dotenv from 'dotenv';
 import { injectable, inject, optional } from 'inversify';
@@ -54,6 +55,7 @@ import {
 } from '../services/UserModerationService';
 import { ModerationOutcomeSource } from '../services/ModerationOutcomeService';
 import { IModerationQueueService } from '../services/ModerationQueueService';
+import { getManualIntakeSettings } from '../utils/manualIntakeSettings';
 
 const CHANNEL_CONTEXT_MESSAGE_LIMIT = 5;
 const MESSAGE_CONTEXT_PRUNE_INTERVAL_MS = 60 * 60 * 1000;
@@ -61,7 +63,8 @@ const SETUP_NUDGE_SUPPRESSION_MS = 7 * 24 * 60 * 60 * 1000;
 const SETUP_WARNING_VALIDATION_PRECHECK_MS = 5 * 60 * 1000;
 const SETUP_WARNING_LAST_FINGERPRINT_SETTING_KEY = 'setup_warning_last_fingerprint';
 const DISCORD_UNKNOWN_BAN_ERROR_CODE = 10026;
-const DISCORD_MEMBER_REMOVE_AUDIT_WINDOW_MS = 60 * 1000;
+const DISCORD_RECENT_AUDIT_WINDOW_MS = 60 * 1000;
+const MANUAL_INTAKE_ROLE_REMOVAL_REASON = 'Manual intake trigger role consumed by Drasil';
 
 type SetupNudgeSource = 'audit_log_installer' | 'owner';
 type SetupNudgeResult = 'sent' | 'dm_failed' | 'no_recipient';
@@ -114,6 +117,7 @@ export class EventHandler implements IEventHandler {
   private userModerationService?: IUserModerationService;
   private moderationQueueService?: IModerationQueueService;
   private serverConfigWarmups: Set<string> = new Set();
+  private manualIntakeTimers = new Map<string, ReturnType<typeof setTimeout>>();
   private configInitializePromise: Promise<void> | null = null;
   private lastMessageContextPruneAt = 0;
 
@@ -174,6 +178,7 @@ export class EventHandler implements IEventHandler {
     this.client.on(Events.ClientReady, this.handleReady.bind(this));
     this.client.on(Events.MessageCreate, this.handleMessage.bind(this));
     this.client.on(Events.GuildMemberAdd, this.handleGuildMemberAdd.bind(this));
+    this.client.on(Events.GuildMemberUpdate, this.handleGuildMemberUpdate.bind(this));
     this.client.on(Events.GuildMemberRemove, this.handleGuildMemberRemove.bind(this));
     this.client.on(Events.GuildBanAdd, this.handleGuildBanAdd.bind(this));
     this.client.on(Events.InteractionCreate, this.handleInteraction.bind(this));
@@ -547,6 +552,202 @@ export class EventHandler implements IEventHandler {
     }
   }
 
+  private async handleGuildMemberUpdate(
+    oldMember: GuildMember | PartialGuildMember,
+    newMember: GuildMember
+  ): Promise<void> {
+    try {
+      await this.ensureConfigInitialized();
+      const serverConfig = await this.configService.getServerConfig(newMember.guild.id);
+      const settings = getManualIntakeSettings(serverConfig.settings);
+      if (!settings.enabled || !settings.roleId) {
+        return;
+      }
+      if (settings.roleId === serverConfig.case_role_id) {
+        console.warn(
+          `Manual intake trigger role for guild ${newMember.guild.id} matches the case role; skipping role-triggered intake.`
+        );
+        return;
+      }
+
+      const hadRole = this.memberHasRole(oldMember, settings.roleId);
+      const hasRole = this.memberHasRole(newMember, settings.roleId);
+      if (!hadRole && hasRole) {
+        this.scheduleManualIntake(newMember, settings.roleId, settings.gracePeriodSeconds);
+        return;
+      }
+
+      if (hadRole && !hasRole) {
+        this.cancelManualIntake(newMember.guild.id, newMember.id, settings.roleId);
+      }
+    } catch (error) {
+      console.error(`Error handling member role update for ${newMember.id}:`, error);
+    }
+  }
+
+  private scheduleManualIntake(
+    member: GuildMember,
+    roleId: string,
+    gracePeriodSeconds: number
+  ): void {
+    const key = this.buildManualIntakeKey(member.guild.id, member.id, roleId);
+    if (this.manualIntakeTimers.has(key)) {
+      return;
+    }
+
+    const timer = setTimeout(() => {
+      this.manualIntakeTimers.delete(key);
+      void this.runManualIntake(member, roleId).catch((error) => {
+        console.error(`Failed to process manual intake role ${roleId} for ${member.id}:`, error);
+      });
+    }, gracePeriodSeconds * 1000);
+    (timer as { unref?: () => void }).unref?.();
+    this.manualIntakeTimers.set(key, timer);
+  }
+
+  private cancelManualIntake(guildId: string, userId: string, roleId: string): void {
+    const key = this.buildManualIntakeKey(guildId, userId, roleId);
+    const timer = this.manualIntakeTimers.get(key);
+    if (!timer) {
+      return;
+    }
+
+    clearTimeout(timer);
+    this.manualIntakeTimers.delete(key);
+  }
+
+  private buildManualIntakeKey(guildId: string, userId: string, roleId: string): string {
+    return `${guildId}:${userId}:${roleId}`;
+  }
+
+  private async runManualIntake(originalMember: GuildMember, roleId: string): Promise<void> {
+    const serverConfig = await this.configService.getServerConfig(originalMember.guild.id);
+    const settings = getManualIntakeSettings(serverConfig.settings);
+    if (!settings.enabled || settings.roleId !== roleId) {
+      return;
+    }
+    if (roleId === serverConfig.case_role_id) {
+      console.warn(
+        `Manual intake trigger role for guild ${originalMember.guild.id} matches the case role; skipping role-triggered intake.`
+      );
+      return;
+    }
+
+    const member = await originalMember.guild.members.fetch(originalMember.id).catch(() => null);
+    if (!member || member.user.bot || !this.memberHasRole(member, roleId)) {
+      return;
+    }
+
+    const assignedBy = await this.resolveManualIntakeAssignedBy(member, roleId);
+    const moderator = assignedBy ?? this.client.user;
+    if (!moderator) {
+      console.warn(
+        `Manual intake role ${roleId} assigned to ${member.id}, but no moderator or bot user was available to open a case.`
+      );
+      return;
+    }
+
+    const roleName = await this.resolveManualIntakeRoleName(member, roleId);
+    const result = await this.securityActionService.openAdminCase(member, moderator, {
+      action: 'open_case',
+      reason: `Manual intake role ${roleName} assigned.`,
+      metadata: {
+        type: 'manual_role_intake',
+        bulk_intake: false,
+        trigger: 'manual_role_assignment',
+        sourceRoleId: roleId,
+        sourceRoleName: roleName,
+        assignedById: assignedBy?.id ?? null,
+      },
+    });
+
+    if (result.opened) {
+      await this.removeManualIntakeRole(member, roleId);
+    }
+  }
+
+  private async resolveManualIntakeRoleName(member: GuildMember, roleId: string): Promise<string> {
+    const cachedRole = member.guild.roles.cache.get(roleId);
+    if (cachedRole) {
+      return cachedRole.name;
+    }
+
+    const fetchedRole = await member.guild.roles.fetch(roleId).catch(() => null);
+    return fetchedRole?.name ?? roleId;
+  }
+
+  private async removeManualIntakeRole(member: GuildMember, roleId: string): Promise<void> {
+    if (!this.memberHasRole(member, roleId)) {
+      return;
+    }
+
+    try {
+      await member.roles.remove(roleId, MANUAL_INTAKE_ROLE_REMOVAL_REASON);
+    } catch (error) {
+      console.warn(
+        `Failed to remove manual intake trigger role ${roleId} from ${member.id}:`,
+        error
+      );
+    }
+  }
+
+  private async resolveManualIntakeAssignedBy(
+    member: GuildMember,
+    roleId: string
+  ): Promise<User | null> {
+    if (typeof member.guild.fetchAuditLogs !== 'function') {
+      return null;
+    }
+
+    try {
+      const auditLogs = await member.guild.fetchAuditLogs({
+        type: AuditLogEvent.MemberRoleUpdate,
+        limit: 5,
+      });
+      const roleUpdateEntry = auditLogs.entries.find(
+        (entry) =>
+          entry.target?.id === member.id &&
+          this.isRecentAuditLogEntry(entry) &&
+          this.auditLogEntryAddedRole(entry, roleId)
+      );
+      const executor = roleUpdateEntry?.executor;
+      if (!executor) {
+        return null;
+      }
+
+      const userManager = (this.client as { users?: { fetch(id: string): Promise<User> } }).users;
+      return (await userManager?.fetch(executor.id).catch(() => null)) ?? (executor as User);
+    } catch (error) {
+      console.warn(
+        `Could not read member role update audit log for guild ${member.guild.id}:`,
+        error
+      );
+      return null;
+    }
+  }
+
+  private auditLogEntryAddedRole(entry: { changes?: unknown }, roleId: string): boolean {
+    if (!Array.isArray(entry.changes)) {
+      return true;
+    }
+
+    const addedRoles = entry.changes.find(
+      (change): change is { key: string; new: Array<{ id?: unknown }> } =>
+        typeof change === 'object' &&
+        change !== null &&
+        'key' in change &&
+        change.key === '$add' &&
+        'new' in change &&
+        Array.isArray(change.new)
+    );
+
+    return addedRoles?.new.some((role) => role.id === roleId) ?? false;
+  }
+
+  private memberHasRole(member: GuildMember | PartialGuildMember, roleId: string): boolean {
+    return member.roles.cache.has(roleId);
+  }
+
   private async handleGuildBanAdd(ban: GuildBan): Promise<void> {
     if (!this.userModerationService) {
       return;
@@ -675,7 +876,7 @@ export class EventHandler implements IEventHandler {
         limit: 5,
       });
       const kickEntry = auditLogs.entries.find(
-        (entry) => entry.target?.id === member.id && this.isRecentMemberRemoveAuditEntry(entry)
+        (entry) => entry.target?.id === member.id && this.isRecentAuditLogEntry(entry)
       );
       if (!kickEntry) {
         return null;
@@ -698,12 +899,12 @@ export class EventHandler implements IEventHandler {
     }
   }
 
-  private isRecentMemberRemoveAuditEntry(entry: { createdTimestamp?: unknown }): boolean {
+  private isRecentAuditLogEntry(entry: { createdTimestamp?: unknown }): boolean {
     if (typeof entry.createdTimestamp !== 'number' || !Number.isFinite(entry.createdTimestamp)) {
       return true;
     }
 
-    return Date.now() - entry.createdTimestamp <= DISCORD_MEMBER_REMOVE_AUDIT_WINDOW_MS;
+    return Date.now() - entry.createdTimestamp <= DISCORD_RECENT_AUDIT_WINDOW_MS;
   }
 
   private getAuditLogEntryDate(entry: { createdTimestamp?: unknown }): Date | null {

--- a/src/controllers/ReportInteractionHandler.ts
+++ b/src/controllers/ReportInteractionHandler.ts
@@ -21,6 +21,7 @@ import { NotificationPresentationBuilder } from '../services/NotificationPresent
 import { type MessageReportAttachment } from '../services/SecurityActionService';
 import { ReportSubmissionService } from '../services/ReportSubmissionService';
 import { IThreadManager } from '../services/ThreadManager';
+import { formatDiscordUserIdentity } from '../utils/discordUserIdentity';
 import {
   REPORT_MESSAGE_REASON_FIELD_ID,
   USER_REPORT_MESSAGE_CONTENT_MAX_LENGTH,
@@ -568,14 +569,7 @@ export class ReportInteractionHandler {
   }
 
   private formatReportTargetLabel(member: GuildMember): string {
-    const displayName = this.readOptionalString((member as { displayName?: unknown }).displayName);
-    const username = this.readOptionalString((member.user as { username?: unknown }).username);
-    const label = [displayName, username].find((name) => Boolean(name));
-    return `<@${member.id}> (${label ?? 'unknown user'}) (${member.id})`;
-  }
-
-  private readOptionalString(value: unknown): string | null {
-    return typeof value === 'string' && value.trim().length > 0 ? value.trim() : null;
+    return formatDiscordUserIdentity(member);
   }
 
   private async fetchReportMessage(

--- a/src/controllers/commandDefinitions.ts
+++ b/src/controllers/commandDefinitions.ts
@@ -19,6 +19,10 @@ import {
   MAX_AUTO_KICK_CONFIDENCE_THRESHOLD,
   MIN_AUTO_KICK_CONFIDENCE_THRESHOLD,
 } from '../utils/detectionResponseSettings';
+import {
+  MAX_MANUAL_INTAKE_GRACE_PERIOD_SECONDS,
+  MIN_MANUAL_INTAKE_GRACE_PERIOD_SECONDS,
+} from '../utils/manualIntakeSettings';
 import { MAX_REPORT_AI_MAX_IMAGE_BYTES, MAX_REPORT_AI_MAX_IMAGES } from '../utils/reportAiSettings';
 import { USER_REPORT_REASON_MAX_LENGTH } from '../utils/userReportSettings';
 import { MAX_VERIFICATION_AI_THREAD_ANALYSIS_MESSAGE_LIMIT } from '../utils/verificationThreadAnalysisSettings';
@@ -657,6 +661,47 @@ const baseApplicationCommandBuilders = [
         )
         .addSubcommand((subcommand) =>
           subcommand.setName('clear-channel').setDescription('Disable and clear the live queue')
+        )
+    )
+    .addSubcommandGroup((group) =>
+      group
+        .setName('manual-intake')
+        .setDescription('Manage role-triggered manual case intake')
+        .addSubcommand((subcommand) =>
+          subcommand.setName('view').setDescription('View manual intake role settings')
+        )
+        .addSubcommand((subcommand) =>
+          subcommand
+            .setName('set-role')
+            .setDescription('Set and enable the manual intake trigger role')
+            .addRoleOption((option) =>
+              option
+                .setName('role')
+                .setDescription('Existing non-case role that opens a case when assigned')
+                .setRequired(true)
+            )
+        )
+        .addSubcommand((subcommand) =>
+          subcommand.setName('clear-role').setDescription('Disable and clear the trigger role')
+        )
+        .addSubcommand((subcommand) =>
+          subcommand.setName('enable').setDescription('Enable manual intake role handling')
+        )
+        .addSubcommand((subcommand) =>
+          subcommand.setName('disable').setDescription('Disable manual intake role handling')
+        )
+        .addSubcommand((subcommand) =>
+          subcommand
+            .setName('set-grace-period')
+            .setDescription('Set delay before opening a case after role assignment')
+            .addIntegerOption((option) =>
+              option
+                .setName('seconds')
+                .setDescription('Seconds to wait so accidental assignments can be removed')
+                .setRequired(true)
+                .setMinValue(MIN_MANUAL_INTAKE_GRACE_PERIOD_SECONDS)
+                .setMaxValue(MAX_MANUAL_INTAKE_GRACE_PERIOD_SECONDS)
+            )
         )
     )
     .addSubcommandGroup((group) =>

--- a/src/repositories/types.ts
+++ b/src/repositories/types.ts
@@ -72,6 +72,9 @@ export interface ServerSettings {
   report_intake_agent_debounce_ms?: number;
   report_intake_agent_min_interval_ms?: number;
   report_intake_confirmed_response_mode?: 'observed_alert' | 'open_case' | 'kick';
+  manual_intake_enabled?: boolean;
+  manual_intake_role_id?: string | null;
+  manual_intake_grace_period_seconds?: number;
   report_instructions_channel_id?: string | null;
   report_instructions_message_id?: string | null;
   case_role_lockdown_enabled?: boolean;

--- a/src/services/NotificationPresentationBuilder.ts
+++ b/src/services/NotificationPresentationBuilder.ts
@@ -24,6 +24,7 @@ import {
 } from '../utils/adminActionCustomIds';
 import { getCaseResponderSettings } from '../utils/caseResponderSettings';
 import { isDetectionEventExcludedFromAccounting } from '../utils/detectionEventAccounting';
+import { formatDiscordUserIdentity } from '../utils/discordUserIdentity';
 import { buildAdminCaseDetailUrl, buildAdminCaseQueueUrl } from '../utils/publicWebLinks';
 import { getVerificationActionFailures } from '../utils/verificationActionFailures';
 
@@ -142,7 +143,11 @@ export class NotificationPresentationBuilder {
               },
             ]
           : []),
-        { name: 'Username', value: member.user.tag, inline: true },
+        {
+          name: 'User',
+          value: formatDiscordUserIdentity(member, { includeSnowflake: false }),
+          inline: false,
+        },
         { name: 'User ID', value: member.id, inline: true },
         { name: 'Account Created', value: accountCreatedFormatted, inline: false },
         { name: 'Joined Server', value: joinedServerFormatted, inline: false },
@@ -247,7 +252,11 @@ export class NotificationPresentationBuilder {
       )
       .setThumbnail(member.user.displayAvatarURL())
       .addFields(
-        { name: 'Username', value: member.user.tag, inline: true },
+        {
+          name: 'User',
+          value: formatDiscordUserIdentity(member, { includeSnowflake: false }),
+          inline: false,
+        },
         { name: 'User ID', value: member.id, inline: true },
         {
           name: 'Account Created',
@@ -329,7 +338,11 @@ export class NotificationPresentationBuilder {
         `A private report intake thread was opened by <@${reporter.id}>. No report has been submitted yet.`
       )
       .addFields(
-        { name: 'Reporter', value: `${reporter.user.tag} (${reporter.id})`, inline: false },
+        {
+          name: 'Reporter',
+          value: formatDiscordUserIdentity(reporter, { includeSnowflake: false }),
+          inline: false,
+        },
         {
           name: 'Report Thread',
           value: `[Open thread](${thread.url}) (${thread.id})`,

--- a/src/services/SecurityActionService.ts
+++ b/src/services/SecurityActionService.ts
@@ -1832,19 +1832,31 @@ export class SecurityActionService implements ISecurityActionService {
       );
 
       const normalizedReason = options.reason?.trim() || undefined;
-      const isRoleIntake = options.metadata?.type === 'admin_role_intake';
+      const isManualRoleIntake = options.metadata?.type === 'manual_role_intake';
+      const isRoleIntake = options.metadata?.type === 'admin_role_intake' || isManualRoleIntake;
       const sourceRoleId =
         typeof options.metadata?.sourceRoleId === 'string' ? options.metadata.sourceRoleId : null;
+      const assignedById =
+        typeof options.metadata?.assignedById === 'string' ? options.metadata.assignedById : null;
+      const assignedByText = assignedById ? `<@${assignedById}>` : 'an unknown moderator';
       const reasonSuffix = normalizedReason ? ` Reason: ${normalizedReason}` : '';
       const reasonText = isRoleIntake
-        ? sourceRoleId
-          ? `Role intake from <@&${sourceRoleId}> started by <@${moderator.id}>.${reasonSuffix}`
-          : `Role intake started by <@${moderator.id}>.${reasonSuffix}`
+        ? isManualRoleIntake
+          ? sourceRoleId
+            ? `Manual intake role <@&${sourceRoleId}> assigned by ${assignedByText}.${reasonSuffix}`
+            : `Manual intake role assigned by ${assignedByText}.${reasonSuffix}`
+          : sourceRoleId
+            ? `Role intake from <@&${sourceRoleId}> started by <@${moderator.id}>.${reasonSuffix}`
+            : `Role intake started by <@${moderator.id}>.${reasonSuffix}`
         : `Admin case opened by <@${moderator.id}>.${reasonSuffix}`;
       const triggerContent = isRoleIntake
-        ? sourceRoleId
-          ? `Role intake from <@&${sourceRoleId}> by <@${moderator.id}>${normalizedReason ? `: ${normalizedReason}` : ''}`
-          : `Role intake by <@${moderator.id}>${normalizedReason ? `: ${normalizedReason}` : ''}`
+        ? isManualRoleIntake
+          ? sourceRoleId
+            ? `Manual intake role <@&${sourceRoleId}> assigned by ${assignedByText}${normalizedReason ? `: ${normalizedReason}` : ''}`
+            : `Manual intake role assigned by ${assignedByText}${normalizedReason ? `: ${normalizedReason}` : ''}`
+          : sourceRoleId
+            ? `Role intake from <@&${sourceRoleId}> by <@${moderator.id}>${normalizedReason ? `: ${normalizedReason}` : ''}`
+            : `Role intake by <@${moderator.id}>${normalizedReason ? `: ${normalizedReason}` : ''}`
         : `Opened by <@${moderator.id}>${normalizedReason ? `: ${normalizedReason}` : ''}`;
       const detectionType = isRoleIntake ? DetectionType.ROLE_INTAKE : DetectionType.ADMIN_CASE;
       const detectionEvent = await this.detectionEventsRepository.create({

--- a/src/services/SetupDiagnosticsService.ts
+++ b/src/services/SetupDiagnosticsService.ts
@@ -5,6 +5,7 @@ import { Server } from '../repositories/types';
 import { TYPES } from '../di/symbols';
 import { getDetectionResponseSettings } from '../utils/detectionResponseSettings';
 import { getCaseResponderSettings } from '../utils/caseResponderSettings';
+import { getManualIntakeSettings } from '../utils/manualIntakeSettings';
 
 export type SetupDiagnosticSeverity = 'error' | 'warning';
 
@@ -168,6 +169,7 @@ export class SetupDiagnosticsService implements ISetupDiagnosticsService {
     }
 
     await this.checkCaseResponderRoles(guild, serverConfig, issues);
+    await this.checkManualIntakeRole(guild, serverConfig, issues);
 
     return this.toReport(guild.id, issues);
   }
@@ -345,6 +347,36 @@ export class SetupDiagnosticsService implements ISetupDiagnosticsService {
         severity: 'error',
         code: 'case-role-hierarchy',
         message: `Move the Drasil role above the selected case role <@&${caseRole.id}>.`,
+      });
+    }
+  }
+
+  private async checkManualIntakeRole(
+    guild: Guild,
+    serverConfig: Server,
+    issues: SetupDiagnosticIssue[]
+  ): Promise<void> {
+    const settings = getManualIntakeSettings(serverConfig.settings);
+    if (!settings.enabled || !settings.roleId) {
+      return;
+    }
+
+    if (settings.roleId === serverConfig.case_role_id) {
+      issues.push({
+        severity: 'warning',
+        code: 'manual-intake-role-is-case-role',
+        message:
+          'Manual intake trigger role matches the case role. Use a separate non-case role such as @Pending Investigation.',
+      });
+      return;
+    }
+
+    const role = await guild.roles.fetch(settings.roleId).catch(() => null);
+    if (!role) {
+      issues.push({
+        severity: 'warning',
+        code: 'manual-intake-role-not-found',
+        message: `Manual intake trigger role ${settings.roleId} no longer exists.`,
       });
     }
   }

--- a/src/utils/discordUserIdentity.ts
+++ b/src/utils/discordUserIdentity.ts
@@ -1,0 +1,70 @@
+interface DiscordUserIdentityUser {
+  readonly id?: string;
+  readonly username?: string | null;
+  readonly tag?: string | null;
+  readonly globalName?: string | null;
+}
+
+interface DiscordUserIdentitySource {
+  readonly id: string;
+  readonly displayName?: string | null;
+  readonly nickname?: string | null;
+  readonly user?: DiscordUserIdentityUser;
+  readonly username?: string | null;
+  readonly tag?: string | null;
+  readonly globalName?: string | null;
+}
+
+interface DiscordUserIdentityOptions {
+  readonly includeSnowflake?: boolean;
+  readonly includeServerNames?: boolean;
+}
+
+export function formatDiscordUserMention(userId: string): string {
+  return `<@${userId}>`;
+}
+
+export function formatInlineIdentifier(value: string): string {
+  const normalized = value.trim().replace(/`/g, "'");
+  return `\`${normalized}\``;
+}
+
+export function formatDiscordUserIdentity(
+  source: DiscordUserIdentitySource,
+  options: DiscordUserIdentityOptions = {}
+): string {
+  const user = source.user ?? source;
+  const userId = readOptionalString(user.id) ?? source.id;
+  const includeSnowflake = options.includeSnowflake ?? true;
+  const includeServerNames = options.includeServerNames ?? true;
+  const details: string[] = [];
+
+  if (includeSnowflake) {
+    details.push(`ID: ${formatInlineIdentifier(userId)}`);
+  }
+
+  const username = readOptionalString(user.username) ?? readOptionalString(user.tag);
+  if (username) {
+    details.push(`Discord username: ${formatInlineIdentifier(username)}`);
+  }
+
+  const globalName = readOptionalString(user.globalName);
+  if (globalName && globalName !== username) {
+    details.push(`Display name: ${formatInlineIdentifier(globalName)}`);
+  }
+
+  if (includeServerNames) {
+    const nickname = readOptionalString(source.nickname);
+    if (nickname && nickname !== username && nickname !== globalName) {
+      details.push(`Server nickname: ${formatInlineIdentifier(nickname)}`);
+    }
+  }
+
+  return details.length
+    ? `${formatDiscordUserMention(userId)} (${details.join('; ')})`
+    : formatDiscordUserMention(userId);
+}
+
+function readOptionalString(value: unknown): string | null {
+  return typeof value === 'string' && value.trim().length > 0 ? value.trim() : null;
+}

--- a/src/utils/manualIntakeSettings.ts
+++ b/src/utils/manualIntakeSettings.ts
@@ -1,0 +1,44 @@
+import type { ServerSettings } from '../repositories/types';
+
+export const MANUAL_INTAKE_ENABLED_SETTING_KEY = 'manual_intake_enabled';
+export const MANUAL_INTAKE_ROLE_ID_SETTING_KEY = 'manual_intake_role_id';
+export const MANUAL_INTAKE_GRACE_PERIOD_SECONDS_SETTING_KEY = 'manual_intake_grace_period_seconds';
+
+export const DEFAULT_MANUAL_INTAKE_GRACE_PERIOD_SECONDS = 30;
+export const MIN_MANUAL_INTAKE_GRACE_PERIOD_SECONDS = 0;
+export const MAX_MANUAL_INTAKE_GRACE_PERIOD_SECONDS = 300;
+
+export interface ManualIntakeSettings {
+  readonly enabled: boolean;
+  readonly roleId: string | null;
+  readonly gracePeriodSeconds: number;
+}
+
+export function getManualIntakeSettings(settings: ServerSettings = {}): ManualIntakeSettings {
+  return {
+    enabled: readBoolean(settings[MANUAL_INTAKE_ENABLED_SETTING_KEY], false),
+    roleId: readString(settings[MANUAL_INTAKE_ROLE_ID_SETTING_KEY]),
+    gracePeriodSeconds: readInteger(
+      settings[MANUAL_INTAKE_GRACE_PERIOD_SECONDS_SETTING_KEY],
+      DEFAULT_MANUAL_INTAKE_GRACE_PERIOD_SECONDS,
+      MIN_MANUAL_INTAKE_GRACE_PERIOD_SECONDS,
+      MAX_MANUAL_INTAKE_GRACE_PERIOD_SECONDS
+    ),
+  };
+}
+
+function readBoolean(value: unknown, fallback: boolean): boolean {
+  return typeof value === 'boolean' ? value : fallback;
+}
+
+function readString(value: unknown): string | null {
+  return typeof value === 'string' && value.trim().length > 0 ? value.trim() : null;
+}
+
+function readInteger(value: unknown, fallback: number, minimum: number, maximum: number): number {
+  if (typeof value !== 'number' || !Number.isInteger(value)) {
+    return fallback;
+  }
+
+  return Math.min(Math.max(value, minimum), maximum);
+}


### PR DESCRIPTION
[AGENT]

## Summary
- Add `/config manual-intake` settings for a separate trigger role, enabled state, and grace-period delay.
- Open a moderation case when the configured trigger role remains assigned, then remove the trigger role after successful intake.
- Standardize Discord user identity display so mentions stay clickable and text identifiers are copyable.

Stacked on #153 (`feat/case-role-required`).

## Validation
- `npm run format:check`
- `npm run lint`
- `npm run build`
- `npm test`
- `npm test -- --runTestsByPath src/__tests__/unit/EventHandler.unit.test.ts`
- `git diff --check`
