### PR TITLE
Keep config command under Discord size limit

### DIFF
--- a/src/__tests__/unit/CommandHandler.catalog.unit.test.ts
+++ b/src/__tests__/unit/CommandHandler.catalog.unit.test.ts
@@ -5,6 +5,10 @@ import {
   InteractionContextType,
   PermissionFlagsBits,
 } from 'discord.js';
+import {
+  DISCORD_APPLICATION_COMMAND_TEXT_LIMIT,
+  getApplicationCommandTextSize,
+} from '../../controllers/commandDefinitions';
 import { USER_REPORT_REASON_MAX_LENGTH } from '../../utils/userReportSettings';
 import { buildHandler, restoreUserInstallReportingEnvAfterEach } from './commandHandlerTestHarness';
 
@@ -40,6 +44,18 @@ describe('CommandHandler command catalog (unit)', () => {
       expect(command.integration_types).toEqual([ApplicationIntegrationType.GuildInstall]);
       expect(command.contexts).toEqual([InteractionContextType.Guild]);
     }
+  });
+
+  it('keeps each application command under Discord text size limits', () => {
+    process.env.DRASIL_USER_INSTALL_REPORTING_ENABLED = 'true';
+    const { handler } = buildHandler();
+    const commands = (handler as any).commands as any[];
+
+    const oversizedCommands = commands
+      .map((command) => ({ name: command.name, textSize: getApplicationCommandTextSize(command) }))
+      .filter((command) => command.textSize > DISCORD_APPLICATION_COMMAND_TEXT_LIMIT);
+
+    expect(oversizedCommands).toEqual([]);
   });
 
   it('registers /report without default moderation permissions', () => {

--- a/src/controllers/commandDefinitions.ts
+++ b/src/controllers/commandDefinitions.ts
@@ -1275,10 +1275,13 @@ function compactCommandNodeDescriptions(node: CompactableCommandNode): void {
 }
 
 function humanizeCommandName(name: string): string {
-  const words = name.split('-').join(' ');
-  return `${words.charAt(0).toUpperCase()}${words.slice(1)}`;
+  const words = name.split('-');
+  words[0] = words[0] === 'ai' ? 'AI' : `${words[0].charAt(0).toUpperCase()}${words[0].slice(1)}`;
+  return words.join(' ');
 }
 
+// Conservative by design: this counts every serialized string, including metadata
+// Discord does not measure, and the compacted /config budget keeps headroom for that.
 export function getApplicationCommandTextSize(
   command: RESTPostAPIApplicationCommandsJSONBody
 ): number {

--- a/src/controllers/commandDefinitions.ts
+++ b/src/controllers/commandDefinitions.ts
@@ -40,6 +40,15 @@ export interface BuildApplicationCommandsOptions {
   userInstallReportingEnabled: boolean;
 }
 
+export const DISCORD_APPLICATION_COMMAND_TEXT_LIMIT = 8000;
+const COMPACT_CONFIG_COMMAND_TEXT_BUDGET = 7600;
+
+interface CompactableCommandNode {
+  name?: string;
+  description?: string;
+  options?: CompactableCommandNode[];
+}
+
 const baseApplicationCommandBuilders = [
   new SlashCommandBuilder()
     .setName('ban')
@@ -1231,5 +1240,69 @@ export function buildApplicationCommands({
     ? [...baseApplicationCommandBuilders, buildReportMessageContextCommand()]
     : baseApplicationCommandBuilders;
 
-  return commandBuilders.map((command) => command.toJSON());
+  return commandBuilders.map((command) => compactConfigCommandDescriptions(command.toJSON()));
+}
+
+function compactConfigCommandDescriptions(
+  command: RESTPostAPIApplicationCommandsJSONBody
+): RESTPostAPIApplicationCommandsJSONBody {
+  if (command.name !== 'config') {
+    return command;
+  }
+
+  // Discord caps the total text in one application command at 8000 characters.
+  // /config is dense, so keep its discoverability through names and compact descriptions.
+  compactCommandNodeDescriptions(command);
+
+  const textSize = getApplicationCommandTextSize(command);
+  if (textSize > COMPACT_CONFIG_COMMAND_TEXT_BUDGET) {
+    throw new Error(
+      `/config command text size ${textSize} exceeds budget ${COMPACT_CONFIG_COMMAND_TEXT_BUDGET}`
+    );
+  }
+
+  return command;
+}
+
+function compactCommandNodeDescriptions(node: CompactableCommandNode): void {
+  if (node.name && node.description) {
+    node.description = humanizeCommandName(node.name);
+  }
+
+  for (const option of node.options ?? []) {
+    compactCommandNodeDescriptions(option);
+  }
+}
+
+function humanizeCommandName(name: string): string {
+  const words = name.split('-').join(' ');
+  return `${words.charAt(0).toUpperCase()}${words.slice(1)}`;
+}
+
+export function getApplicationCommandTextSize(
+  command: RESTPostAPIApplicationCommandsJSONBody
+): number {
+  let textSize = 0;
+  const collectTextSize = (value: unknown): void => {
+    if (typeof value === 'string') {
+      textSize += value.length;
+      return;
+    }
+
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        collectTextSize(item);
+      }
+      return;
+    }
+
+    if (value && typeof value === 'object') {
+      for (const item of Object.values(value)) {
+        collectTextSize(item);
+      }
+    }
+  };
+
+  collectTextSize(command);
+  return textSize;
 }


### PR DESCRIPTION
[AGENT]

Fixes production slash-command registration failing with `APPLICATION_COMMAND_TOO_LARGE` on `/config`, which prevented newly added commands like `/audit integrity` from reaching Discord.

The generated `/config` payload now compacts descriptions while keeping command names and handlers unchanged, and unit coverage asserts every application command remains below Discord's per-command text limit.

Operational context: production ECS is running the latest bot image, but startup logs show Discord rejecting the global command bulk PUT before this fix.