### PR TITLE
[AGENT] Add Codex wrappers for agent tooling

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,6 @@
+# Drasil currently has no project-scoped MCP servers to mirror from OpenCode.
+#
+# Keep repo-specific MCP servers here when Drasil adds a committed OpenCode
+# MCP inventory. Generic Codex MCPs such as Playwright, GitHub, Context7, or
+# Node REPL should stay in global/plugin config unless they become
+# Drasil-specific.

--- a/.codex/skills/db-reset-local/SKILL.md
+++ b/.codex/skills/db-reset-local/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: db-reset-local
+description: Reset and seed the local database for Drasil.
+---
+
+# db-reset-local
+
+This is the Codex wrapper for the repo source skill:
+
+- `.opencode/skills/db-reset-local/SKILL.md`
+
+Codex translation notes:
+
+- Read the OpenCode source skill before acting.
+- Use Codex shell/app tools for commands, and follow `AGENTS.md` plus `AGENTS.local.md`
+  when present.
+- Keep this wrapper thin. Put detailed workflow changes in the OpenCode source skill.

--- a/.codex/skills/git-worktrees/SKILL.md
+++ b/.codex/skills/git-worktrees/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: git-worktrees
+description: Create and manage git worktrees for parallel Drasil branches.
+---
+
+# git-worktrees
+
+This is the Codex wrapper for the repo source skill:
+
+- `.opencode/skills/git-worktrees/SKILL.md`
+
+Codex translation notes:
+
+- Read the OpenCode source skill before acting.
+- Use Codex shell/app tools for commands, and follow `AGENTS.md` plus `AGENTS.local.md`
+  when present.
+- Keep this wrapper thin. Put detailed workflow changes in the OpenCode source skill.

--- a/.codex/skills/pr-workflow/SKILL.md
+++ b/.codex/skills/pr-workflow/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: pr-workflow
+description: Land Drasil changes through issue, worktree, pull request, CI, and review loops.
+---
+
+# pr-workflow
+
+This is the Codex wrapper for the repo source skill:
+
+- `.opencode/skills/pr-workflow/SKILL.md`
+
+Codex translation notes:
+
+- Read the OpenCode source skill before acting.
+- Use Codex GitHub tools when available; otherwise use `gh` and repo docs.
+- Keep public GitHub prose scrubbed according to `AGENTS.md` and `AGENTS.local.md` when
+  present.
+- Keep this wrapper thin. Put detailed workflow changes in the OpenCode source skill.

--- a/.codex/skills/prisma-workflow/SKILL.md
+++ b/.codex/skills/prisma-workflow/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: prisma-workflow
+description: Handle Drasil Prisma schema, migration, and repository workflow.
+---
+
+# prisma-workflow
+
+This is the Codex wrapper for the repo source skill:
+
+- `.opencode/skills/prisma-workflow/SKILL.md`
+
+Codex translation notes:
+
+- Read the OpenCode source skill before acting.
+- Use Codex shell/app tools for commands, and follow `AGENTS.md` plus `AGENTS.local.md`
+  when present.
+- Keep this wrapper thin. Put detailed workflow changes in the OpenCode source skill.

--- a/.codex/skills/testing-integration/SKILL.md
+++ b/.codex/skills/testing-integration/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: testing-integration
+description: Run and debug Drasil integration tests against real Postgres via Prisma.
+---
+
+# testing-integration
+
+This is the Codex wrapper for the repo source skill:
+
+- `.opencode/skills/testing-integration/SKILL.md`
+
+Codex translation notes:
+
+- Read the OpenCode source skill before acting.
+- Use Codex shell/app tools for commands, and follow `AGENTS.md` plus `AGENTS.local.md`
+  when present.
+- Keep this wrapper thin. Put detailed workflow changes in the OpenCode source skill.

--- a/.gitignore
+++ b/.gitignore
@@ -65,8 +65,9 @@ coverage/
 supabase/.temp/
 supabase/.env
 
-# OpenCode
+# Local agent tool state
 .opencode/state/
+.playwright-mcp/
 
 # Local intelligence repository data
 data/intel/cases/**

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,8 @@ Persistence uses Postgres (often Supabase) via Prisma. Orchestration is direct (
 - Always-on rules: `AGENTS.md`
 - Local-only (paths/preferences): `AGENTS.local.md` (gitignored)
 - Canonical reference docs: `docs/` (prefer linking over duplicating)
-- Progressive disclosure playbooks: `.opencode/skills/*` (keep short; point to canonical docs)
+- Progressive disclosure playbooks: `.opencode/skills/*` with Codex wrappers in
+  `.codex/skills/*` (keep short; point to canonical docs)
 
 ## Stack
 
@@ -159,6 +160,7 @@ Practical workflow tips:
 - `npm run check` local quality gate (lint:fix, build, tests)
 - `npm run check:full` full gate (format:check, check, integration tests)
 - `npm run check:ci` CI gate (format:check, lint, build, tests, integration tests)
+- `npm run agent:check` verify OpenCode/Codex skill wrapper and MCP doc parity
 
 ## Engineering Guidelines
 
@@ -248,7 +250,12 @@ Jest:
 
 This repo keeps always-on guidance in `AGENTS.md`.
 
-Use Skills for deeper workflows/playbooks. Skills live under `.opencode/skills/<name>/SKILL.md`.
+Use Skills for deeper workflows/playbooks. OpenCode source skills live under
+`.opencode/skills/<name>/SKILL.md`; Codex wrappers live under
+`.codex/skills/<name>/SKILL.md`. Keep the wrappers thin and put detailed changes in the
+OpenCode source skill.
+
+Codex-specific notes: `docs/dev/codex.md`.
 
 Common skills in this repo:
 

--- a/docs/dev/codex.md
+++ b/docs/dev/codex.md
@@ -1,0 +1,59 @@
+# Codex Notes
+
+Drasil has historically kept durable agent playbooks in OpenCode skills. Codex should reuse
+those playbooks through thin wrappers rather than duplicating long workflow text.
+
+## Startup
+
+- Read `AGENTS.md` first, and `AGENTS.local.md` when present.
+- The base checkout may be a protected `main` mirror. Use `docs/dev/worktrees.md` and local
+  guidance before editing.
+- Keep private server, guild, customer, and production-environment names out of public prose.
+
+## Skills
+
+The OpenCode source skills live under `.opencode/skills/<name>/SKILL.md`.
+
+Codex wrappers live under `.codex/skills/<name>/SKILL.md`. Each wrapper keeps Codex-valid
+frontmatter and points back to the OpenCode source skill. If a Codex session does not
+auto-discover repo-local skills, open the wrapper or source skill by path.
+
+Current wrappers:
+
+- `db-reset-local`
+- `git-worktrees`
+- `pr-workflow`
+- `prisma-workflow`
+- `testing-integration`
+
+Keep `.opencode/skills` as the detailed source of truth. Keep `.codex/skills` as thin
+compatibility shims with only `name` and `description` in frontmatter.
+
+## Tool Mapping
+
+- OpenCode-specific wording in source skills should be translated to the available Codex tools in
+  the current session.
+- For GitHub and PR review loops, prefer a GitHub connector when available; otherwise use `gh`
+  and the PR workflow docs.
+- For frontend verification, use the Codex Browser or Playwright MCP when available, plus the
+  repo's web test commands.
+- For library, SDK, CLI, and cloud-service docs, use Codex documentation tools such as Context7
+  when available, or primary-source docs when required.
+- For reminders, monitors, or follow-ups, use Codex automations only when the user asks for that
+  behavior.
+
+## MCPs
+
+No project-scoped OpenCode MCP servers are committed for Drasil today: there is no repo
+`opencode.json` MCP inventory to mirror into Codex.
+
+Codex project MCP config lives at `.codex/config.toml`. Leave it without `[mcp_servers.*]`
+entries until Drasil has an explicit repo-scoped MCP server to launch. Generic Codex MCPs such
+as Playwright, GitHub, Context7, or Node REPL may still be available from global config or
+plugins; verify the active tool surface before relying on one.
+
+PostHog and Phoenix docs in `docs/dev/` describe Drasil runtime integrations, not MCP access.
+Do not add PostHog or Phoenix MCP entries unless a Drasil-specific endpoint and authentication
+path are explicitly chosen.
+
+Run `npm run agent:check` after changing `.opencode`, `.codex`, or this document.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -59,6 +59,22 @@ const configs = [
       'prettier/prettier': 'warn',
     },
   },
+  // Config for ESM Node.js scripts in scripts/ directory
+  {
+    files: ['scripts/**/*.mjs'],
+    languageOptions: {
+      globals: {
+        ...globals.node,
+      },
+      sourceType: 'module',
+    },
+    plugins: {
+      prettier,
+    },
+    rules: {
+      'prettier/prettier': 'warn',
+    },
+  },
   // Base config for all TypeScript files
   {
     files: ['**/*.ts'],

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "contracts:test": "npm --workspace packages/contracts run test",
     "contracts:test:coverage": "npm --workspace packages/contracts run test:coverage",
     "code:metrics": "bash scripts/check-metrics.sh",
+    "agent:check": "node scripts/check-agent-tooling.mjs",
     "format": "prettier --write \"**/*.{ts,js,json,md,mjs}\"",
     "format:check": "prettier --check \"**/*.{ts,js,json,md,mjs}\"",
     "check": "npm run lint:fix && npm run build && npm test",

--- a/scripts/check-agent-tooling.mjs
+++ b/scripts/check-agent-tooling.mjs
@@ -1,0 +1,109 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(scriptDir, '..');
+const errors = [];
+
+const toPath = (relativePath) => path.join(repoRoot, relativePath);
+const exists = (relativePath) => fs.existsSync(toPath(relativePath));
+const read = (relativePath) => fs.readFileSync(toPath(relativePath), 'utf8');
+const assert = (condition, message) => {
+  if (!condition) errors.push(message);
+};
+
+const readIfExists = (relativePath) => (exists(relativePath) ? read(relativePath) : '');
+
+const listDirectories = (relativePath) => {
+  if (!exists(relativePath)) return [];
+
+  return fs
+    .readdirSync(toPath(relativePath), { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name)
+    .sort((left, right) => left.localeCompare(right));
+};
+
+const parseProjectOpenCodeMcpNames = () => {
+  if (!exists('opencode.json')) return [];
+
+  try {
+    const opencode = JSON.parse(read('opencode.json'));
+    return Object.keys(opencode.mcp ?? {}).sort((left, right) => left.localeCompare(right));
+  } catch (error) {
+    errors.push(`opencode.json must be valid JSON: ${error.message}`);
+    return [];
+  }
+};
+
+const parseCodexMcpNames = () => {
+  const config = readIfExists('.codex/config.toml');
+  return [...config.matchAll(/^\[mcp_servers\.([^\]]+)\]/gmu)]
+    .map((match) => match[1])
+    .sort((left, right) => left.localeCompare(right));
+};
+
+assert(exists('AGENTS.md'), 'AGENTS.md must exist.');
+assert(exists('docs/dev/codex.md'), 'docs/dev/codex.md must exist.');
+assert(exists('.opencode/skills'), '.opencode/skills must exist.');
+assert(exists('.codex/skills'), '.codex/skills must exist.');
+
+const agents = readIfExists('AGENTS.md');
+const codexDocs = readIfExists('docs/dev/codex.md');
+const opencodeSkillNames = listDirectories('.opencode/skills');
+const codexSkillNames = listDirectories('.codex/skills');
+
+assert(opencodeSkillNames.length > 0, '.opencode/skills must contain at least one skill.');
+assert(
+  agents.includes('.codex/skills/*'),
+  'AGENTS.md must mention the Codex wrapper skill location.'
+);
+
+for (const skillName of opencodeSkillNames) {
+  const sourcePath = `.opencode/skills/${skillName}/SKILL.md`;
+  const wrapperPath = `.codex/skills/${skillName}/SKILL.md`;
+  const wrapper = readIfExists(wrapperPath);
+
+  assert(exists(sourcePath), `${sourcePath} must exist.`);
+  assert(exists(wrapperPath), `${wrapperPath} must exist.`);
+  assert(codexSkillNames.includes(skillName), `.codex/skills must include ${skillName}.`);
+  assert(wrapper.startsWith('---\n'), `${wrapperPath} must start with frontmatter.`);
+  assert(wrapper.includes(`name: ${skillName}`), `${wrapperPath} must declare name: ${skillName}.`);
+  assert(/^description:\s+\S/mu.test(wrapper), `${wrapperPath} must include a description.`);
+  assert(
+    !/^compatibility:/mu.test(wrapper),
+    `${wrapperPath} must not use OpenCode-only compatibility frontmatter.`
+  );
+  assert(wrapper.includes(sourcePath), `${wrapperPath} must point to ${sourcePath}.`);
+  assert(codexDocs.includes(`- \`${skillName}\``), `docs/dev/codex.md must list ${skillName}.`);
+}
+
+const opencodeMcpNames = parseProjectOpenCodeMcpNames();
+const codexMcpNames = parseCodexMcpNames();
+
+for (const mcpName of opencodeMcpNames) {
+  assert(
+    codexMcpNames.includes(mcpName),
+    `.codex/config.toml must define [mcp_servers.${mcpName}] to mirror opencode.json.`
+  );
+}
+
+for (const mcpName of codexMcpNames) {
+  assert(codexDocs.includes(`- \`${mcpName}\``), `docs/dev/codex.md must list MCP ${mcpName}.`);
+}
+
+if (opencodeMcpNames.length === 0 && codexMcpNames.length === 0) {
+  assert(
+    codexDocs.includes('No project-scoped OpenCode MCP servers are committed'),
+    'docs/dev/codex.md must state that Drasil has no project-scoped OpenCode MCP servers.'
+  );
+}
+
+if (errors.length > 0) {
+  console.error('Agent tooling check failed:');
+  for (const error of errors) console.error(`- ${error}`);
+  process.exit(1);
+}
+
+console.log('Agent tooling check passed.');


### PR DESCRIPTION
[AGENT]

## What / Why

Adds Codex compatibility for the existing OpenCode agent playbooks without duplicating the long source guidance. This gives Codex sessions repo-local skill wrappers, a Codex notes doc, and a parity check so future OpenCode/Codex tooling drift is caught early.

## Linked issues

- None.

## How to test

- `npm run agent:check`
- `git diff --check HEAD~1..HEAD`

## Risk / rollout

Low-risk repo tooling/docs change. No runtime bot behavior, database schema, CI workflow, or deployment path changes.

## AI Review Packet (fresh-context friendly)

- Primary goal: make Drasil's existing `.opencode/skills` usable and discoverable from Codex.
- Non-goals: add project-scoped PostHog/Phoenix MCP access, change runtime observability config, or modify bot behavior.
- Key files changed: `.codex/skills/*/SKILL.md`, `.codex/config.toml`, `docs/dev/codex.md`, `scripts/check-agent-tooling.mjs`, `AGENTS.md`, `.gitignore`, `package.json`.
- Invariants this PR must preserve: OpenCode source skills remain the detailed source of truth; Codex wrappers stay thin; Drasil-specific MCPs are not implied unless a project MCP inventory exists.
- Manual test notes: validated the new parity checker and whitespace check locally.
- Questions for reviewers: none.

## Merge checklist

- [ ] All PR review threads resolved (or explicitly addressed)