### PR TITLE
[AGENT] Add native moderation actions and permission policies

### DIFF
--- a/docs/moderation-permissions.md
+++ b/docs/moderation-permissions.md
@@ -1,0 +1,51 @@
+# Moderation Permission Policy
+
+Discord does not expose a `Manage Members` permission. Drasil uses Discord's
+`ModerateMembers` permission for staff who can open cases, and reserves
+`KickMembers` and `BanMembers` for destructive member actions.
+
+## Staff-facing actions
+
+| Surface                                               | User permission                    | Bot permission or config                                                                        | Notes                                                                                                                                                                      |
+| ----------------------------------------------------- | ---------------------------------- | ----------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Open Case` user context action                       | `ModerateMembers`                  | Case role requires `ManageRoles` and role hierarchy                                             | Opens the reason modal before applying the case role.                                                                                                                      |
+| `Open Case` message context action                    | `ModerateMembers`                  | Case role requires `ManageRoles` and role hierarchy                                             | Preserves the selected message as case source evidence.                                                                                                                    |
+| `/case open`                                          | `ModerateMembers`                  | Case role requires `ManageRoles` and role hierarchy                                             | Uses a confirmation button before opening the case.                                                                                                                        |
+| `/case repair`                                        | `Administrator`                    | Thread and role permissions as needed                                                           | The slash command is visible to `ModerateMembers` because Discord scopes default permissions to the whole `/case` command; runtime checks keep this subcommand admin-only. |
+| `/case refresh`                                       | `Administrator`                    | Admin notification access                                                                       | Runtime admin-only for stored case notification repair.                                                                                                                    |
+| `/case intake-role`                                   | `Administrator`                    | Case role requires `ManageRoles` and role hierarchy                                             | Bulk case opening remains admin-only.                                                                                                                                      |
+| `Ban User` user/message context action                | `BanMembers`                       | `moderator_ban_action_enabled`; bot needs `BanMembers`                                          | Opens a reason modal, then a second confirmation modal before banning.                                                                                                     |
+| `Kick User` user/message context action               | `KickMembers`                      | `moderator_kick_action_enabled`; bot needs `KickMembers`                                        | Opens a reason modal, then a second confirmation modal before kicking.                                                                                                     |
+| Case/observed ban buttons                             | `BanMembers`                       | `moderator_ban_action_enabled`; bot needs `BanMembers`                                          | Uses a ban reason modal.                                                                                                                                                   |
+| Case kick buttons                                     | `KickMembers`                      | `moderator_kick_action_enabled`; bot needs `KickMembers`                                        | Uses a kick reason modal before resolving pending cases as kicked.                                                                                                         |
+| Observed kick buttons                                 | `KickMembers`                      | `observed_action_kick_enabled`; bot needs `KickMembers`                                         | Uses a kick reason modal before actioning the observed alert.                                                                                                              |
+| Case verify, close, repair, reopen, history           | `ManageGuild` or `ModerateMembers` | Varies by action                                                                                | Existing admin-action menu behavior.                                                                                                                                       |
+| Observed open case, dismiss, false positive, history  | `ManageGuild` or `ModerateMembers` | Varies by action                                                                                | Existing observed-alert action behavior.                                                                                                                                   |
+| `/ban`                                                | `BanMembers`                       | `moderator_ban_action_enabled`; bot needs `BanMembers`                                          | Uses a confirmation button before banning.                                                                                                                                 |
+| `/audit`                                              | `ManageGuild`                      | None for read-only checks; repair actions depend on target                                      | Runtime also enforces `ManageGuild`.                                                                                                                                       |
+| `/flaguser`                                           | `Administrator`                    | Case role requires `ManageRoles` and role hierarchy                                             | Legacy manual suspicious-user flow; not broadened in this audit.                                                                                                           |
+| `/config`, `/setupverification`, `/setupreportbutton` | `Administrator`                    | Setup-specific permissions                                                                      | Server configuration stays admin-only.                                                                                                                                     |
+| `/close-report` in report intake threads              | Reporter or staff context          | Report-intake staff can be `ManageGuild`, `ModerateMembers`, or configured case responder roles | Role fallback is intentionally limited to report-intake thread moderation, not case opening.                                                                               |
+
+## Reason policies
+
+These guild settings control whether the reason field is optional or required:
+
+| Setting key                             | Applies to                                                                      |
+| --------------------------------------- | ------------------------------------------------------------------------------- |
+| `admin_case_open_requires_reason`       | `Open Case` context actions, `/case open`, and executed role-intake case opens. |
+| `moderator_ban_action_requires_reason`  | Native ban actions, case/observed ban buttons, and `/ban`.                      |
+| `moderator_kick_action_requires_reason` | Native kick actions and case/observed kick buttons.                             |
+
+`observed_action_ban_requires_reason` is preserved as a legacy alias for the
+shared ban reason policy so existing guild settings keep their behavior.
+
+## Product notes
+
+- Native action command visibility is only a Discord-level hint. Every action
+  still re-checks permissions at execution time.
+- Case responder roles control who is notified or added to case/report review
+  threads. They do not grant case-opening permission.
+- For selected-message case opens, Drasil keeps the latest
+  `source_channel_id`/`source_message_id` fields for existing renderers and also
+  appends unique entries to `source_messages` for later evidence rendering.

--- a/src/__tests__/unit/CommandHandler.case.unit.test.ts
+++ b/src/__tests__/unit/CommandHandler.case.unit.test.ts
@@ -1,6 +1,12 @@
 import { MessageFlags } from 'discord.js';
 import { buildHandler } from './commandHandlerTestHarness';
 import { handleSlashCommandConfirmationButton } from '../../utils/slashCommandConfirmations';
+import { OPEN_CASE_CONTEXT_COMMAND_NAME } from '../../controllers/commandDefinitions';
+import {
+  OPEN_CASE_CONTEXT_REASON_FIELD_ID,
+  buildOpenCaseContextModalCustomId,
+  buildOpenCaseMessageContextModalCustomId,
+} from '../../controllers/CaseCommandHandler';
 
 const confirmLastSlashCommand = async (interaction: any): Promise<any> => {
   const reply = interaction.reply.mock.calls.at(-1)?.[0];
@@ -20,6 +26,118 @@ const confirmLastSlashCommand = async (interaction: any): Promise<any> => {
 };
 
 describe('CommandHandler case commands (unit)', () => {
+  it('shows a reason modal from the Open Case user context command', async () => {
+    const { handler, securityActionService } = buildHandler();
+    const invoker = { id: 'admin-1' } as any;
+    const targetUser = { id: 'user-2', tag: 'target#0001' } as any;
+    const targetMember = { id: targetUser.id } as any;
+    const guild = {
+      id: 'guild-1',
+      members: {
+        fetch: jest.fn().mockResolvedValue(targetMember),
+      },
+    } as any;
+    const interaction = {
+      commandName: OPEN_CASE_CONTEXT_COMMAND_NAME,
+      user: invoker,
+      targetUser,
+      guild,
+      memberPermissions: { has: jest.fn().mockReturnValue(true) },
+      reply: jest.fn().mockResolvedValue(undefined),
+      showModal: jest.fn().mockResolvedValue(undefined),
+    } as any;
+
+    await handler.handleUserContextMenuCommand(interaction);
+
+    expect(guild.members.fetch).toHaveBeenCalledWith(targetUser.id);
+    expect(securityActionService.openAdminCase).not.toHaveBeenCalled();
+    expect(interaction.showModal).toHaveBeenCalledTimes(1);
+
+    const modalJson = interaction.showModal.mock.calls[0][0].toJSON();
+    expect(modalJson.custom_id).toBe(buildOpenCaseContextModalCustomId(targetUser.id));
+    expect(modalJson.title).toBe('Open Case');
+    expect(modalJson.components[0].components[0]).toMatchObject({
+      custom_id: OPEN_CASE_CONTEXT_REASON_FIELD_ID,
+      required: false,
+      max_length: 500,
+    });
+  });
+
+  it('shows a reason modal from the Open Case message context command', async () => {
+    const { handler, securityActionService } = buildHandler();
+    const invoker = { id: 'admin-1' } as any;
+    const targetUser = { id: 'user-2', tag: 'target#0001' } as any;
+    const targetMember = { id: targetUser.id } as any;
+    const targetMessage = {
+      id: 'message-1',
+      channelId: 'channel-1',
+      author: targetUser,
+    } as any;
+    const guild = {
+      id: 'guild-1',
+      members: {
+        fetch: jest.fn().mockResolvedValue(targetMember),
+      },
+    } as any;
+    const interaction = {
+      commandName: OPEN_CASE_CONTEXT_COMMAND_NAME,
+      user: invoker,
+      targetMessage,
+      guild,
+      memberPermissions: { has: jest.fn().mockReturnValue(true) },
+      reply: jest.fn().mockResolvedValue(undefined),
+      showModal: jest.fn().mockResolvedValue(undefined),
+    } as any;
+
+    await handler.handleMessageContextMenuCommand(interaction);
+
+    expect(guild.members.fetch).toHaveBeenCalledWith(targetUser.id);
+    expect(securityActionService.openAdminCase).not.toHaveBeenCalled();
+    expect(interaction.showModal).toHaveBeenCalledTimes(1);
+
+    const modalJson = interaction.showModal.mock.calls[0][0].toJSON();
+    expect(modalJson.custom_id).toBe(
+      buildOpenCaseMessageContextModalCustomId(
+        targetUser.id,
+        targetMessage.channelId,
+        targetMessage.id
+      )
+    );
+    expect(modalJson.title).toBe('Open Case from Message');
+    expect(modalJson.components[0].components[0]).toMatchObject({
+      custom_id: OPEN_CASE_CONTEXT_REASON_FIELD_ID,
+      required: false,
+      max_length: 500,
+    });
+  });
+
+  it('rejects the Open Case user context command without Moderate Members permission', async () => {
+    const { handler, securityActionService } = buildHandler();
+    const interaction = {
+      commandName: OPEN_CASE_CONTEXT_COMMAND_NAME,
+      user: { id: 'member-1' },
+      targetUser: { id: 'user-2', tag: 'target#0001' },
+      guild: {
+        id: 'guild-1',
+        members: {
+          fetch: jest.fn(),
+        },
+      },
+      memberPermissions: { has: jest.fn().mockReturnValue(false) },
+      reply: jest.fn().mockResolvedValue(undefined),
+      showModal: jest.fn().mockResolvedValue(undefined),
+    } as any;
+
+    await handler.handleUserContextMenuCommand(interaction);
+
+    expect(securityActionService.openAdminCase).not.toHaveBeenCalled();
+    expect(interaction.showModal).not.toHaveBeenCalled();
+    expect(interaction.reply).toHaveBeenCalledWith({
+      content: 'You need Moderate Members permission to open a case.',
+      flags: MessageFlags.Ephemeral,
+    });
+  });
+
   it('opens an admin case and applies the case role via /case open', async () => {
     const openAdminCase = jest.fn().mockResolvedValue({
       opened: true,
@@ -75,6 +193,46 @@ describe('CommandHandler case commands (unit)', () => {
     expect(interaction.editReply).toHaveBeenCalledWith({
       content: 'Opened a case for target#0001 and applied the case role.',
       allowedMentions: { parse: [] },
+    });
+  });
+
+  it('rejects /case open without a reason when case reasons are required', async () => {
+    const openAdminCase = jest.fn().mockResolvedValue({
+      opened: true,
+      caseRoleAttempted: true,
+      caseRoleActive: true,
+    });
+    const getServerConfig = jest.fn().mockResolvedValue({
+      settings: { admin_case_open_requires_reason: true },
+    });
+    const { handler, securityActionService } = buildHandler({ openAdminCase, getServerConfig });
+    const targetUser = { id: 'user-2', tag: 'target#0001' } as any;
+    const guild = {
+      id: 'guild-1',
+      members: {
+        fetch: jest.fn(),
+      },
+    } as any;
+    const interaction = {
+      commandName: 'case',
+      user: { id: 'case-mod-1' },
+      guild,
+      memberPermissions: { has: jest.fn().mockReturnValue(true) },
+      options: {
+        getSubcommand: jest.fn().mockReturnValue('open'),
+        getUser: jest.fn().mockReturnValue(targetUser),
+        getString: jest.fn().mockReturnValue(null),
+      },
+      reply: jest.fn().mockResolvedValue(undefined),
+    } as any;
+
+    await handler.handleSlashCommand(interaction);
+
+    expect(securityActionService.openAdminCase).not.toHaveBeenCalled();
+    expect(guild.members.fetch).not.toHaveBeenCalledWith(targetUser.id);
+    expect(interaction.reply).toHaveBeenCalledWith({
+      content: 'A case reason is required.',
+      flags: MessageFlags.Ephemeral,
     });
   });
 
@@ -495,7 +653,7 @@ describe('CommandHandler case commands (unit)', () => {
     });
   });
 
-  it('denies /case commands for non-admin members', async () => {
+  it('denies /case open for members without Moderate Members permission', async () => {
     const openAdminCase = jest.fn().mockResolvedValue({
       opened: true,
       caseRoleAttempted: false,
@@ -524,7 +682,7 @@ describe('CommandHandler case commands (unit)', () => {
 
     expect(securityActionService.openAdminCase).not.toHaveBeenCalled();
     expect(interaction.reply).toHaveBeenCalledWith({
-      content: 'You need administrator permissions to use this command.',
+      content: 'You need Moderate Members permission to open a case.',
       flags: MessageFlags.Ephemeral,
     });
   });

--- a/src/__tests__/unit/CommandHandler.catalog.unit.test.ts
+++ b/src/__tests__/unit/CommandHandler.catalog.unit.test.ts
@@ -363,7 +363,7 @@ describe('CommandHandler command catalog (unit)', () => {
 
     expect(caseCommand).toBeDefined();
     expect(caseCommand.default_member_permissions).toBe(
-      PermissionFlagsBits.Administrator.toString()
+      PermissionFlagsBits.ModerateMembers.toString()
     );
     expect(caseCommand.options.map((option: any) => option.name)).toEqual([
       'open',

--- a/src/__tests__/unit/CommandHandler.catalog.unit.test.ts
+++ b/src/__tests__/unit/CommandHandler.catalog.unit.test.ts
@@ -217,6 +217,53 @@ describe('CommandHandler command catalog (unit)', () => {
     expect(reportUserCommand.contexts).toEqual([InteractionContextType.Guild]);
   });
 
+  it('registers guild-only Open Case user context command for case moderators', () => {
+    const { handler } = buildHandler();
+    const commands = (handler as any).commands as any[];
+    const openCaseCommand = commands.find(
+      (c) => c.name === 'Open Case' && c.type === ApplicationCommandType.User
+    );
+
+    expect(openCaseCommand).toBeDefined();
+    expect(openCaseCommand.type).toBe(ApplicationCommandType.User);
+    expect(openCaseCommand.integration_types).toEqual([ApplicationIntegrationType.GuildInstall]);
+    expect(openCaseCommand.contexts).toEqual([InteractionContextType.Guild]);
+    expect(openCaseCommand.default_member_permissions).toBe(
+      PermissionFlagsBits.ModerateMembers.toString()
+    );
+  });
+
+  it('registers guild-only Open Case message context command for case moderators', () => {
+    const { handler } = buildHandler();
+    const commands = (handler as any).commands as any[];
+    const openCaseCommand = commands.find(
+      (c) => c.name === 'Open Case' && c.type === ApplicationCommandType.Message
+    );
+
+    expect(openCaseCommand).toBeDefined();
+    expect(openCaseCommand.integration_types).toEqual([ApplicationIntegrationType.GuildInstall]);
+    expect(openCaseCommand.contexts).toEqual([InteractionContextType.Guild]);
+    expect(openCaseCommand.default_member_permissions).toBe(
+      PermissionFlagsBits.ModerateMembers.toString()
+    );
+  });
+
+  it.each([
+    ['Ban User', ApplicationCommandType.User, PermissionFlagsBits.BanMembers],
+    ['Ban User', ApplicationCommandType.Message, PermissionFlagsBits.BanMembers],
+    ['Kick User', ApplicationCommandType.User, PermissionFlagsBits.KickMembers],
+    ['Kick User', ApplicationCommandType.Message, PermissionFlagsBits.KickMembers],
+  ])('registers guild-only %s context command', (name, type, permission) => {
+    const { handler } = buildHandler();
+    const commands = (handler as any).commands as any[];
+    const command = commands.find((c) => c.name === name && c.type === type);
+
+    expect(command).toBeDefined();
+    expect(command.integration_types).toEqual([ApplicationIntegrationType.GuildInstall]);
+    expect(command.contexts).toEqual([InteractionContextType.Guild]);
+    expect(command.default_member_permissions).toBe(permission.toString());
+  });
+
   it('does not register Report Message context command unless user-install reporting is enabled', () => {
     delete process.env.DRASIL_USER_INSTALL_REPORTING_ENABLED;
 

--- a/src/__tests__/unit/CommandHandler.config-detection.unit.test.ts
+++ b/src/__tests__/unit/CommandHandler.config-detection.unit.test.ts
@@ -266,6 +266,34 @@ describe('CommandHandler detection config commands (unit)', () => {
 
   it.each([
     [
+      'case-reason-require',
+      'admin_case_open_requires_reason',
+      true,
+      'Case reason required: `yes`',
+      undefined,
+    ],
+    [
+      'case-reason-optional',
+      'admin_case_open_requires_reason',
+      false,
+      'Case reason required: `no`',
+      undefined,
+    ],
+    [
+      'kick-reason-require',
+      'moderator_kick_action_requires_reason',
+      true,
+      'Kick reason required: `yes`',
+      undefined,
+    ],
+    [
+      'kick-reason-optional',
+      'moderator_kick_action_requires_reason',
+      false,
+      'Kick reason required: `no`',
+      undefined,
+    ],
+    [
       'kick-action-enable',
       'moderator_kick_action_enabled',
       true,
@@ -366,6 +394,49 @@ describe('CommandHandler detection config commands (unit)', () => {
 
     expect(configService.updateServerSettings).toHaveBeenCalledWith('guild-1', {
       [key]: value,
+    });
+    expect(interaction.reply).toHaveBeenCalledWith({
+      content: expect.stringContaining(responseText),
+      flags: MessageFlags.Ephemeral,
+      allowedMentions: { parse: [] },
+    });
+  });
+
+  it.each([
+    ['ban-reason-require', true, 'Ban reason required: `yes`'],
+    ['ban-reason-optional', false, 'Ban reason required: `no`'],
+  ])('handles /config detection %s', async (subcommand, value, responseText) => {
+    const updateServerSettings = jest.fn().mockResolvedValue({
+      settings: {
+        moderator_ban_action_requires_reason: value,
+        observed_action_ban_requires_reason: value,
+      },
+    });
+    const { handler, configService } = buildHandler({ updateServerSettings });
+
+    const interaction = {
+      commandName: 'config',
+      user: { id: 'admin-1' },
+      guild: {
+        id: 'guild-1',
+        members: {
+          fetch: jest.fn().mockResolvedValue({
+            permissions: { has: jest.fn().mockReturnValue(true) },
+          }),
+        },
+      },
+      options: {
+        getSubcommandGroup: jest.fn().mockReturnValue('detection'),
+        getSubcommand: jest.fn().mockReturnValue(subcommand),
+      },
+      reply: jest.fn().mockResolvedValue(undefined),
+    } as any;
+
+    await handler.handleSlashCommand(interaction);
+
+    expect(configService.updateServerSettings).toHaveBeenCalledWith('guild-1', {
+      moderator_ban_action_requires_reason: value,
+      observed_action_ban_requires_reason: value,
     });
     expect(interaction.reply).toHaveBeenCalledWith({
       content: expect.stringContaining(responseText),

--- a/src/__tests__/unit/CommandHandler.moderation.unit.test.ts
+++ b/src/__tests__/unit/CommandHandler.moderation.unit.test.ts
@@ -2,6 +2,11 @@ import { MessageFlags, PermissionFlagsBits, User } from 'discord.js';
 import { MODERATOR_BAN_ACTION_ENABLED_SETTING_KEY } from '../../utils/detectionResponseSettings';
 import { handleSlashCommandConfirmationButton } from '../../utils/slashCommandConfirmations';
 import { buildHandler } from './commandHandlerTestHarness';
+import {
+  BAN_USER_CONTEXT_COMMAND_NAME,
+  KICK_USER_CONTEXT_COMMAND_NAME,
+} from '../../controllers/commandDefinitions';
+import { MODERATION_ACTION_REASON_FIELD_ID } from '../../utils/moderationActionCustomIds';
 
 const confirmLastSlashCommand = async (interaction: any): Promise<void> => {
   const reply = interaction.reply.mock.calls.at(-1)?.[0];
@@ -255,6 +260,75 @@ describe('CommandHandler moderation commands (unit)', () => {
     expect(userModerationService.banUser).toHaveBeenCalledWith(targetMember, 'reason', invoker);
     expect(interaction.editReply).toHaveBeenCalledWith({
       content: `User ${targetUser.tag} has been banned.`,
+    });
+  });
+
+  it('shows a native Ban User reason modal for Ban Members moderators', async () => {
+    const { handler } = buildHandler();
+    const targetUser = { id: 'user-2', tag: 'target#0001' } as any;
+    const interaction = {
+      commandName: BAN_USER_CONTEXT_COMMAND_NAME,
+      user: { id: 'ban-mod-1' },
+      targetUser,
+      guild: {
+        id: 'guild-1',
+        members: {
+          me: { permissions: { has: jest.fn().mockReturnValue(true) } },
+        },
+      },
+      memberPermissions: {
+        has: jest.fn((permission: bigint) => permission === PermissionFlagsBits.BanMembers),
+      },
+      reply: jest.fn().mockResolvedValue(undefined),
+      showModal: jest.fn().mockResolvedValue(undefined),
+    } as any;
+
+    await handler.handleUserContextMenuCommand(interaction);
+
+    expect(interaction.showModal).toHaveBeenCalledTimes(1);
+    const modalJson = interaction.showModal.mock.calls[0][0].toJSON();
+    expect(modalJson.custom_id).toBe('moderation_action_reason:ban:user-2');
+    expect(modalJson.components[0].components[0]).toMatchObject({
+      custom_id: MODERATION_ACTION_REASON_FIELD_ID,
+      required: false,
+    });
+  });
+
+  it('shows a native Kick User message reason modal for Kick Members moderators', async () => {
+    const { handler } = buildHandler();
+    const targetUser = { id: 'user-2', tag: 'target#0001' } as any;
+    const targetMember = { id: targetUser.id } as any;
+    const targetMessage = {
+      id: 'message-1',
+      channelId: 'channel-1',
+      author: targetUser,
+    } as any;
+    const interaction = {
+      commandName: KICK_USER_CONTEXT_COMMAND_NAME,
+      user: { id: 'kick-mod-1' },
+      targetMessage,
+      guild: {
+        id: 'guild-1',
+        members: {
+          me: { permissions: { has: jest.fn().mockReturnValue(true) } },
+          fetch: jest.fn().mockResolvedValue(targetMember),
+        },
+      },
+      memberPermissions: {
+        has: jest.fn((permission: bigint) => permission === PermissionFlagsBits.KickMembers),
+      },
+      reply: jest.fn().mockResolvedValue(undefined),
+      showModal: jest.fn().mockResolvedValue(undefined),
+    } as any;
+
+    await handler.handleMessageContextMenuCommand(interaction);
+
+    expect(interaction.showModal).toHaveBeenCalledTimes(1);
+    const modalJson = interaction.showModal.mock.calls[0][0].toJSON();
+    expect(modalJson.custom_id).toBe('moderation_action_reason:kick:user-2:channel-1:message-1');
+    expect(modalJson.components[0].components[0]).toMatchObject({
+      custom_id: MODERATION_ACTION_REASON_FIELD_ID,
+      required: false,
     });
   });
 });

--- a/src/__tests__/unit/InteractionHandler.unit.test.ts
+++ b/src/__tests__/unit/InteractionHandler.unit.test.ts
@@ -6,6 +6,7 @@ import {
   Client,
   Guild,
   GuildMember,
+  Message,
   MessageFlags,
   ModalSubmitInteraction,
   PermissionFlagsBits,
@@ -42,6 +43,11 @@ import {
   buildCaseReviewDigestSelectCustomId,
   CASE_REVIEW_DIGEST_OPEN_CUSTOM_ID,
 } from '../../utils/caseReviewDigestCustomIds';
+import {
+  OPEN_CASE_CONTEXT_REASON_FIELD_ID,
+  buildOpenCaseContextModalCustomId,
+  buildOpenCaseMessageContextModalCustomId,
+} from '../../controllers/CaseCommandHandler';
 
 const buildMember = (guildId: string, userId: string, displayName = 'test-user'): GuildMember =>
   ({
@@ -389,6 +395,168 @@ describe('InteractionHandler (unit)', () => {
       settings: { [OBSERVED_ACTION_KICK_ENABLED_SETTING_KEY]: true },
     });
   };
+
+  it('opens a case from the native Open Case modal reason', async () => {
+    securityActionService.openAdminCase.mockResolvedValueOnce({
+      opened: true,
+      caseRoleAttempted: true,
+      caseRoleActive: true,
+    });
+    const handler = new InteractionHandler(
+      client,
+      notificationManager,
+      userModerationService,
+      securityActionService,
+      configService,
+      verificationEventRepository,
+      threadManager,
+      adminActionRepository
+    );
+    const interaction = {
+      customId: buildOpenCaseContextModalCustomId('user-2'),
+      guildId: 'guild-1',
+      user: { id: 'admin-1' },
+      memberPermissions: { has: jest.fn().mockReturnValue(true) },
+      fields: {
+        getTextInputValue: jest.fn(() => 'manual review'),
+      },
+      deferred: false,
+      replied: false,
+      deferReply: jest.fn().mockImplementation(async () => {
+        interaction.deferred = true;
+      }),
+      editReply: jest.fn().mockResolvedValue(undefined),
+      reply: jest.fn().mockResolvedValue(undefined),
+    } as unknown as ModalSubmitInteraction;
+
+    await handler.handleModalSubmit(interaction);
+
+    expect(interaction.fields.getTextInputValue).toHaveBeenCalledWith(
+      OPEN_CASE_CONTEXT_REASON_FIELD_ID
+    );
+    expect(securityActionService.openAdminCase).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'user-2' }),
+      interaction.user,
+      {
+        action: 'open_case',
+        reason: 'manual review',
+      }
+    );
+    expect(interaction.deferReply).toHaveBeenCalledWith({ flags: MessageFlags.Ephemeral });
+    expect(interaction.editReply).toHaveBeenCalledWith({
+      content: 'Opened a case for test-user#0001 and applied the case role.',
+      allowedMentions: { parse: [] },
+    });
+  });
+
+  it('opens a case from the native Open Case message modal with source metadata', async () => {
+    securityActionService.openAdminCase.mockResolvedValueOnce({
+      opened: true,
+      caseRoleAttempted: true,
+      caseRoleActive: true,
+    });
+    const sourceMessage = {
+      id: 'message-1',
+      channelId: 'channel-1',
+      url: 'https://discord.com/channels/guild-1/channel-1/message-1',
+    } as Message;
+    const sourceFetch = jest.fn().mockResolvedValue(sourceMessage);
+    Object.assign(client, {
+      channels: {
+        fetch: jest.fn().mockResolvedValue({
+          messages: {
+            fetch: sourceFetch,
+          },
+        }),
+      },
+    });
+    const handler = new InteractionHandler(
+      client,
+      notificationManager,
+      userModerationService,
+      securityActionService,
+      configService,
+      verificationEventRepository,
+      threadManager,
+      adminActionRepository
+    );
+    const interaction = {
+      customId: buildOpenCaseMessageContextModalCustomId('user-2', 'channel-1', 'message-1'),
+      guildId: 'guild-1',
+      user: { id: 'admin-1' },
+      memberPermissions: { has: jest.fn().mockReturnValue(true) },
+      fields: {
+        getTextInputValue: jest.fn(() => 'message review'),
+      },
+      deferred: false,
+      replied: false,
+      deferReply: jest.fn().mockImplementation(async () => {
+        interaction.deferred = true;
+      }),
+      editReply: jest.fn().mockResolvedValue(undefined),
+      reply: jest.fn().mockResolvedValue(undefined),
+    } as unknown as ModalSubmitInteraction;
+
+    await handler.handleModalSubmit(interaction);
+
+    expect((client as any).channels.fetch).toHaveBeenCalledWith('channel-1');
+    expect(sourceFetch).toHaveBeenCalledWith('message-1');
+    expect(securityActionService.openAdminCase).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'user-2' }),
+      interaction.user,
+      {
+        action: 'open_case',
+        reason: 'message review',
+        metadata: {
+          source: 'message_context_case',
+          source_channel_id: 'channel-1',
+          source_message_id: 'message-1',
+        },
+        sourceMessage,
+      }
+    );
+    expect(interaction.editReply).toHaveBeenCalledWith({
+      content: 'Opened a case for test-user#0001 and applied the case role.',
+      allowedMentions: { parse: [] },
+    });
+  });
+
+  it('rejects native Open Case modal submits without administrator permission', async () => {
+    const handler = new InteractionHandler(
+      client,
+      notificationManager,
+      userModerationService,
+      securityActionService,
+      configService,
+      verificationEventRepository,
+      threadManager,
+      adminActionRepository
+    );
+    const interaction = {
+      customId: buildOpenCaseContextModalCustomId('user-2'),
+      guildId: 'guild-1',
+      user: { id: 'member-1' },
+      memberPermissions: { has: jest.fn().mockReturnValue(false) },
+      fields: {
+        getTextInputValue: jest.fn(),
+      },
+      deferred: false,
+      replied: false,
+      deferReply: jest.fn().mockResolvedValue(undefined),
+      editReply: jest.fn().mockResolvedValue(undefined),
+      reply: jest.fn().mockResolvedValue(undefined),
+    } as unknown as ModalSubmitInteraction;
+
+    await handler.handleModalSubmit(interaction);
+
+    expect(interaction.fields.getTextInputValue).not.toHaveBeenCalled();
+    expect(securityActionService.openAdminCase).not.toHaveBeenCalled();
+    expect(interaction.deferReply).not.toHaveBeenCalled();
+    expect(interaction.reply).toHaveBeenCalledWith({
+      content: 'You need Moderate Members permission to open a case.',
+      flags: MessageFlags.Ephemeral,
+    });
+  });
 
   it('handles verify button by calling UserModerationService', async () => {
     const handler = new InteractionHandler(
@@ -988,7 +1156,7 @@ describe('InteractionHandler (unit)', () => {
     expect(interaction.showModal).toHaveBeenCalledTimes(1);
     const modal = (interaction.showModal as jest.Mock).mock.calls[0][0] as any;
     expect(modal.toJSON().custom_id).toBe('verification:ban_modal:user-1');
-    expect(JSON.stringify(modal.toJSON())).toContain('Final notes (optional)');
+    expect(JSON.stringify(modal.toJSON())).toContain('Ban reason (optional)');
   });
 
   it('shows sync existing ban to a Ban Members moderator when a pending case user is already banned', async () => {
@@ -1557,7 +1725,7 @@ describe('InteractionHandler (unit)', () => {
     });
   });
 
-  it('handles observed kick button for present members', async () => {
+  it('shows an observed kick reason modal for present members', async () => {
     enableObservedKickActions();
     const handler = new InteractionHandler(
       client,
@@ -1580,20 +1748,13 @@ describe('InteractionHandler (unit)', () => {
 
     await handler.handleButtonInteraction(interaction);
 
-    expect(securityActionService.kickObservedDetection).toHaveBeenCalledWith(
-      expect.objectContaining({ id: 'user-1' }),
-      'det-1',
-      interaction.user,
-      'Kicked from observed suspicious notification'
-    );
-    expect(interaction.followUp).toHaveBeenCalledWith({
-      content: 'Kicked <@user-1> from the observed alert.',
-      allowedMentions: { parse: [] },
-      flags: MessageFlags.Ephemeral,
-    });
+    expect(securityActionService.kickObservedDetection).not.toHaveBeenCalled();
+    expect(interaction.showModal).toHaveBeenCalledTimes(1);
+    const modal = (interaction.showModal as jest.Mock).mock.calls[0][0] as any;
+    expect(modal.toJSON().custom_id).toBe('observed:kick_modal:user-1:det-1');
   });
 
-  it('reports observed kick failures after deferred confirmation', async () => {
+  it('reports observed kick failures after modal submission', async () => {
     enableObservedKickActions();
     securityActionService.kickObservedDetection.mockRejectedValueOnce(
       new Error('Discord rejected')
@@ -1608,25 +1769,30 @@ describe('InteractionHandler (unit)', () => {
       threadManager,
       adminActionRepository
     );
-    const interaction = buildInteraction(
-      'admin_actions:confirm_observed_kick:observed:user-1:det-1',
-      'guild-1',
-      {
-        id: 'admin-1',
-      } as User
-    );
+    const interaction = {
+      customId: 'observed:kick_modal:user-1:det-1',
+      guildId: 'guild-1',
+      user: { id: 'admin-1' } as User,
+      fields: {
+        getTextInputValue: jest.fn(() => 'observed kick reason'),
+      },
+      deferReply: jest.fn().mockResolvedValue(undefined),
+      editReply: jest.fn().mockResolvedValue(undefined),
+      reply: jest.fn().mockResolvedValue(undefined),
+      replied: false,
+      deferred: false,
+    } as unknown as ModalSubmitInteraction;
     grantInteractionPermissions(interaction);
 
-    await handler.handleButtonInteraction(interaction);
+    await handler.handleModalSubmit(interaction);
 
-    expect(interaction.deferUpdate).toHaveBeenCalled();
-    expect(interaction.followUp).toHaveBeenCalledWith({
+    expect(interaction.deferReply).toHaveBeenCalledWith({ flags: MessageFlags.Ephemeral });
+    expect(interaction.editReply).toHaveBeenCalledWith({
       content: 'An error occurred while kicking the user.',
-      flags: MessageFlags.Ephemeral,
     });
   });
 
-  it('handles case kick button by default', async () => {
+  it('shows a case kick reason modal by default', async () => {
     const handler = new InteractionHandler(
       client,
       notificationManager,
@@ -1644,15 +1810,156 @@ describe('InteractionHandler (unit)', () => {
 
     await handler.handleButtonInteraction(interaction);
 
+    expect(userModerationService.kickUser).not.toHaveBeenCalled();
+    expect(interaction.showModal).toHaveBeenCalledTimes(1);
+    const modal = (interaction.showModal as jest.Mock).mock.calls[0][0] as any;
+    expect(modal.toJSON().custom_id).toBe('verification:kick_modal:user-1');
+  });
+
+  it('submits case kick modal with the default reason when blank', async () => {
+    const handler = new InteractionHandler(
+      client,
+      notificationManager,
+      userModerationService,
+      securityActionService,
+      configService,
+      verificationEventRepository,
+      threadManager,
+      adminActionRepository
+    );
+    const interaction = {
+      customId: 'verification:kick_modal:user-1',
+      guildId: 'guild-1',
+      user: { id: 'admin-1' } as User,
+      fields: {
+        getTextInputValue: jest.fn(() => '   '),
+      },
+      deferReply: jest.fn().mockResolvedValue(undefined),
+      editReply: jest.fn().mockResolvedValue(undefined),
+      reply: jest.fn().mockResolvedValue(undefined),
+      replied: false,
+      deferred: false,
+    } as unknown as ModalSubmitInteraction;
+    grantInteractionPermissions(interaction);
+
+    await handler.handleModalSubmit(interaction);
+
     expect(userModerationService.kickUser).toHaveBeenCalledWith(
       expect.objectContaining({ id: 'user-1' }),
       'Kicked by moderator during verification',
       interaction.user
     );
-    expect(interaction.followUp).toHaveBeenCalledWith({
+    expect(interaction.editReply).toHaveBeenCalledWith({
       content: 'Kicked <@user-1> and resolved pending verification cases as kicked.',
       allowedMentions: { parse: [] },
-      flags: MessageFlags.Ephemeral,
+    });
+  });
+
+  it('submits observed kick modal with the provided reason', async () => {
+    enableObservedKickActions();
+    const handler = new InteractionHandler(
+      client,
+      notificationManager,
+      userModerationService,
+      securityActionService,
+      configService,
+      verificationEventRepository,
+      threadManager,
+      adminActionRepository
+    );
+    const interaction = {
+      customId: 'observed:kick_modal:user-1:det-1',
+      guildId: 'guild-1',
+      user: { id: 'admin-1' } as User,
+      fields: {
+        getTextInputValue: jest.fn(() => 'observed kick reason'),
+      },
+      deferReply: jest.fn().mockResolvedValue(undefined),
+      editReply: jest.fn().mockResolvedValue(undefined),
+      reply: jest.fn().mockResolvedValue(undefined),
+      replied: false,
+      deferred: false,
+    } as unknown as ModalSubmitInteraction;
+    grantInteractionPermissions(interaction);
+
+    await handler.handleModalSubmit(interaction);
+
+    expect(securityActionService.kickObservedDetection).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'user-1' }),
+      'det-1',
+      interaction.user,
+      'observed kick reason'
+    );
+    expect(interaction.editReply).toHaveBeenCalledWith({
+      content: 'Kicked <@user-1> from the observed alert.',
+      allowedMentions: { parse: [] },
+    });
+  });
+
+  it('executes native ban action only after the second confirmation modal', async () => {
+    const handler = new InteractionHandler(
+      client,
+      notificationManager,
+      userModerationService,
+      securityActionService,
+      configService,
+      verificationEventRepository,
+      threadManager,
+      adminActionRepository
+    );
+    const reasonInteraction = {
+      customId: 'moderation_action_reason:ban:user-1',
+      guildId: 'guild-1',
+      user: { id: 'ban-mod-1' } as User,
+      fields: {
+        getTextInputValue: jest.fn(() => 'native ban reason'),
+      },
+      reply: jest.fn().mockResolvedValue(undefined),
+      replied: false,
+      deferred: false,
+    } as unknown as ModalSubmitInteraction;
+    grantOnlyBanMembersPermission(reasonInteraction);
+
+    await handler.handleModalSubmit(reasonInteraction);
+
+    expect(userModerationService.banUser).not.toHaveBeenCalled();
+    const reply = (reasonInteraction.reply as jest.Mock).mock.calls[0][0];
+    const confirmButton = reply.components[0].components[0];
+    const confirmButtonInteraction = buildInteraction(confirmButton.toJSON().custom_id, 'guild-1', {
+      id: 'ban-mod-1',
+    } as User);
+    grantOnlyBanMembersPermission(confirmButtonInteraction);
+
+    await handler.handleButtonInteraction(confirmButtonInteraction);
+
+    expect(confirmButtonInteraction.showModal).toHaveBeenCalledTimes(1);
+    const confirmationModal = (confirmButtonInteraction.showModal as jest.Mock).mock.calls[0][0];
+    const confirmationModalId = confirmationModal.toJSON().custom_id;
+    const confirmationInteraction = {
+      customId: confirmationModalId,
+      guildId: 'guild-1',
+      user: { id: 'ban-mod-1' } as User,
+      fields: {
+        getTextInputValue: jest.fn(() => 'BAN'),
+      },
+      deferReply: jest.fn().mockResolvedValue(undefined),
+      editReply: jest.fn().mockResolvedValue(undefined),
+      reply: jest.fn().mockResolvedValue(undefined),
+      replied: false,
+      deferred: false,
+    } as unknown as ModalSubmitInteraction;
+    grantOnlyBanMembersPermission(confirmationInteraction);
+
+    await handler.handleModalSubmit(confirmationInteraction);
+
+    expect(userModerationService.banUser).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'user-1' }),
+      'native ban reason',
+      confirmationInteraction.user
+    );
+    expect(confirmationInteraction.editReply).toHaveBeenCalledWith({
+      content: 'Banned <@user-1> from this server.',
+      allowedMentions: { parse: [] },
     });
   });
 

--- a/src/__tests__/unit/SecurityActionService.unit.test.ts
+++ b/src/__tests__/unit/SecurityActionService.unit.test.ts
@@ -1266,6 +1266,96 @@ describe('SecurityActionService (unit)', () => {
     });
   });
 
+  it('stores admin case source message metadata on the active case', async () => {
+    const guildId = 'guild-admin-message-source';
+    const userId = 'user-admin-message-source';
+    const moderator = { id: 'admin-message-source' } as User;
+    const member = buildMember(guildId, userId);
+    const sourceMessage = buildMessage(guildId, 'source-channel-1');
+
+    await buildService().openAdminCase(member, moderator, {
+      action: 'open_case',
+      reason: 'message evidence',
+      metadata: {
+        source: 'message_context_case',
+        source_channel_id: sourceMessage.channelId,
+        source_message_id: sourceMessage.id,
+      },
+      sourceMessage,
+    });
+
+    const activeCase = await verificationEventRepository.findActiveByUserAndServer(userId, guildId);
+    expect(activeCase?.metadata).toMatchObject({
+      source: 'message_context_case',
+      source_channel_id: 'source-channel-1',
+      source_message_id: 'message-1',
+      source_messages: [
+        {
+          source: 'message_context_case',
+          source_channel_id: 'source-channel-1',
+          source_message_id: 'message-1',
+        },
+      ],
+    });
+    expect(notificationManager.upsertSuspiciousUserNotification).toHaveBeenCalledWith(
+      member,
+      expect.any(Object),
+      expect.any(Object),
+      sourceMessage
+    );
+  });
+
+  it('appends additional admin case source messages to an active case', async () => {
+    const guildId = 'guild-admin-message-source-append';
+    const userId = 'user-admin-message-source-append';
+    const moderator = { id: 'admin-message-source' } as User;
+    const member = buildMember(guildId, userId);
+    const sourceMessageOne = buildMessage(guildId, 'source-channel-1');
+    const sourceMessageTwo = {
+      ...buildMessage(guildId, 'source-channel-2'),
+      id: 'message-2',
+      url: `https://discord.com/channels/${guildId}/source-channel-2/message-2`,
+    } as Message;
+    const service = buildService();
+
+    await service.openAdminCase(member, moderator, {
+      action: 'open_case',
+      metadata: {
+        source: 'message_context_case',
+        source_channel_id: sourceMessageOne.channelId,
+        source_message_id: sourceMessageOne.id,
+      },
+      sourceMessage: sourceMessageOne,
+    });
+    await service.openAdminCase(member, moderator, {
+      action: 'open_case',
+      metadata: {
+        source: 'message_context_case',
+        source_channel_id: sourceMessageTwo.channelId,
+        source_message_id: sourceMessageTwo.id,
+      },
+      sourceMessage: sourceMessageTwo,
+    });
+
+    const activeCase = await verificationEventRepository.findActiveByUserAndServer(userId, guildId);
+    expect(activeCase?.metadata).toMatchObject({
+      source_channel_id: 'source-channel-2',
+      source_message_id: 'message-2',
+      source_messages: [
+        {
+          source: 'message_context_case',
+          source_channel_id: 'source-channel-1',
+          source_message_id: 'message-1',
+        },
+        {
+          source: 'message_context_case',
+          source_channel_id: 'source-channel-2',
+          source_message_id: 'message-2',
+        },
+      ],
+    });
+  });
+
   it('posts an observed alert for user report without opening a case', async () => {
     const guildId = 'guild-3';
     const userId = 'user-3';

--- a/src/__tests__/unit/detectionResponseSettings.unit.test.ts
+++ b/src/__tests__/unit/detectionResponseSettings.unit.test.ts
@@ -13,7 +13,10 @@ describe('detectionResponseSettings (unit)', () => {
     expect(settings.observedMinConfidenceThreshold).toBe(70);
     expect(settings.observedNotificationWindowMinutes).toBe(60);
     expect(settings.automaticDetectionExemptModerators).toBe(true);
+    expect(settings.adminCaseOpenRequiresReason).toBe(false);
     expect(settings.observedActionBanRequiresReason).toBe(false);
+    expect(settings.moderatorBanActionRequiresReason).toBe(false);
+    expect(settings.moderatorKickActionRequiresReason).toBe(false);
     expect(settings.moderatorBanActionEnabled).toBe(true);
     expect(settings.moderatorKickActionEnabled).toBe(true);
     expect(settings.observedActionKickEnabled).toBe(false);
@@ -31,6 +34,9 @@ describe('detectionResponseSettings (unit)', () => {
     expect(settings.joinMode).toBe('restrict');
     expect(settings.moderatorBanActionEnabled).toBe(true);
     expect(settings.moderatorKickActionEnabled).toBe(true);
+    expect(settings.adminCaseOpenRequiresReason).toBe(false);
+    expect(settings.moderatorBanActionRequiresReason).toBe(false);
+    expect(settings.moderatorKickActionRequiresReason).toBe(false);
     expect(settings.observedActionKickEnabled).toBe(false);
     expect(settings.messageDetectionAutoKickEnabled).toBe(false);
     expect(settings.joinDetectionAutoKickEnabled).toBe(false);
@@ -128,12 +134,26 @@ describe('detectionResponseSettings (unit)', () => {
     expect(settings.automaticDetectionExemptModerators).toBe(false);
   });
 
-  it('allows observed notification ban reasons to be required', () => {
+  it('allows staff action reasons to be required', () => {
+    const settings = getDetectionResponseSettings({
+      admin_case_open_requires_reason: true,
+      moderator_ban_action_requires_reason: true,
+      moderator_kick_action_requires_reason: true,
+    });
+
+    expect(settings.adminCaseOpenRequiresReason).toBe(true);
+    expect(settings.observedActionBanRequiresReason).toBe(true);
+    expect(settings.moderatorBanActionRequiresReason).toBe(true);
+    expect(settings.moderatorKickActionRequiresReason).toBe(true);
+  });
+
+  it('maps legacy observed ban reason policy to the shared ban reason policy', () => {
     const settings = getDetectionResponseSettings({
       observed_action_ban_requires_reason: true,
     });
 
     expect(settings.observedActionBanRequiresReason).toBe(true);
+    expect(settings.moderatorBanActionRequiresReason).toBe(true);
   });
 
   it('clamps numeric observe-only notification settings', () => {

--- a/src/controllers/CaseCommandHandler.ts
+++ b/src/controllers/CaseCommandHandler.ts
@@ -1,16 +1,79 @@
 import {
+  ActionRowBuilder,
   ButtonStyle,
   ChatInputCommandInteraction,
   Guild,
+  MessageContextMenuCommandInteraction,
   MessageFlags,
+  ModalBuilder,
   PermissionFlagsBits,
   Role,
+  TextInputBuilder,
+  TextInputStyle,
+  UserContextMenuCommandInteraction,
 } from 'discord.js';
 import { IConfigService } from '../config/ConfigService';
 import { ISecurityActionService, RoleIntakeProgress } from '../services/SecurityActionService';
+import { getDetectionResponseSettings } from '../utils/detectionResponseSettings';
 import { requestSlashCommandConfirmation } from '../utils/slashCommandConfirmations';
 
-type ReplyGuildInstallRequired = (interaction: ChatInputCommandInteraction) => Promise<void>;
+export const OPEN_CASE_CONTEXT_MODAL_PREFIX = 'case_open_context';
+export const OPEN_CASE_MESSAGE_CONTEXT_MODAL_PREFIX = 'case_open_message_context';
+export const OPEN_CASE_CONTEXT_REASON_FIELD_ID = 'case_open_reason';
+
+type CaseCommandInteraction =
+  | ChatInputCommandInteraction
+  | UserContextMenuCommandInteraction
+  | MessageContextMenuCommandInteraction;
+type ReplyGuildInstallRequired = (interaction: CaseCommandInteraction) => Promise<void>;
+
+export interface OpenCaseMessageContextModalData {
+  targetUserId: string;
+  sourceChannelId: string;
+  sourceMessageId: string;
+}
+
+export function buildOpenCaseContextModalCustomId(targetUserId: string): string {
+  return `${OPEN_CASE_CONTEXT_MODAL_PREFIX}:${targetUserId}`;
+}
+
+export function buildOpenCaseMessageContextModalCustomId(
+  targetUserId: string,
+  sourceChannelId: string,
+  sourceMessageId: string
+): string {
+  return [
+    OPEN_CASE_MESSAGE_CONTEXT_MODAL_PREFIX,
+    targetUserId,
+    sourceChannelId,
+    sourceMessageId,
+  ].join(':');
+}
+
+export function parseOpenCaseContextModalCustomId(customId: string): string | null {
+  const prefix = `${OPEN_CASE_CONTEXT_MODAL_PREFIX}:`;
+  if (!customId.startsWith(prefix)) {
+    return null;
+  }
+
+  return customId.slice(prefix.length) || null;
+}
+
+export function parseOpenCaseMessageContextModalCustomId(
+  customId: string
+): OpenCaseMessageContextModalData | null {
+  const [prefix, targetUserId, sourceChannelId, sourceMessageId] = customId.split(':');
+  if (
+    prefix !== OPEN_CASE_MESSAGE_CONTEXT_MODAL_PREFIX ||
+    !targetUserId ||
+    !sourceChannelId ||
+    !sourceMessageId
+  ) {
+    return null;
+  }
+
+  return { targetUserId, sourceChannelId, sourceMessageId };
+}
 
 export class CaseCommandHandler {
   public constructor(
@@ -20,7 +83,7 @@ export class CaseCommandHandler {
   ) {}
 
   private async requireAdministrator(
-    interaction: ChatInputCommandInteraction,
+    interaction: CaseCommandInteraction,
     guild: Guild
   ): Promise<boolean> {
     const memberPermissions = interaction.memberPermissions;
@@ -48,6 +111,153 @@ export class CaseCommandHandler {
     return true;
   }
 
+  private async requireCaseOpenPermission(
+    interaction: CaseCommandInteraction,
+    guild: Guild
+  ): Promise<boolean> {
+    const memberPermissions = interaction.memberPermissions;
+    if (
+      memberPermissions?.has(PermissionFlagsBits.Administrator) ||
+      memberPermissions?.has(PermissionFlagsBits.ModerateMembers)
+    ) {
+      return true;
+    }
+
+    if (
+      memberPermissions &&
+      !memberPermissions.has(PermissionFlagsBits.ModerateMembers) &&
+      !memberPermissions.has(PermissionFlagsBits.Administrator)
+    ) {
+      await interaction.reply({
+        content: 'You need Moderate Members permission to open a case.',
+        flags: MessageFlags.Ephemeral,
+      });
+      return false;
+    }
+
+    const member = await guild.members.fetch(interaction.user.id).catch(() => null);
+    if (
+      !member ||
+      (!member.permissions.has(PermissionFlagsBits.Administrator) &&
+        !member.permissions.has(PermissionFlagsBits.ModerateMembers))
+    ) {
+      await interaction.reply({
+        content: 'You need Moderate Members permission to open a case.',
+        flags: MessageFlags.Ephemeral,
+      });
+      return false;
+    }
+
+    return true;
+  }
+
+  private async getCaseOpenReasonRequired(guildId: string): Promise<boolean> {
+    const serverConfig = await this.configService.getServerConfig(guildId);
+    return getDetectionResponseSettings(serverConfig.settings).adminCaseOpenRequiresReason;
+  }
+
+  public async handleOpenCaseUserContextCommand(
+    interaction: UserContextMenuCommandInteraction
+  ): Promise<void> {
+    const guild = interaction.guild;
+    if (!guild) {
+      await this.replyGuildInstallRequired(interaction);
+      return;
+    }
+
+    if (!(await this.requireCaseOpenPermission(interaction, guild))) {
+      return;
+    }
+
+    const targetUser = interaction.targetUser;
+    if (targetUser.id === interaction.user.id) {
+      await interaction.reply({
+        content: 'You cannot open a case for yourself.',
+        flags: MessageFlags.Ephemeral,
+      });
+      return;
+    }
+
+    const targetMember = await guild.members.fetch(targetUser.id).catch(() => null);
+    if (!targetMember) {
+      await interaction.reply({
+        content: `Could not find user ${targetUser.tag} in this server.`,
+        flags: MessageFlags.Ephemeral,
+      });
+      return;
+    }
+
+    await this.showOpenCaseReasonModal(
+      interaction,
+      buildOpenCaseContextModalCustomId(targetUser.id),
+      'Open Case',
+      await this.getCaseOpenReasonRequired(guild.id)
+    );
+  }
+
+  public async handleOpenCaseMessageContextCommand(
+    interaction: MessageContextMenuCommandInteraction
+  ): Promise<void> {
+    const guild = interaction.guild;
+    if (!guild) {
+      await this.replyGuildInstallRequired(interaction);
+      return;
+    }
+
+    if (!(await this.requireCaseOpenPermission(interaction, guild))) {
+      return;
+    }
+
+    const targetMessage = interaction.targetMessage;
+    const targetUser = targetMessage.author;
+    if (targetUser.id === interaction.user.id) {
+      await interaction.reply({
+        content: 'You cannot open a case for yourself.',
+        flags: MessageFlags.Ephemeral,
+      });
+      return;
+    }
+
+    const targetMember = await guild.members.fetch(targetUser.id).catch(() => null);
+    if (!targetMember) {
+      await interaction.reply({
+        content: `Could not find user ${targetUser.tag} in this server.`,
+        flags: MessageFlags.Ephemeral,
+      });
+      return;
+    }
+
+    await this.showOpenCaseReasonModal(
+      interaction,
+      buildOpenCaseMessageContextModalCustomId(
+        targetUser.id,
+        targetMessage.channelId,
+        targetMessage.id
+      ),
+      'Open Case from Message',
+      await this.getCaseOpenReasonRequired(guild.id)
+    );
+  }
+
+  private async showOpenCaseReasonModal(
+    interaction: UserContextMenuCommandInteraction | MessageContextMenuCommandInteraction,
+    customId: string,
+    title: string,
+    reasonRequired: boolean
+  ): Promise<void> {
+    const modal = new ModalBuilder().setCustomId(customId).setTitle(title);
+    const reasonInput = new TextInputBuilder()
+      .setCustomId(OPEN_CASE_CONTEXT_REASON_FIELD_ID)
+      .setLabel(reasonRequired ? 'Reason' : 'Reason (optional)')
+      .setStyle(TextInputStyle.Paragraph)
+      .setRequired(reasonRequired)
+      .setMaxLength(500)
+      .setPlaceholder('Why should moderators review this user?');
+
+    modal.addComponents(new ActionRowBuilder<TextInputBuilder>().addComponents(reasonInput));
+    await interaction.showModal(modal);
+  }
+
   public async handleCaseCommand(interaction: ChatInputCommandInteraction): Promise<void> {
     const guild = interaction.guild;
     if (!guild) {
@@ -55,13 +265,16 @@ export class CaseCommandHandler {
       return;
     }
 
-    if (!(await this.requireAdministrator(interaction, guild))) {
+    const subcommand = interaction.options.getSubcommand(true);
+    if (subcommand === 'open') {
+      if (!(await this.requireCaseOpenPermission(interaction, guild))) {
+        return;
+      }
+      await this.handleCaseUserCommand(interaction, guild);
       return;
     }
 
-    const subcommand = interaction.options.getSubcommand(true);
-    if (subcommand === 'open') {
-      await this.handleCaseUserCommand(interaction, guild);
+    if (!(await this.requireAdministrator(interaction, guild))) {
       return;
     }
 
@@ -92,6 +305,14 @@ export class CaseCommandHandler {
   ): Promise<void> {
     const targetUser = interaction.options.getUser('user', true);
     const reason = interaction.options.getString('reason')?.trim() || undefined;
+    if ((await this.getCaseOpenReasonRequired(guild.id)) && !reason) {
+      await interaction.reply({
+        content: 'A case reason is required.',
+        flags: MessageFlags.Ephemeral,
+      });
+      return;
+    }
+
     const targetMember = await guild.members.fetch(targetUser.id).catch(() => null);
     if (!targetMember) {
       await interaction.reply({
@@ -261,6 +482,14 @@ export class CaseCommandHandler {
     const execute = interaction.options.getBoolean('execute') ?? false;
     const limit = interaction.options.getInteger('limit') ?? undefined;
     const reason = interaction.options.getString('reason')?.trim() || undefined;
+
+    if (execute && (await this.getCaseOpenReasonRequired(guild.id)) && !reason) {
+      await interaction.reply({
+        content: 'A case reason is required before executing role intake.',
+        flags: MessageFlags.Ephemeral,
+      });
+      return;
+    }
 
     if (execute) {
       await requestSlashCommandConfirmation(interaction, {

--- a/src/controllers/CommandHandler.ts
+++ b/src/controllers/CommandHandler.ts
@@ -28,7 +28,10 @@ import { ISetupDiagnosticsService } from '../services/SetupDiagnosticsService';
 import { ICaseRoleLockdownService } from '../services/CaseRoleLockdownService';
 import { ReportSubmissionService } from '../services/ReportSubmissionService';
 import {
+  BAN_USER_CONTEXT_COMMAND_NAME,
   buildApplicationCommands,
+  KICK_USER_CONTEXT_COMMAND_NAME,
+  OPEN_CASE_CONTEXT_COMMAND_NAME,
   REPORT_MESSAGE_CONTEXT_COMMAND_NAME,
   REPORT_USER_CONTEXT_COMMAND_NAME,
 } from './commandDefinitions';
@@ -269,29 +272,49 @@ export class CommandHandler implements ICommandHandler {
   public async handleUserContextMenuCommand(
     interaction: UserContextMenuCommandInteraction
   ): Promise<void> {
-    if (interaction.commandName !== REPORT_USER_CONTEXT_COMMAND_NAME) {
-      await interaction.reply({
-        content: `Unknown user command: ${interaction.commandName}`,
-        flags: MessageFlags.Ephemeral,
-      });
-      return;
+    switch (interaction.commandName) {
+      case REPORT_USER_CONTEXT_COMMAND_NAME:
+        await this.reportCommandHandler.handleReportUserContextCommand(interaction);
+        return;
+      case OPEN_CASE_CONTEXT_COMMAND_NAME:
+        await this.caseCommandHandler.handleOpenCaseUserContextCommand(interaction);
+        return;
+      case BAN_USER_CONTEXT_COMMAND_NAME:
+        await this.moderationCommandHandler.handleBanUserContextCommand(interaction);
+        return;
+      case KICK_USER_CONTEXT_COMMAND_NAME:
+        await this.moderationCommandHandler.handleKickUserContextCommand(interaction);
+        return;
+      default:
+        await interaction.reply({
+          content: `Unknown user command: ${interaction.commandName}`,
+          flags: MessageFlags.Ephemeral,
+        });
     }
-
-    await this.reportCommandHandler.handleReportUserContextCommand(interaction);
   }
 
   public async handleMessageContextMenuCommand(
     interaction: MessageContextMenuCommandInteraction
   ): Promise<void> {
-    if (interaction.commandName !== REPORT_MESSAGE_CONTEXT_COMMAND_NAME) {
-      await interaction.reply({
-        content: `Unknown message command: ${interaction.commandName}`,
-        flags: MessageFlags.Ephemeral,
-      });
-      return;
+    switch (interaction.commandName) {
+      case REPORT_MESSAGE_CONTEXT_COMMAND_NAME:
+        await this.reportCommandHandler.handleReportMessageContextCommand(interaction);
+        return;
+      case OPEN_CASE_CONTEXT_COMMAND_NAME:
+        await this.caseCommandHandler.handleOpenCaseMessageContextCommand(interaction);
+        return;
+      case BAN_USER_CONTEXT_COMMAND_NAME:
+        await this.moderationCommandHandler.handleBanMessageContextCommand(interaction);
+        return;
+      case KICK_USER_CONTEXT_COMMAND_NAME:
+        await this.moderationCommandHandler.handleKickMessageContextCommand(interaction);
+        return;
+      default:
+        await interaction.reply({
+          content: `Unknown message command: ${interaction.commandName}`,
+          flags: MessageFlags.Ephemeral,
+        });
     }
-
-    await this.reportCommandHandler.handleReportMessageContextCommand(interaction);
   }
 
   public async handleTestCommands(message: Message): Promise<void> {
@@ -486,7 +509,10 @@ export class CommandHandler implements ICommandHandler {
   }
 
   private async replyGuildInstallRequired(
-    interaction: ChatInputCommandInteraction | UserContextMenuCommandInteraction
+    interaction:
+      | ChatInputCommandInteraction
+      | UserContextMenuCommandInteraction
+      | MessageContextMenuCommandInteraction
   ): Promise<void> {
     const installLink = this.getGuildInstallLink();
     const setupLink = interaction.guildId ? buildAdminGuildSetupUrl(interaction.guildId) : null;

--- a/src/controllers/ConfigSubcommandHandler.ts
+++ b/src/controllers/ConfigSubcommandHandler.ts
@@ -26,6 +26,7 @@ import {
   getCaseReviewReminderSettings,
 } from '../utils/caseReviewReminderSettings';
 import {
+  ADMIN_CASE_OPEN_REQUIRES_REASON_SETTING_KEY,
   AUTO_KICK_MIN_CONFIDENCE_THRESHOLD_SETTING_KEY,
   AUTOMATIC_DETECTION_EXEMPT_MODERATORS_SETTING_KEY,
   DETECTION_RESPONSE_MODE_SETTING_KEY,
@@ -35,7 +36,9 @@ import {
   MESSAGE_DETECTION_AUTO_KICK_ENABLED_SETTING_KEY,
   MESSAGE_DETECTION_RESPONSE_MODE_SETTING_KEY,
   MODERATOR_BAN_ACTION_ENABLED_SETTING_KEY,
+  MODERATOR_BAN_ACTION_REQUIRES_REASON_SETTING_KEY,
   MODERATOR_KICK_ACTION_ENABLED_SETTING_KEY,
+  MODERATOR_KICK_ACTION_REQUIRES_REASON_SETTING_KEY,
   OBSERVED_ACTION_BAN_REQUIRES_REASON_SETTING_KEY,
   OBSERVED_ACTION_KICK_ENABLED_SETTING_KEY,
   OBSERVED_DETECTION_MIN_CONFIDENCE_THRESHOLD_SETTING_KEY,
@@ -163,7 +166,9 @@ export class ConfigSubcommandHandler {
       `Observed notification channel: ${settings.observedNotificationChannelId ? `<#${settings.observedNotificationChannelId}>` : '`admin_channel_id` fallback'}`,
       `Observed notification threshold: \`${settings.observedMinConfidenceThreshold}%\``,
       `Observed notification window: \`${settings.observedNotificationWindowMinutes} minutes\``,
-      `Observed ban reason required: \`${settings.observedActionBanRequiresReason ? 'yes' : 'no'}\``,
+      `Case reason required: \`${settings.adminCaseOpenRequiresReason ? 'yes' : 'no'}\``,
+      `Ban reason required: \`${settings.moderatorBanActionRequiresReason ? 'yes' : 'no'}\``,
+      `Kick reason required: \`${settings.moderatorKickActionRequiresReason ? 'yes' : 'no'}\``,
       `Moderator ban action enabled: \`${settings.moderatorBanActionEnabled ? 'yes' : 'no'}\``,
       `Moderator kick action enabled: \`${settings.moderatorKickActionEnabled ? 'yes' : 'no'}\``,
       `Observed kick action enabled: \`${settings.observedActionKickEnabled ? 'yes' : 'no'}\``,
@@ -948,16 +953,51 @@ export class ConfigSubcommandHandler {
           return;
         }
 
+        case 'case-reason-require':
+        case 'case-reason-optional': {
+          const required = subcommand === 'case-reason-require';
+          const updated = await this.configService.updateServerSettings(guildId, {
+            [ADMIN_CASE_OPEN_REQUIRES_REASON_SETTING_KEY]: required,
+          });
+          const settings = getDetectionResponseSettings(updated.settings);
+          await interaction.reply({
+            content:
+              'Updated staff case-open reason policy.\n\n' +
+              this.formatDetectionResponseSettings(guildId, settings),
+            flags: MessageFlags.Ephemeral,
+            allowedMentions: { parse: [] },
+          });
+          return;
+        }
+
         case 'ban-reason-require':
         case 'ban-reason-optional': {
           const required = subcommand === 'ban-reason-require';
           const updated = await this.configService.updateServerSettings(guildId, {
+            [MODERATOR_BAN_ACTION_REQUIRES_REASON_SETTING_KEY]: required,
             [OBSERVED_ACTION_BAN_REQUIRES_REASON_SETTING_KEY]: required,
           });
           const settings = getDetectionResponseSettings(updated.settings);
           await interaction.reply({
             content:
-              'Updated observed notification ban reason policy.\n\n' +
+              'Updated staff ban reason policy.\n\n' +
+              this.formatDetectionResponseSettings(guildId, settings),
+            flags: MessageFlags.Ephemeral,
+            allowedMentions: { parse: [] },
+          });
+          return;
+        }
+
+        case 'kick-reason-require':
+        case 'kick-reason-optional': {
+          const required = subcommand === 'kick-reason-require';
+          const updated = await this.configService.updateServerSettings(guildId, {
+            [MODERATOR_KICK_ACTION_REQUIRES_REASON_SETTING_KEY]: required,
+          });
+          const settings = getDetectionResponseSettings(updated.settings);
+          await interaction.reply({
+            content:
+              'Updated staff kick reason policy.\n\n' +
               this.formatDetectionResponseSettings(guildId, settings),
             flags: MessageFlags.Ephemeral,
             allowedMentions: { parse: [] },

--- a/src/controllers/InteractionHandler.ts
+++ b/src/controllers/InteractionHandler.ts
@@ -4,6 +4,7 @@ import {
   ButtonBuilder,
   MessageFlags,
   GuildMember,
+  Message,
   PermissionFlagsBits,
   ModalBuilder,
   TextInputBuilder,
@@ -64,6 +65,12 @@ import {
   REPORT_USER_TYPED_MODAL_ID,
   ReportInteractionHandler,
 } from './ReportInteractionHandler';
+import {
+  OPEN_CASE_CONTEXT_REASON_FIELD_ID,
+  OpenCaseMessageContextModalData,
+  parseOpenCaseContextModalCustomId,
+  parseOpenCaseMessageContextModalCustomId,
+} from './CaseCommandHandler';
 import { SetupVerificationModalHandler } from './SetupVerificationModalHandler';
 import { buildAdminCaseDetailUrl, buildAdminCaseQueueUrl } from '../utils/publicWebLinks';
 import {
@@ -75,17 +82,38 @@ import {
   ModerationQueueService,
 } from '../services/ModerationQueueService';
 import { IRoleGateService, RoleGateResolutionResult } from '../services/RoleGateService';
+import {
+  MODERATION_ACTION_REASON_FIELD_ID,
+  MODERATOR_ACTION_BAN_DEFAULT_REASON,
+  MODERATOR_ACTION_KICK_DEFAULT_REASON,
+  ModeratorUserAction,
+  parseModerationActionReasonModalCustomId,
+} from '../utils/moderationActionCustomIds';
 // Load environment variables
 dotenv.config();
 
 const OBSERVED_ACTION_MODAL_REASON_FIELD_ID = 'observed_ban_reason';
+const KICK_ACTION_MODAL_REASON_FIELD_ID = 'kick_action_reason';
 const OBSERVED_BAN_DEFAULT_REASON = 'Banned from observed suspicious notification';
 const OBSERVED_KICK_DEFAULT_REASON = 'Kicked from observed suspicious notification';
 const VERIFICATION_BAN_MODAL_PREFIX = 'verification:ban_modal';
 const VERIFICATION_BAN_NOTES_FIELD_ID = 'verification_ban_notes';
 const VERIFICATION_BAN_DEFAULT_REASON = 'Banned by moderator during verification';
+const VERIFICATION_KICK_MODAL_PREFIX = 'verification:kick_modal';
 const VERIFICATION_KICK_DEFAULT_REASON = 'Kicked by moderator during verification';
+const OBSERVED_KICK_MODAL_PREFIX = 'observed:kick_modal';
+const MODERATION_ACTION_CONFIRMATION_PREFIX = 'moderation_action_confirm';
+const MODERATION_ACTION_CONFIRMATION_TTL_MS = 10 * 60 * 1000;
 const CASE_REVIEW_DIGEST_PAGE_SIZE = 25;
+
+interface PendingModerationActionConfirmation {
+  readonly action: ModeratorUserAction;
+  readonly targetUserId: string;
+  readonly userId: string;
+  readonly guildId: string;
+  readonly reason: string;
+  readonly createdAt: number;
+}
 /**
  * Interface for the Bot class
  */
@@ -120,6 +148,11 @@ export class InteractionHandler implements IInteractionHandler {
   private moderationQueueService?: IModerationQueueService;
   private roleGateService?: IRoleGateService;
   private detectionEventsRepository?: IDetectionEventsRepository;
+  private moderationActionConfirmationCounter = 0;
+  private readonly pendingModerationActionConfirmations = new Map<
+    string,
+    PendingModerationActionConfirmation
+  >();
 
   constructor(
     @inject(TYPES.DiscordClient) client: Client,
@@ -211,6 +244,11 @@ export class InteractionHandler implements IInteractionHandler {
 
       if (isSlashCommandConfirmationCustomId(customId)) {
         await handleSlashCommandConfirmationButton(interaction);
+        return;
+      }
+
+      if (this.isModerationActionConfirmationCustomId(customId)) {
+        await this.handleModerationActionConfirmationButton(interaction, guildId);
         return;
       }
 
@@ -318,7 +356,7 @@ export class InteractionHandler implements IInteractionHandler {
             });
             return;
           }
-          await this.handleBanButton(interaction, targetUserId);
+          await this.handleBanButton(interaction, guildId, targetUserId);
           break;
         case 'thread':
           if (
@@ -1339,7 +1377,7 @@ export class InteractionHandler implements IInteractionHandler {
       return;
     }
 
-    await this.handleBanButton(interaction, parsed.userId);
+    await this.handleBanButton(interaction, guildId, parsed.userId);
   }
 
   private async executeConfirmedAdminAction(
@@ -1426,7 +1464,7 @@ export class InteractionHandler implements IInteractionHandler {
         });
         return;
       }
-      await this.handleKickButton(interaction, guildId, parsed.userId);
+      await this.showVerificationKickModal(interaction, guildId, parsed.userId);
       return;
     }
 
@@ -1466,8 +1504,12 @@ export class InteractionHandler implements IInteractionHandler {
         });
         return;
       }
-      await interaction.deferUpdate();
-      await this.kickObservedUser(interaction, guildId, parsed.userId, parsed.detectionEventId);
+      await this.showObservedKickModal(
+        interaction,
+        guildId,
+        parsed.userId,
+        parsed.detectionEventId
+      );
       return;
     }
 
@@ -1601,38 +1643,28 @@ export class InteractionHandler implements IInteractionHandler {
     }
   }
 
-  private async handleKickButton(
+  private async showVerificationKickModal(
     interaction: ButtonInteraction,
     guildId: string,
     userId: string
   ): Promise<void> {
-    await interaction.deferUpdate();
+    const serverConfig = await this.configService.getServerConfig(guildId);
+    const settings = getDetectionResponseSettings(serverConfig.settings);
+    const modal = new ModalBuilder()
+      .setCustomId(`${VERIFICATION_KICK_MODAL_PREFIX}:${userId}`)
+      .setTitle('Confirm User Kick');
+    const reasonInput = new TextInputBuilder()
+      .setCustomId(KICK_ACTION_MODAL_REASON_FIELD_ID)
+      .setLabel(
+        settings.moderatorKickActionRequiresReason ? 'Kick reason' : 'Kick reason (optional)'
+      )
+      .setStyle(TextInputStyle.Paragraph)
+      .setRequired(settings.moderatorKickActionRequiresReason)
+      .setMaxLength(500)
+      .setPlaceholder(VERIFICATION_KICK_DEFAULT_REASON);
 
-    try {
-      const guild = await this.client.guilds.fetch(guildId);
-      const member = await guild.members.fetch(userId).catch(() => null);
-      if (!member) {
-        throw new Error('Could not find member in guild');
-      }
-
-      await this.userModerationService.kickUser(
-        member,
-        VERIFICATION_KICK_DEFAULT_REASON,
-        interaction.user
-      );
-
-      await interaction.followUp({
-        content: `Kicked <@${userId}> and resolved pending verification cases as kicked.`,
-        allowedMentions: { parse: [] },
-        flags: MessageFlags.Ephemeral,
-      });
-    } catch (error) {
-      console.error('Error kicking user from case action:', error);
-      await interaction.followUp({
-        content: 'An error occurred while kicking the user.',
-        flags: MessageFlags.Ephemeral,
-      });
-    }
+    modal.addComponents(new ActionRowBuilder<TextInputBuilder>().addComponents(reasonInput));
+    await interaction.showModal(modal);
   }
 
   private async handleCloseNoActionButton(
@@ -1734,15 +1766,21 @@ export class InteractionHandler implements IInteractionHandler {
     return lines.length > 0 ? `\n\n${lines.join('\n')}` : '';
   }
 
-  private async handleBanButton(interaction: ButtonInteraction, userId: string): Promise<void> {
+  private async handleBanButton(
+    interaction: ButtonInteraction,
+    guildId: string,
+    userId: string
+  ): Promise<void> {
+    const serverConfig = await this.configService.getServerConfig(guildId);
+    const settings = getDetectionResponseSettings(serverConfig.settings);
     const modal = new ModalBuilder()
       .setCustomId(`${VERIFICATION_BAN_MODAL_PREFIX}:${userId}`)
       .setTitle('Confirm User Ban');
     const notesInput = new TextInputBuilder()
       .setCustomId(VERIFICATION_BAN_NOTES_FIELD_ID)
-      .setLabel('Final notes (optional)')
+      .setLabel(settings.moderatorBanActionRequiresReason ? 'Ban reason' : 'Ban reason (optional)')
       .setStyle(TextInputStyle.Paragraph)
-      .setRequired(false)
+      .setRequired(settings.moderatorBanActionRequiresReason)
       .setMaxLength(500)
       .setPlaceholder('Submitting this form bans the user. Add notes for the audit log.');
 
@@ -1901,6 +1939,37 @@ export class InteractionHandler implements IInteractionHandler {
   }
 
   public async handleModalSubmit(interaction: ModalSubmitInteraction): Promise<void> {
+    const moderationActionReason = parseModerationActionReasonModalCustomId(interaction.customId);
+    if (moderationActionReason) {
+      await this.handleModerationActionReasonModalSubmit(interaction, moderationActionReason);
+      return;
+    }
+
+    const moderationActionConfirmationId = this.parseModerationActionConfirmationModalCustomId(
+      interaction.customId
+    );
+    if (moderationActionConfirmationId) {
+      await this.handleModerationActionConfirmationModalSubmit(
+        interaction,
+        moderationActionConfirmationId
+      );
+      return;
+    }
+
+    const openCaseMessageContext = parseOpenCaseMessageContextModalCustomId(interaction.customId);
+    if (openCaseMessageContext) {
+      await this.handleOpenCaseContextModalSubmit(interaction, openCaseMessageContext);
+      return;
+    }
+
+    const openCaseTargetUserId = parseOpenCaseContextModalCustomId(interaction.customId);
+    if (openCaseTargetUserId) {
+      await this.handleOpenCaseContextModalSubmit(interaction, {
+        targetUserId: openCaseTargetUserId,
+      });
+      return;
+    }
+
     switch (interaction.customId) {
       case REPORT_USER_TYPED_MODAL_ID:
         await this.reportInteractionHandler.handleReportUserModalSubmit(interaction);
@@ -1913,6 +1982,10 @@ export class InteractionHandler implements IInteractionHandler {
           await this.handleVerificationBanModalSubmit(interaction);
           return;
         }
+        if (interaction.customId.startsWith(`${VERIFICATION_KICK_MODAL_PREFIX}:`)) {
+          await this.handleVerificationKickModalSubmit(interaction);
+          return;
+        }
         if (interaction.customId.startsWith(`${REPORT_MESSAGE_MODAL_PREFIX}:`)) {
           await this.reportInteractionHandler.handleReportMessageModalSubmit(interaction);
           return;
@@ -1921,10 +1994,482 @@ export class InteractionHandler implements IInteractionHandler {
           await this.handleObservedBanModalSubmit(interaction);
           return;
         }
+        if (interaction.customId.startsWith(`${OBSERVED_KICK_MODAL_PREFIX}:`)) {
+          await this.handleObservedKickModalSubmit(interaction);
+          return;
+        }
         console.log(
           `[InteractionHandler] Ignoring unknown modal submission: ${interaction.customId}`
         );
     }
+  }
+
+  private nextModerationActionConfirmationId(): string {
+    this.moderationActionConfirmationCounter += 1;
+    return `${Date.now().toString(36)}${this.moderationActionConfirmationCounter.toString(36)}`;
+  }
+
+  private buildModerationActionConfirmationCustomId(
+    action: 'confirm' | 'cancel',
+    id: string
+  ): string {
+    return `${MODERATION_ACTION_CONFIRMATION_PREFIX}:${action}:${id}`;
+  }
+
+  private parseModerationActionConfirmationCustomId(
+    customId: string
+  ): { action: 'confirm' | 'cancel'; id: string } | null {
+    const [prefix, action, id] = customId.split(':');
+    if (prefix !== MODERATION_ACTION_CONFIRMATION_PREFIX || !id) {
+      return null;
+    }
+    if (action !== 'confirm' && action !== 'cancel') {
+      return null;
+    }
+
+    return { action, id };
+  }
+
+  private isModerationActionConfirmationCustomId(customId: string): boolean {
+    return this.parseModerationActionConfirmationCustomId(customId) !== null;
+  }
+
+  private buildModerationActionConfirmationModalCustomId(id: string): string {
+    return `${MODERATION_ACTION_CONFIRMATION_PREFIX}:modal:${id}`;
+  }
+
+  private parseModerationActionConfirmationModalCustomId(customId: string): string | null {
+    const [prefix, action, id] = customId.split(':');
+    if (prefix !== MODERATION_ACTION_CONFIRMATION_PREFIX || action !== 'modal' || !id) {
+      return null;
+    }
+
+    return id;
+  }
+
+  private pruneModerationActionConfirmations(now = Date.now()): void {
+    for (const [id, pending] of this.pendingModerationActionConfirmations.entries()) {
+      if (now - pending.createdAt > MODERATION_ACTION_CONFIRMATION_TTL_MS) {
+        this.pendingModerationActionConfirmations.delete(id);
+      }
+    }
+  }
+
+  private getModerationActionLabel(action: ModeratorUserAction): string {
+    return action === 'ban' ? 'Ban User' : 'Kick User';
+  }
+
+  private getModerationActionDefaultReason(action: ModeratorUserAction): string {
+    return action === 'ban'
+      ? MODERATOR_ACTION_BAN_DEFAULT_REASON
+      : MODERATOR_ACTION_KICK_DEFAULT_REASON;
+  }
+
+  private async getModerationActionReasonRequired(
+    guildId: string,
+    action: ModeratorUserAction
+  ): Promise<boolean> {
+    const serverConfig = await this.configService.getServerConfig(guildId);
+    const settings = getDetectionResponseSettings(serverConfig.settings);
+    return action === 'ban'
+      ? settings.moderatorBanActionRequiresReason
+      : settings.moderatorKickActionRequiresReason;
+  }
+
+  private async ensureModerationActionAllowed(
+    interaction: ButtonInteraction | ModalSubmitInteraction,
+    guildId: string,
+    action: ModeratorUserAction
+  ): Promise<boolean> {
+    const permission =
+      action === 'ban' ? PermissionFlagsBits.BanMembers : PermissionFlagsBits.KickMembers;
+    const permissionName = action === 'ban' ? 'Ban Members' : 'Kick Members';
+    if (!(await this.hasAnyPermission(interaction, guildId, [permission]))) {
+      await this.replyPermissionDenied(
+        interaction,
+        `You need ${permissionName} permission to ${action} a user.`
+      );
+      return false;
+    }
+
+    const actionEnabled =
+      action === 'ban'
+        ? await this.canUseModeratorBanAction(guildId)
+        : await this.canUseModeratorKickAction(guildId, 'case');
+    if (!actionEnabled) {
+      await interaction.reply({
+        content:
+          action === 'ban'
+            ? 'Drasil ban actions are disabled for this server or the bot lacks Ban Members permission.'
+            : 'Drasil kick actions are disabled for this server or the bot lacks Kick Members permission.',
+        flags: MessageFlags.Ephemeral,
+      });
+      return false;
+    }
+
+    return true;
+  }
+
+  private async handleModerationActionReasonModalSubmit(
+    interaction: ModalSubmitInteraction,
+    input: {
+      action: ModeratorUserAction;
+      targetUserId: string;
+      sourceChannelId?: string;
+      sourceMessageId?: string;
+    }
+  ): Promise<void> {
+    if (!interaction.guildId) {
+      await interaction.reply({
+        content: 'This action can only be performed in a server.',
+        flags: MessageFlags.Ephemeral,
+      });
+      return;
+    }
+
+    if (input.targetUserId === interaction.user.id) {
+      await interaction.reply({
+        content: input.action === 'ban' ? 'You cannot ban yourself.' : 'You cannot kick yourself.',
+        flags: MessageFlags.Ephemeral,
+      });
+      return;
+    }
+
+    if (
+      !(await this.ensureModerationActionAllowed(interaction, interaction.guildId, input.action))
+    ) {
+      return;
+    }
+
+    const providedReason = interaction.fields
+      .getTextInputValue(MODERATION_ACTION_REASON_FIELD_ID)
+      .trim();
+    const reasonRequired = await this.getModerationActionReasonRequired(
+      interaction.guildId,
+      input.action
+    );
+    if (reasonRequired && !providedReason) {
+      await interaction.reply({
+        content:
+          input.action === 'ban' ? 'A ban reason is required.' : 'A kick reason is required.',
+        flags: MessageFlags.Ephemeral,
+      });
+      return;
+    }
+
+    const reason = providedReason || this.getModerationActionDefaultReason(input.action);
+    const guild = await this.client.guilds.fetch(interaction.guildId);
+    if (input.action === 'kick') {
+      const member = await guild.members.fetch(input.targetUserId).catch(() => null);
+      if (!member) {
+        await interaction.reply({
+          content: `Could not find user <@${input.targetUserId}> in this server.`,
+          allowedMentions: { parse: [] },
+          flags: MessageFlags.Ephemeral,
+        });
+        return;
+      }
+    }
+
+    this.pruneModerationActionConfirmations();
+    const id = this.nextModerationActionConfirmationId();
+    this.pendingModerationActionConfirmations.set(id, {
+      action: input.action,
+      targetUserId: input.targetUserId,
+      userId: interaction.user.id,
+      guildId: interaction.guildId,
+      reason,
+      createdAt: Date.now(),
+    });
+
+    const label = this.getModerationActionLabel(input.action);
+    await interaction.reply({
+      content: `${label} for <@${input.targetUserId}>? Confirming will apply this action immediately.`,
+      allowedMentions: { parse: [] },
+      components: [
+        new ActionRowBuilder<ButtonBuilder>().addComponents(
+          new ButtonBuilder()
+            .setCustomId(this.buildModerationActionConfirmationCustomId('confirm', id))
+            .setLabel(label)
+            .setStyle(ButtonStyle.Danger),
+          new ButtonBuilder()
+            .setCustomId(this.buildModerationActionConfirmationCustomId('cancel', id))
+            .setLabel('Cancel')
+            .setStyle(ButtonStyle.Secondary)
+        ),
+      ],
+      flags: MessageFlags.Ephemeral,
+    });
+  }
+
+  private async handleModerationActionConfirmationButton(
+    interaction: ButtonInteraction,
+    guildId: string
+  ): Promise<void> {
+    const parsed = this.parseModerationActionConfirmationCustomId(interaction.customId);
+    if (!parsed) {
+      await interaction.reply({
+        content: 'Unknown moderation confirmation.',
+        flags: MessageFlags.Ephemeral,
+      });
+      return;
+    }
+
+    this.pruneModerationActionConfirmations();
+    const pending = this.pendingModerationActionConfirmations.get(parsed.id);
+    if (!pending) {
+      await interaction.reply({
+        content: 'That confirmation expired. Start the action again if you still want to continue.',
+        flags: MessageFlags.Ephemeral,
+      });
+      return;
+    }
+
+    if (pending.userId !== interaction.user.id || pending.guildId !== guildId) {
+      await interaction.reply({
+        content: 'Only the moderator who started this action can use this confirmation.',
+        flags: MessageFlags.Ephemeral,
+      });
+      return;
+    }
+
+    if (parsed.action === 'cancel') {
+      this.pendingModerationActionConfirmations.delete(parsed.id);
+      await interaction.update({ content: 'Cancelled.', components: [] });
+      return;
+    }
+
+    const confirmationText = pending.action.toUpperCase();
+    const modal = new ModalBuilder()
+      .setCustomId(this.buildModerationActionConfirmationModalCustomId(parsed.id))
+      .setTitle(`Confirm ${this.getModerationActionLabel(pending.action)}`);
+    const input = new TextInputBuilder()
+      .setCustomId('moderation_action_confirmation_text')
+      .setLabel(`Type ${confirmationText} to confirm`)
+      .setStyle(TextInputStyle.Short)
+      .setRequired(true)
+      .setMaxLength(8);
+    modal.addComponents(new ActionRowBuilder<TextInputBuilder>().addComponents(input));
+    await interaction.showModal(modal);
+  }
+
+  private async handleModerationActionConfirmationModalSubmit(
+    interaction: ModalSubmitInteraction,
+    id: string
+  ): Promise<void> {
+    if (!interaction.guildId) {
+      await interaction.reply({
+        content: 'This action can only be performed in a server.',
+        flags: MessageFlags.Ephemeral,
+      });
+      return;
+    }
+
+    this.pruneModerationActionConfirmations();
+    const pending = this.pendingModerationActionConfirmations.get(id);
+    if (!pending) {
+      await interaction.reply({
+        content: 'That confirmation expired. Start the action again if you still want to continue.',
+        flags: MessageFlags.Ephemeral,
+      });
+      return;
+    }
+
+    if (pending.userId !== interaction.user.id || pending.guildId !== interaction.guildId) {
+      await interaction.reply({
+        content: 'Only the moderator who started this action can use this confirmation.',
+        flags: MessageFlags.Ephemeral,
+      });
+      return;
+    }
+
+    const confirmationText = interaction.fields
+      .getTextInputValue('moderation_action_confirmation_text')
+      .trim()
+      .toUpperCase();
+    if (confirmationText !== pending.action.toUpperCase()) {
+      await interaction.reply({
+        content: `Confirmation text did not match. Type ${pending.action.toUpperCase()} to continue.`,
+        flags: MessageFlags.Ephemeral,
+      });
+      return;
+    }
+
+    if (
+      !(await this.ensureModerationActionAllowed(interaction, interaction.guildId, pending.action))
+    ) {
+      return;
+    }
+
+    this.pendingModerationActionConfirmations.delete(id);
+    await interaction.deferReply({ flags: MessageFlags.Ephemeral });
+
+    try {
+      const guild = await this.client.guilds.fetch(interaction.guildId);
+      if (pending.action === 'ban') {
+        const member = await guild.members.fetch(pending.targetUserId).catch(() => null);
+        if (member) {
+          await this.userModerationService.banUser(member, pending.reason, interaction.user);
+        } else {
+          await this.userModerationService.banUserById(
+            guild,
+            pending.targetUserId,
+            pending.reason,
+            interaction.user
+          );
+        }
+        await interaction.editReply({
+          content: `Banned <@${pending.targetUserId}> from this server.`,
+          allowedMentions: { parse: [] },
+        });
+        return;
+      }
+
+      const member = await guild.members.fetch(pending.targetUserId).catch(() => null);
+      if (!member) {
+        await interaction.editReply({
+          content: `Could not find user <@${pending.targetUserId}> in this server.`,
+          allowedMentions: { parse: [] },
+        });
+        return;
+      }
+      await this.userModerationService.kickUser(member, pending.reason, interaction.user);
+      await interaction.editReply({
+        content: `Kicked <@${pending.targetUserId}> from this server.`,
+        allowedMentions: { parse: [] },
+      });
+    } catch (error) {
+      console.error(`Failed to ${pending.action} user from native action:`, error);
+      await interaction.editReply({
+        content: `Failed to ${pending.action} <@${pending.targetUserId}>. Please try again later.`,
+        allowedMentions: { parse: [] },
+      });
+    }
+  }
+
+  private async handleOpenCaseContextModalSubmit(
+    interaction: ModalSubmitInteraction,
+    input: { targetUserId: string } | OpenCaseMessageContextModalData
+  ): Promise<void> {
+    const { targetUserId } = input;
+    if (!interaction.guildId) {
+      await interaction.reply({
+        content: 'This action can only be performed in a server.',
+        flags: MessageFlags.Ephemeral,
+      });
+      return;
+    }
+
+    if (targetUserId === interaction.user.id) {
+      await interaction.reply({
+        content: 'You cannot open a case for yourself.',
+        flags: MessageFlags.Ephemeral,
+      });
+      return;
+    }
+
+    if (
+      !(await this.hasAnyPermission(interaction, interaction.guildId, [
+        PermissionFlagsBits.ModerateMembers,
+      ]))
+    ) {
+      await this.replyPermissionDenied(
+        interaction,
+        'You need Moderate Members permission to open a case.'
+      );
+      return;
+    }
+
+    const reason =
+      interaction.fields.getTextInputValue(OPEN_CASE_CONTEXT_REASON_FIELD_ID).trim() || undefined;
+    const serverConfig = await this.configService.getServerConfig(interaction.guildId);
+    const settings = getDetectionResponseSettings(serverConfig.settings);
+    if (settings.adminCaseOpenRequiresReason && !reason) {
+      await interaction.reply({
+        content: 'A case reason is required.',
+        flags: MessageFlags.Ephemeral,
+      });
+      return;
+    }
+
+    await interaction.deferReply({ flags: MessageFlags.Ephemeral });
+
+    try {
+      const guild = await this.client.guilds.fetch(interaction.guildId);
+      const targetMember = await guild.members.fetch(targetUserId).catch(() => null);
+      if (!targetMember) {
+        await interaction.editReply({
+          content: `Could not find user <@${targetUserId}> in this server.`,
+          allowedMentions: { parse: [] },
+        });
+        return;
+      }
+
+      const sourceMetadata = this.getOpenCaseSourceMetadata(input);
+      const sourceMessage = sourceMetadata
+        ? await this.fetchOpenCaseSourceMessage(
+            sourceMetadata.source_channel_id,
+            sourceMetadata.source_message_id
+          )
+        : undefined;
+      const result = await this.securityActionService.openAdminCase(
+        targetMember,
+        interaction.user,
+        {
+          action: 'open_case',
+          reason,
+          ...(sourceMetadata
+            ? {
+                metadata: sourceMetadata,
+                ...(sourceMessage ? { sourceMessage } : {}),
+              }
+            : {}),
+        }
+      );
+      if (!result.opened) {
+        throw new Error('Case flow returned false');
+      }
+
+      const content = result.caseRoleActive
+        ? `Opened a case for ${targetMember.user.tag} and applied the case role.`
+        : `Opened a case for ${targetMember.user.tag}, but I could not apply the case role. Check bot permissions and role hierarchy.`;
+      await interaction.editReply({
+        content,
+        allowedMentions: { parse: [] },
+      });
+    } catch (error) {
+      console.error('Failed to open case from native user action:', error);
+      await interaction.editReply({
+        content: `Failed to open a case for <@${targetUserId}>. Please try again later.`,
+        allowedMentions: { parse: [] },
+      });
+    }
+  }
+
+  private getOpenCaseSourceMetadata(
+    input: { targetUserId: string } | OpenCaseMessageContextModalData
+  ): { source: string; source_channel_id: string; source_message_id: string } | undefined {
+    if (!('sourceChannelId' in input)) {
+      return undefined;
+    }
+
+    return {
+      source: 'message_context_case',
+      source_channel_id: input.sourceChannelId,
+      source_message_id: input.sourceMessageId,
+    };
+  }
+
+  private async fetchOpenCaseSourceMessage(
+    sourceChannelId: string,
+    sourceMessageId: string
+  ): Promise<Message | undefined> {
+    const channel = await this.client.channels.fetch(sourceChannelId).catch(() => null);
+    if (!channel || !('messages' in channel)) {
+      return undefined;
+    }
+
+    return (await channel.messages.fetch(sourceMessageId).catch(() => null)) ?? undefined;
   }
 
   private async handleVerificationBanModalSubmit(
@@ -1968,6 +2513,15 @@ export class InteractionHandler implements IInteractionHandler {
     }
 
     const finalNotes = interaction.fields.getTextInputValue(VERIFICATION_BAN_NOTES_FIELD_ID).trim();
+    const serverConfig = await this.configService.getServerConfig(interaction.guildId);
+    const settings = getDetectionResponseSettings(serverConfig.settings);
+    if (settings.moderatorBanActionRequiresReason && !finalNotes) {
+      await interaction.reply({
+        content: 'A ban reason is required.',
+        flags: MessageFlags.Ephemeral,
+      });
+      return;
+    }
     const banReason = finalNotes || VERIFICATION_BAN_DEFAULT_REASON;
 
     await interaction.deferReply({ flags: MessageFlags.Ephemeral });
@@ -1989,6 +2543,83 @@ export class InteractionHandler implements IInteractionHandler {
       console.error('Error banning user:', error);
       await interaction.editReply({
         content: 'An error occurred while banning the user.',
+      });
+    }
+  }
+
+  private async handleVerificationKickModalSubmit(
+    interaction: ModalSubmitInteraction
+  ): Promise<void> {
+    if (!interaction.guildId) {
+      await interaction.reply({
+        content: 'This action can only be performed in a server.',
+        flags: MessageFlags.Ephemeral,
+      });
+      return;
+    }
+
+    const userId = interaction.customId.slice(`${VERIFICATION_KICK_MODAL_PREFIX}:`.length);
+    if (!userId) {
+      await interaction.reply({
+        content: 'Unknown kick action.',
+        flags: MessageFlags.Ephemeral,
+      });
+      return;
+    }
+
+    if (
+      !(await this.hasAnyPermission(interaction, interaction.guildId, [
+        PermissionFlagsBits.KickMembers,
+      ]))
+    ) {
+      await this.replyPermissionDenied(
+        interaction,
+        'You need Kick Members permission to kick a user.'
+      );
+      return;
+    }
+    if (!(await this.canUseModeratorKickAction(interaction.guildId, 'case'))) {
+      await interaction.reply({
+        content:
+          'Drasil case kick actions are disabled for this server or the bot lacks Kick Members permission.',
+        flags: MessageFlags.Ephemeral,
+      });
+      return;
+    }
+
+    const providedReason = interaction.fields
+      .getTextInputValue(KICK_ACTION_MODAL_REASON_FIELD_ID)
+      .trim();
+    const serverConfig = await this.configService.getServerConfig(interaction.guildId);
+    const settings = getDetectionResponseSettings(serverConfig.settings);
+    if (settings.moderatorKickActionRequiresReason && !providedReason) {
+      await interaction.reply({
+        content: 'A kick reason is required.',
+        flags: MessageFlags.Ephemeral,
+      });
+      return;
+    }
+
+    const reason = providedReason || VERIFICATION_KICK_DEFAULT_REASON;
+    await interaction.deferReply({ flags: MessageFlags.Ephemeral });
+
+    try {
+      const guild = await this.client.guilds.fetch(interaction.guildId);
+      const member = await guild.members.fetch(userId).catch(() => null);
+      if (!member) {
+        throw new Error('Could not find member in guild');
+      }
+
+      await this.userModerationService.kickUser(member, reason, interaction.user);
+
+      await interaction.editReply({
+        content: `Kicked <@${userId}> and resolved pending verification cases as kicked.`,
+        allowedMentions: { parse: [] },
+      });
+    } catch (error) {
+      console.error('Error kicking user from case action:', error);
+      await interaction.editReply({
+        content: 'An error occurred while kicking the user.',
       });
     }
   }
@@ -2300,32 +2931,102 @@ export class InteractionHandler implements IInteractionHandler {
     });
   }
 
-  private async kickObservedUser(
+  private async showObservedKickModal(
     interaction: ButtonInteraction,
     guildId: string,
     userId: string,
     detectionEventId: string
   ): Promise<void> {
+    const serverConfig = await this.configService.getServerConfig(guildId);
+    const settings = getDetectionResponseSettings(serverConfig.settings);
+    const modal = new ModalBuilder()
+      .setCustomId(`${OBSERVED_KICK_MODAL_PREFIX}:${userId}:${detectionEventId}`)
+      .setTitle('Confirm Observed Kick');
+    const reasonInput = new TextInputBuilder()
+      .setCustomId(KICK_ACTION_MODAL_REASON_FIELD_ID)
+      .setLabel(
+        settings.moderatorKickActionRequiresReason ? 'Kick reason' : 'Kick reason (optional)'
+      )
+      .setStyle(TextInputStyle.Paragraph)
+      .setRequired(settings.moderatorKickActionRequiresReason)
+      .setMaxLength(500)
+      .setPlaceholder(OBSERVED_KICK_DEFAULT_REASON);
+
+    modal.addComponents(new ActionRowBuilder<TextInputBuilder>().addComponents(reasonInput));
+    await interaction.showModal(modal);
+  }
+
+  private async handleObservedKickModalSubmit(interaction: ModalSubmitInteraction): Promise<void> {
+    if (!interaction.guildId) {
+      await interaction.reply({
+        content: 'This action can only be performed in a server.',
+        flags: MessageFlags.Ephemeral,
+      });
+      return;
+    }
+
+    const parsed = this.parseObservedActionCustomId(interaction.customId);
+    if (!parsed || parsed.action !== 'kick_modal') {
+      await interaction.reply({
+        content: 'Unknown observed kick action.',
+        flags: MessageFlags.Ephemeral,
+      });
+      return;
+    }
+    if (
+      !(await this.hasAnyPermission(interaction, interaction.guildId, [
+        PermissionFlagsBits.KickMembers,
+      ]))
+    ) {
+      await this.replyPermissionDenied(
+        interaction,
+        'You need Kick Members permission to kick a user.'
+      );
+      return;
+    }
+    if (!(await this.canUseModeratorKickAction(interaction.guildId, 'observed'))) {
+      await interaction.reply({
+        content:
+          'Drasil observed alert kick actions are disabled for this server or the bot lacks Kick Members permission.',
+        flags: MessageFlags.Ephemeral,
+      });
+      return;
+    }
+
+    const providedReason = interaction.fields
+      .getTextInputValue(KICK_ACTION_MODAL_REASON_FIELD_ID)
+      .trim();
+    const serverConfig = await this.configService.getServerConfig(interaction.guildId);
+    const settings = getDetectionResponseSettings(serverConfig.settings);
+    if (settings.moderatorKickActionRequiresReason && !providedReason) {
+      await interaction.reply({
+        content: 'A kick reason is required.',
+        flags: MessageFlags.Ephemeral,
+      });
+      return;
+    }
+
+    const reason = providedReason || OBSERVED_KICK_DEFAULT_REASON;
+    await interaction.deferReply({ flags: MessageFlags.Ephemeral });
+
     try {
-      const member = await this.getObservedTargetMember(guildId, userId);
+      const member = await this.getObservedTargetMember(interaction.guildId, parsed.userId);
       const kicked = await this.securityActionService.kickObservedDetection(
         member,
-        detectionEventId,
+        parsed.detectionEventId,
         interaction.user,
-        OBSERVED_KICK_DEFAULT_REASON
+        reason
       );
-      await interaction.followUp({
+      await interaction.editReply({
         content: kicked
-          ? `Kicked <@${userId}> from the observed alert.`
-          : `This observed alert for <@${userId}> was already actioned.`,
+          ? `Kicked <@${parsed.userId}> from the observed alert.`
+          : `This observed alert for <@${parsed.userId}> was already actioned.`,
         allowedMentions: { parse: [] },
-        flags: MessageFlags.Ephemeral,
       });
     } catch (error) {
       console.error('Error kicking user from observed alert:', error);
-      await interaction.followUp({
+      await interaction.editReply({
         content: 'An error occurred while kicking the user.',
-        flags: MessageFlags.Ephemeral,
       });
     }
   }
@@ -2343,9 +3044,9 @@ export class InteractionHandler implements IInteractionHandler {
       .setTitle('Confirm Observed Ban');
     const reasonInput = new TextInputBuilder()
       .setCustomId(OBSERVED_ACTION_MODAL_REASON_FIELD_ID)
-      .setLabel(settings.observedActionBanRequiresReason ? 'Ban reason' : 'Ban reason (optional)')
+      .setLabel(settings.moderatorBanActionRequiresReason ? 'Ban reason' : 'Ban reason (optional)')
       .setStyle(TextInputStyle.Paragraph)
-      .setRequired(settings.observedActionBanRequiresReason)
+      .setRequired(settings.moderatorBanActionRequiresReason)
       .setMaxLength(500)
       .setPlaceholder(OBSERVED_BAN_DEFAULT_REASON);
     modal.addComponents(new ActionRowBuilder<TextInputBuilder>().addComponents(reasonInput));
@@ -2394,7 +3095,7 @@ export class InteractionHandler implements IInteractionHandler {
     const providedReason = interaction.fields
       .getTextInputValue(OBSERVED_ACTION_MODAL_REASON_FIELD_ID)
       .trim();
-    if (settings.observedActionBanRequiresReason && !providedReason) {
+    if (settings.moderatorBanActionRequiresReason && !providedReason) {
       await interaction.reply({
         content: 'A ban reason is required.',
         flags: MessageFlags.Ephemeral,

--- a/src/controllers/ModerationCommandHandler.ts
+++ b/src/controllers/ModerationCommandHandler.ts
@@ -1,9 +1,15 @@
 import {
+  ActionRowBuilder,
   ButtonStyle,
   ChatInputCommandInteraction,
   Guild,
+  MessageContextMenuCommandInteraction,
   MessageFlags,
+  ModalBuilder,
   PermissionFlagsBits,
+  TextInputBuilder,
+  TextInputStyle,
+  UserContextMenuCommandInteraction,
 } from 'discord.js';
 import { IConfigService } from '../config/ConfigService';
 import {
@@ -18,9 +24,20 @@ import {
 import { ISecurityActionService } from '../services/SecurityActionService';
 import { IUserModerationService } from '../services/UserModerationService';
 import { getDetectionResponseSettings } from '../utils/detectionResponseSettings';
+import {
+  buildModerationActionReasonModalCustomId,
+  MODERATION_ACTION_REASON_FIELD_ID,
+  MODERATOR_ACTION_BAN_DEFAULT_REASON,
+  MODERATOR_ACTION_KICK_DEFAULT_REASON,
+  ModeratorUserAction,
+} from '../utils/moderationActionCustomIds';
 import { requestSlashCommandConfirmation } from '../utils/slashCommandConfirmations';
 
-type ReplyGuildInstallRequired = (interaction: ChatInputCommandInteraction) => Promise<void>;
+type ModerationCommandInteraction =
+  | ChatInputCommandInteraction
+  | UserContextMenuCommandInteraction
+  | MessageContextMenuCommandInteraction;
+type ReplyGuildInstallRequired = (interaction: ModerationCommandInteraction) => Promise<void>;
 
 const AUDIT_INTEGRITY_RESPONSE_MAX_LENGTH = 1900;
 
@@ -44,7 +61,7 @@ export class ModerationCommandHandler {
       return;
     }
 
-    const reason = interaction.options.getString('reason') || 'No reason provided';
+    const providedReason = interaction.options.getString('reason')?.trim() || undefined;
     const guild = interaction.guild;
     if (!guild) {
       await this.replyGuildInstallRequired(interaction);
@@ -76,6 +93,17 @@ export class ModerationCommandHandler {
       return;
     }
 
+    const serverConfig = await this.configService.getServerConfig(guild.id);
+    const settings = getDetectionResponseSettings(serverConfig.settings);
+    if (settings.moderatorBanActionRequiresReason && !providedReason) {
+      await interaction.reply({
+        content: 'A ban reason is required.',
+        flags: MessageFlags.Ephemeral,
+      });
+      return;
+    }
+
+    const reason = providedReason ?? 'No reason provided';
     const member = await guild.members.fetch(targetUser.id).catch(() => null);
 
     await requestSlashCommandConfirmation(interaction, {
@@ -106,6 +134,173 @@ export class ModerationCommandHandler {
         }
       },
     });
+  }
+
+  public async handleBanUserContextCommand(
+    interaction: UserContextMenuCommandInteraction
+  ): Promise<void> {
+    await this.handleModerationUserContextCommand(interaction, 'ban');
+  }
+
+  public async handleKickUserContextCommand(
+    interaction: UserContextMenuCommandInteraction
+  ): Promise<void> {
+    await this.handleModerationUserContextCommand(interaction, 'kick');
+  }
+
+  public async handleBanMessageContextCommand(
+    interaction: MessageContextMenuCommandInteraction
+  ): Promise<void> {
+    await this.handleModerationMessageContextCommand(interaction, 'ban');
+  }
+
+  public async handleKickMessageContextCommand(
+    interaction: MessageContextMenuCommandInteraction
+  ): Promise<void> {
+    await this.handleModerationMessageContextCommand(interaction, 'kick');
+  }
+
+  private async handleModerationUserContextCommand(
+    interaction: UserContextMenuCommandInteraction,
+    action: ModeratorUserAction
+  ): Promise<void> {
+    const guild = interaction.guild;
+    if (!guild) {
+      await this.replyGuildInstallRequired(interaction);
+      return;
+    }
+
+    await this.showModerationActionReasonModal(interaction, guild, action, interaction.targetUser);
+  }
+
+  private async handleModerationMessageContextCommand(
+    interaction: MessageContextMenuCommandInteraction,
+    action: ModeratorUserAction
+  ): Promise<void> {
+    const guild = interaction.guild;
+    if (!guild) {
+      await this.replyGuildInstallRequired(interaction);
+      return;
+    }
+
+    await this.showModerationActionReasonModal(
+      interaction,
+      guild,
+      action,
+      interaction.targetMessage.author,
+      interaction.targetMessage.channelId,
+      interaction.targetMessage.id
+    );
+  }
+
+  private async showModerationActionReasonModal(
+    interaction: UserContextMenuCommandInteraction | MessageContextMenuCommandInteraction,
+    guild: Guild,
+    action: ModeratorUserAction,
+    targetUser: UserContextMenuCommandInteraction['targetUser'],
+    sourceChannelId?: string,
+    sourceMessageId?: string
+  ): Promise<void> {
+    if (targetUser.id === interaction.user.id) {
+      await interaction.reply({
+        content: action === 'ban' ? 'You cannot ban yourself.' : 'You cannot kick yourself.',
+        flags: MessageFlags.Ephemeral,
+      });
+      return;
+    }
+
+    const requiredPermission =
+      action === 'ban' ? PermissionFlagsBits.BanMembers : PermissionFlagsBits.KickMembers;
+    const permissionName = action === 'ban' ? 'Ban Members' : 'Kick Members';
+    const hasPermission = await this.hasGuildPermission(interaction, guild, requiredPermission);
+    if (!hasPermission) {
+      await interaction.reply({
+        content: `You need ${permissionName} permission to ${action} a user.`,
+        flags: MessageFlags.Ephemeral,
+      });
+      return;
+    }
+
+    if (action === 'ban') {
+      if (!(await this.canUseModeratorBanAction(guild))) {
+        await interaction.reply({
+          content:
+            'Drasil ban actions are disabled for this server or the bot lacks Ban Members permission.',
+          flags: MessageFlags.Ephemeral,
+        });
+        return;
+      }
+    } else {
+      if (!(await this.canUseModeratorKickAction(guild))) {
+        await interaction.reply({
+          content:
+            'Drasil kick actions are disabled for this server or the bot lacks Kick Members permission.',
+          flags: MessageFlags.Ephemeral,
+        });
+        return;
+      }
+
+      const targetMember = await guild.members.fetch(targetUser.id).catch(() => null);
+      if (!targetMember) {
+        await interaction.reply({
+          content: `Could not find user ${targetUser.tag} in this server.`,
+          flags: MessageFlags.Ephemeral,
+        });
+        return;
+      }
+    }
+
+    const serverConfig = await this.configService.getServerConfig(guild.id);
+    const settings = getDetectionResponseSettings(serverConfig.settings);
+    const reasonRequired =
+      action === 'ban'
+        ? settings.moderatorBanActionRequiresReason
+        : settings.moderatorKickActionRequiresReason;
+    const defaultReason =
+      action === 'ban' ? MODERATOR_ACTION_BAN_DEFAULT_REASON : MODERATOR_ACTION_KICK_DEFAULT_REASON;
+    const title = action === 'ban' ? 'Ban User' : 'Kick User';
+    const modal = new ModalBuilder()
+      .setCustomId(
+        buildModerationActionReasonModalCustomId(
+          action,
+          targetUser.id,
+          sourceChannelId,
+          sourceMessageId
+        )
+      )
+      .setTitle(title);
+    const reasonInput = new TextInputBuilder()
+      .setCustomId(MODERATION_ACTION_REASON_FIELD_ID)
+      .setLabel(reasonRequired ? `${title} reason` : `${title} reason (optional)`)
+      .setStyle(TextInputStyle.Paragraph)
+      .setRequired(reasonRequired)
+      .setMaxLength(500)
+      .setPlaceholder(defaultReason);
+
+    modal.addComponents(new ActionRowBuilder<TextInputBuilder>().addComponents(reasonInput));
+    await interaction.showModal(modal);
+  }
+
+  private async hasGuildPermission(
+    interaction: ModerationCommandInteraction,
+    guild: Guild,
+    permission: bigint
+  ): Promise<boolean> {
+    if (
+      interaction.memberPermissions?.has(PermissionFlagsBits.Administrator) ||
+      interaction.memberPermissions?.has(permission)
+    ) {
+      return true;
+    }
+    if (interaction.memberPermissions) {
+      return false;
+    }
+
+    const member = await guild.members.fetch(interaction.user.id).catch(() => null);
+    return (
+      member?.permissions.has(PermissionFlagsBits.Administrator) === true ||
+      member?.permissions.has(permission) === true
+    );
   }
 
   public async handleAuditCommand(interaction: ChatInputCommandInteraction): Promise<void> {
@@ -265,6 +460,21 @@ export class ModerationCommandHandler {
         ? await guild.members.fetchMe().catch(() => null)
         : null);
     return botMember?.permissions.has(PermissionFlagsBits.BanMembers) ?? false;
+  }
+
+  private async canUseModeratorKickAction(guild: Guild): Promise<boolean> {
+    const serverConfig = await this.configService.getServerConfig(guild.id);
+    const settings = getDetectionResponseSettings(serverConfig.settings);
+    if (!settings.moderatorKickActionEnabled) {
+      return false;
+    }
+
+    const botMember =
+      guild.members.me ??
+      (typeof guild.members.fetchMe === 'function'
+        ? await guild.members.fetchMe().catch(() => null)
+        : null);
+    return botMember?.permissions.has(PermissionFlagsBits.KickMembers) ?? false;
   }
 
   private async handleIntegrityAuditCommand(

--- a/src/controllers/commandDefinitions.ts
+++ b/src/controllers/commandDefinitions.ts
@@ -35,6 +35,9 @@ import {
 
 export const REPORT_USER_CONTEXT_COMMAND_NAME = 'Report User';
 export const REPORT_MESSAGE_CONTEXT_COMMAND_NAME = 'Report Message';
+export const OPEN_CASE_CONTEXT_COMMAND_NAME = 'Open Case';
+export const BAN_USER_CONTEXT_COMMAND_NAME = 'Ban User';
+export const KICK_USER_CONTEXT_COMMAND_NAME = 'Kick User';
 
 export interface BuildApplicationCommandsOptions {
   userInstallReportingEnabled: boolean;
@@ -515,13 +518,33 @@ const baseApplicationCommandBuilders = [
         )
         .addSubcommand((subcommand) =>
           subcommand
+            .setName('case-reason-require')
+            .setDescription('Require a reason when staff open a case')
+        )
+        .addSubcommand((subcommand) =>
+          subcommand
+            .setName('case-reason-optional')
+            .setDescription('Allow staff to open cases without a reason')
+        )
+        .addSubcommand((subcommand) =>
+          subcommand
             .setName('ban-reason-require')
-            .setDescription('Require a reason when banning from observed notifications')
+            .setDescription('Require a reason for staff ban actions')
         )
         .addSubcommand((subcommand) =>
           subcommand
             .setName('ban-reason-optional')
-            .setDescription('Allow the default reason when banning from observed notifications')
+            .setDescription('Allow the default reason for staff ban actions')
+        )
+        .addSubcommand((subcommand) =>
+          subcommand
+            .setName('kick-reason-require')
+            .setDescription('Require a reason for staff kick actions')
+        )
+        .addSubcommand((subcommand) =>
+          subcommand
+            .setName('kick-reason-optional')
+            .setDescription('Allow the default reason for staff kick actions')
         )
         .addSubcommand((subcommand) =>
           subcommand
@@ -1141,7 +1164,7 @@ const baseApplicationCommandBuilders = [
     )
     .setIntegrationTypes(ApplicationIntegrationType.GuildInstall)
     .setContexts(InteractionContextType.Guild)
-    .setDefaultMemberPermissions(PermissionFlagsBits.Administrator),
+    .setDefaultMemberPermissions(PermissionFlagsBits.ModerateMembers),
   new SlashCommandBuilder()
     .setName('case')
     .setDescription('Open moderation cases or bulk-intake case-role users')
@@ -1246,6 +1269,42 @@ const baseApplicationCommandBuilders = [
     .setType(ApplicationCommandType.User)
     .setIntegrationTypes(ApplicationIntegrationType.GuildInstall)
     .setContexts(InteractionContextType.Guild),
+  new ContextMenuCommandBuilder()
+    .setName(OPEN_CASE_CONTEXT_COMMAND_NAME)
+    .setType(ApplicationCommandType.User)
+    .setIntegrationTypes(ApplicationIntegrationType.GuildInstall)
+    .setContexts(InteractionContextType.Guild)
+    .setDefaultMemberPermissions(PermissionFlagsBits.ModerateMembers),
+  new ContextMenuCommandBuilder()
+    .setName(OPEN_CASE_CONTEXT_COMMAND_NAME)
+    .setType(ApplicationCommandType.Message)
+    .setIntegrationTypes(ApplicationIntegrationType.GuildInstall)
+    .setContexts(InteractionContextType.Guild)
+    .setDefaultMemberPermissions(PermissionFlagsBits.ModerateMembers),
+  new ContextMenuCommandBuilder()
+    .setName(BAN_USER_CONTEXT_COMMAND_NAME)
+    .setType(ApplicationCommandType.User)
+    .setIntegrationTypes(ApplicationIntegrationType.GuildInstall)
+    .setContexts(InteractionContextType.Guild)
+    .setDefaultMemberPermissions(PermissionFlagsBits.BanMembers),
+  new ContextMenuCommandBuilder()
+    .setName(BAN_USER_CONTEXT_COMMAND_NAME)
+    .setType(ApplicationCommandType.Message)
+    .setIntegrationTypes(ApplicationIntegrationType.GuildInstall)
+    .setContexts(InteractionContextType.Guild)
+    .setDefaultMemberPermissions(PermissionFlagsBits.BanMembers),
+  new ContextMenuCommandBuilder()
+    .setName(KICK_USER_CONTEXT_COMMAND_NAME)
+    .setType(ApplicationCommandType.User)
+    .setIntegrationTypes(ApplicationIntegrationType.GuildInstall)
+    .setContexts(InteractionContextType.Guild)
+    .setDefaultMemberPermissions(PermissionFlagsBits.KickMembers),
+  new ContextMenuCommandBuilder()
+    .setName(KICK_USER_CONTEXT_COMMAND_NAME)
+    .setType(ApplicationCommandType.Message)
+    .setIntegrationTypes(ApplicationIntegrationType.GuildInstall)
+    .setContexts(InteractionContextType.Guild)
+    .setDefaultMemberPermissions(PermissionFlagsBits.KickMembers),
 ];
 
 function buildReportMessageContextCommand(): ContextMenuCommandBuilder {

--- a/src/controllers/commandDefinitions.ts
+++ b/src/controllers/commandDefinitions.ts
@@ -1245,7 +1245,7 @@ const baseApplicationCommandBuilders = [
     )
     .setIntegrationTypes(ApplicationIntegrationType.GuildInstall)
     .setContexts(InteractionContextType.Guild)
-    .setDefaultMemberPermissions(PermissionFlagsBits.Administrator),
+    .setDefaultMemberPermissions(PermissionFlagsBits.ModerateMembers),
   new SlashCommandBuilder()
     .setName('close-report')
     .setDescription('Close the current report intake thread without submitting a report')

--- a/src/repositories/types.ts
+++ b/src/repositories/types.ts
@@ -47,7 +47,10 @@ export interface ServerSettings {
   observed_detection_min_confidence_threshold?: number;
   observed_detection_notification_window_minutes?: number;
   automatic_detection_exempt_moderators?: boolean;
+  admin_case_open_requires_reason?: boolean;
   observed_action_ban_requires_reason?: boolean;
+  moderator_ban_action_requires_reason?: boolean;
+  moderator_kick_action_requires_reason?: boolean;
   moderator_ban_action_enabled?: boolean;
   moderator_kick_action_enabled?: boolean;
   observed_action_kick_enabled?: boolean;

--- a/src/services/SecurityActionService.ts
+++ b/src/services/SecurityActionService.ts
@@ -295,6 +295,7 @@ export interface AdminCaseOptions {
   reason?: string;
   action: AdminCaseAction;
   metadata?: Record<string, unknown>;
+  sourceMessage?: Message;
 }
 
 export interface AdminCaseResult {
@@ -739,6 +740,113 @@ export class SecurityActionService implements ISecurityActionService {
       console.warn(`Failed to refresh user snapshot for case ${verificationEvent.id}:`, error);
       return verificationEvent;
     }
+  }
+
+  private getAdminCaseSourceMetadata(
+    metadata: Record<string, unknown> | undefined
+  ): VerificationEvent['metadata'] | null {
+    const sourceChannelId =
+      typeof metadata?.source_channel_id === 'string' ? metadata.source_channel_id : null;
+    const sourceMessageId =
+      typeof metadata?.source_message_id === 'string' ? metadata.source_message_id : null;
+    if (!sourceChannelId || !sourceMessageId) {
+      return null;
+    }
+
+    return {
+      source_channel_id: sourceChannelId,
+      source_message_id: sourceMessageId,
+      source_messages: [
+        {
+          source_channel_id: sourceChannelId,
+          source_message_id: sourceMessageId,
+          ...(typeof metadata?.source === 'string' ? { source: metadata.source } : {}),
+        },
+      ],
+      ...(typeof metadata?.source === 'string' ? { source: metadata.source } : {}),
+    } as VerificationEvent['metadata'];
+  }
+
+  private mergeSourceMessages(
+    existingMetadata: Record<string, unknown>,
+    sourceMetadata: Record<string, unknown>
+  ): Array<Record<string, string>> | undefined {
+    const sourceChannelId =
+      typeof sourceMetadata.source_channel_id === 'string'
+        ? sourceMetadata.source_channel_id
+        : null;
+    const sourceMessageId =
+      typeof sourceMetadata.source_message_id === 'string'
+        ? sourceMetadata.source_message_id
+        : null;
+    if (!sourceChannelId || !sourceMessageId) {
+      return undefined;
+    }
+
+    const existingSourceMessages = Array.isArray(existingMetadata.source_messages)
+      ? existingMetadata.source_messages.filter(
+          (entry): entry is Record<string, string> =>
+            typeof entry === 'object' &&
+            entry !== null &&
+            typeof (entry as Record<string, unknown>).source_channel_id === 'string' &&
+            typeof (entry as Record<string, unknown>).source_message_id === 'string'
+        )
+      : [];
+    const nextEntry = {
+      source_channel_id: sourceChannelId,
+      source_message_id: sourceMessageId,
+      ...(typeof sourceMetadata.source === 'string' ? { source: sourceMetadata.source } : {}),
+    };
+    const alreadyPresent = existingSourceMessages.some(
+      (entry) =>
+        entry.source_channel_id === nextEntry.source_channel_id &&
+        entry.source_message_id === nextEntry.source_message_id
+    );
+
+    return alreadyPresent ? existingSourceMessages : [...existingSourceMessages, nextEntry];
+  }
+
+  private async mergeActiveCaseMetadata(
+    member: GuildMember,
+    metadata: VerificationEvent['metadata'] | null
+  ): Promise<void> {
+    if (!metadata) {
+      return;
+    }
+
+    try {
+      const activeCase = await this.verificationEventRepository.findActiveByUserAndServer(
+        member.id,
+        member.guild.id
+      );
+      if (!activeCase) {
+        return;
+      }
+
+      await this.verificationEventRepository.update(
+        activeCase.id,
+        {
+          metadata: this.mergeVerificationMetadata(activeCase.metadata, metadata),
+        },
+        { touchUpdatedAt: false }
+      );
+    } catch (error) {
+      console.warn(`Failed to persist source metadata for case on ${member.user.tag}:`, error);
+    }
+  }
+
+  private mergeVerificationMetadata(
+    existing: VerificationEvent['metadata'],
+    next: VerificationEvent['metadata']
+  ): VerificationEvent['metadata'] {
+    const existingRecord = this.metadataToRecord(existing);
+    const nextRecord = this.metadataToRecord(next);
+    const sourceMessages = this.mergeSourceMessages(existingRecord, nextRecord);
+    return {
+      ...existingRecord,
+      ...nextRecord,
+      ...(sourceMessages ? { source_messages: sourceMessages } : {}),
+    } as VerificationEvent['metadata'];
   }
 
   private async adoptObservedNotificationForCase(
@@ -2609,6 +2717,7 @@ export class SecurityActionService implements ISecurityActionService {
         typeof options.metadata?.sourceRoleId === 'string' ? options.metadata.sourceRoleId : null;
       const assignedById =
         typeof options.metadata?.assignedById === 'string' ? options.metadata.assignedById : null;
+      const sourceMetadata = this.getAdminCaseSourceMetadata(options.metadata);
       const assignedByText = assignedById ? `<@${assignedById}>` : 'an unknown moderator';
       const reasonSuffix = normalizedReason ? ` Reason: ${normalizedReason}` : '';
       const reasonText = isRoleIntake
@@ -2661,12 +2770,13 @@ export class SecurityActionService implements ISecurityActionService {
       const handled = await this.handleSuspiciousMember(
         member,
         detectionResult,
-        undefined,
+        options.sourceMessage,
         undefined,
         true,
         moderator
       );
       if (handled) {
+        await this.mergeActiveCaseMetadata(member, sourceMetadata);
         this.captureMemberAnalytics(
           member,
           'admin case opened',

--- a/src/utils/detectionResponseSettings.ts
+++ b/src/utils/detectionResponseSettings.ts
@@ -11,8 +11,13 @@ export const OBSERVED_DETECTION_NOTIFICATION_WINDOW_MINUTES_SETTING_KEY =
   'observed_detection_notification_window_minutes';
 export const AUTOMATIC_DETECTION_EXEMPT_MODERATORS_SETTING_KEY =
   'automatic_detection_exempt_moderators';
+export const ADMIN_CASE_OPEN_REQUIRES_REASON_SETTING_KEY = 'admin_case_open_requires_reason';
 export const OBSERVED_ACTION_BAN_REQUIRES_REASON_SETTING_KEY =
   'observed_action_ban_requires_reason';
+export const MODERATOR_BAN_ACTION_REQUIRES_REASON_SETTING_KEY =
+  'moderator_ban_action_requires_reason';
+export const MODERATOR_KICK_ACTION_REQUIRES_REASON_SETTING_KEY =
+  'moderator_kick_action_requires_reason';
 export const MODERATOR_BAN_ACTION_ENABLED_SETTING_KEY = 'moderator_ban_action_enabled';
 export const MODERATOR_KICK_ACTION_ENABLED_SETTING_KEY = 'moderator_kick_action_enabled';
 export const OBSERVED_ACTION_KICK_ENABLED_SETTING_KEY = 'observed_action_kick_enabled';
@@ -30,6 +35,9 @@ export type DetectionResponseEvent = 'message' | 'join';
 export const DEFAULT_DETECTION_RESPONSE_MODE: DetectionResponseMode = 'restrict';
 export const DEFAULT_MODERATOR_BAN_ACTION_ENABLED = true;
 export const DEFAULT_MODERATOR_KICK_ACTION_ENABLED = true;
+export const DEFAULT_ADMIN_CASE_OPEN_REQUIRES_REASON = false;
+export const DEFAULT_MODERATOR_BAN_ACTION_REQUIRES_REASON = false;
+export const DEFAULT_MODERATOR_KICK_ACTION_REQUIRES_REASON = false;
 export const DEFAULT_OBSERVED_ACTION_KICK_ENABLED = false;
 export const DEFAULT_MESSAGE_DETECTION_AUTO_KICK_ENABLED = false;
 export const DEFAULT_JOIN_DETECTION_AUTO_KICK_ENABLED = false;
@@ -47,7 +55,10 @@ export interface DetectionResponseSettings {
   observedMinConfidenceThreshold: number;
   observedNotificationWindowMinutes: number;
   automaticDetectionExemptModerators: boolean;
+  adminCaseOpenRequiresReason: boolean;
   observedActionBanRequiresReason: boolean;
+  moderatorBanActionRequiresReason: boolean;
+  moderatorKickActionRequiresReason: boolean;
   moderatorBanActionEnabled: boolean;
   moderatorKickActionEnabled: boolean;
   observedActionKickEnabled: boolean;
@@ -113,6 +124,11 @@ export function getDetectionResponseSettings(
     typeof settings[OBSERVED_DETECTION_NOTIFICATION_CHANNEL_ID_SETTING_KEY] === 'string'
       ? settings[OBSERVED_DETECTION_NOTIFICATION_CHANNEL_ID_SETTING_KEY].trim()
       : undefined;
+  const moderatorBanActionRequiresReason =
+    settings[MODERATOR_BAN_ACTION_REQUIRES_REASON_SETTING_KEY] ??
+    (settings[OBSERVED_ACTION_BAN_REQUIRES_REASON_SETTING_KEY] === true
+      ? true
+      : DEFAULT_MODERATOR_BAN_ACTION_REQUIRES_REASON);
 
   return {
     mode,
@@ -134,8 +150,14 @@ export function getDetectionResponseSettings(
     ),
     automaticDetectionExemptModerators:
       settings[AUTOMATIC_DETECTION_EXEMPT_MODERATORS_SETTING_KEY] !== false,
-    observedActionBanRequiresReason:
-      settings[OBSERVED_ACTION_BAN_REQUIRES_REASON_SETTING_KEY] === true,
+    adminCaseOpenRequiresReason:
+      settings[ADMIN_CASE_OPEN_REQUIRES_REASON_SETTING_KEY] ??
+      DEFAULT_ADMIN_CASE_OPEN_REQUIRES_REASON,
+    observedActionBanRequiresReason: moderatorBanActionRequiresReason,
+    moderatorBanActionRequiresReason,
+    moderatorKickActionRequiresReason:
+      settings[MODERATOR_KICK_ACTION_REQUIRES_REASON_SETTING_KEY] ??
+      DEFAULT_MODERATOR_KICK_ACTION_REQUIRES_REASON,
     moderatorBanActionEnabled:
       settings[MODERATOR_BAN_ACTION_ENABLED_SETTING_KEY] ?? DEFAULT_MODERATOR_BAN_ACTION_ENABLED,
     moderatorKickActionEnabled:

--- a/src/utils/moderationActionCustomIds.ts
+++ b/src/utils/moderationActionCustomIds.ts
@@ -1,0 +1,49 @@
+export const MODERATION_ACTION_REASON_MODAL_PREFIX = 'moderation_action_reason';
+export const MODERATION_ACTION_REASON_FIELD_ID = 'moderation_action_reason';
+export const MODERATOR_ACTION_BAN_DEFAULT_REASON = 'Banned by moderator action';
+export const MODERATOR_ACTION_KICK_DEFAULT_REASON = 'Kicked by moderator action';
+
+export type ModeratorUserAction = 'ban' | 'kick';
+
+export interface ModerationActionReasonModalData {
+  readonly action: ModeratorUserAction;
+  readonly targetUserId: string;
+  readonly sourceChannelId?: string;
+  readonly sourceMessageId?: string;
+}
+
+export function buildModerationActionReasonModalCustomId(
+  action: ModeratorUserAction,
+  targetUserId: string,
+  sourceChannelId?: string,
+  sourceMessageId?: string
+): string {
+  const parts = [MODERATION_ACTION_REASON_MODAL_PREFIX, action, targetUserId];
+  if (sourceChannelId && sourceMessageId) {
+    parts.push(sourceChannelId, sourceMessageId);
+  }
+  return parts.join(':');
+}
+
+export function parseModerationActionReasonModalCustomId(
+  customId: string
+): ModerationActionReasonModalData | null {
+  const [prefix, action, targetUserId, sourceChannelId, sourceMessageId] = customId.split(':');
+  if (
+    prefix !== MODERATION_ACTION_REASON_MODAL_PREFIX ||
+    (action !== 'ban' && action !== 'kick') ||
+    !targetUserId
+  ) {
+    return null;
+  }
+
+  if ((sourceChannelId && !sourceMessageId) || (!sourceChannelId && sourceMessageId)) {
+    return null;
+  }
+
+  return {
+    action,
+    targetUserId,
+    ...(sourceChannelId && sourceMessageId ? { sourceChannelId, sourceMessageId } : {}),
+  };
+}


### PR DESCRIPTION
[AGENT]

## What / Why
Adds native Discord context-menu moderation flows for staff: `Open Case`, `Ban User`, and `Kick User` on users and messages. The message case path preserves the selected message as case metadata/evidence, and ban/kick actions share the existing moderation service path instead of implementing one-off command behavior.

This also adds guild policy toggles for requiring reasons on case opens, bans, and kicks, plus a permission audit for the moderation surfaces.

## Linked issues
- Closes #176

## How to test
- `git diff --check`
- `npm run lint -- --quiet`
- `npx prettier --check src/controllers/CommandHandler.ts src/controllers/InteractionHandler.ts src/controllers/CaseCommandHandler.ts src/controllers/ModerationCommandHandler.ts src/controllers/ConfigSubcommandHandler.ts src/controllers/commandDefinitions.ts src/services/SecurityActionService.ts src/utils/detectionResponseSettings.ts src/utils/moderationActionCustomIds.ts src/repositories/types.ts docs/moderation-permissions.md src/__tests__/unit/CommandHandler.case.unit.test.ts src/__tests__/unit/CommandHandler.catalog.unit.test.ts src/__tests__/unit/CommandHandler.config-detection.unit.test.ts src/__tests__/unit/CommandHandler.moderation.unit.test.ts src/__tests__/unit/InteractionHandler.unit.test.ts src/__tests__/unit/SecurityActionService.unit.test.ts src/__tests__/unit/detectionResponseSettings.unit.test.ts`
- `npm run build`
- `npm test`

Integration tests not run locally; this change does not include migrations.

## Risk / rollout
The highest-risk surface is Discord interaction routing: native context commands, modal submits, and confirmation buttons all carry encoded target context and re-check permissions before executing. Ban/kick native actions require a second confirmation modal to reduce accidental destructive actions.

## AI Review Packet
- Primary goal: Add native Discord staff actions for opening cases and taking direct kick/ban action, with configurable reason requirements.
- Non-goals: Replacing report intake, changing automatic detection policy, or introducing new role-based staff configuration.
- Key files changed: `src/controllers/CommandHandler.ts`, `src/controllers/InteractionHandler.ts`, `src/controllers/CaseCommandHandler.ts`, `src/controllers/ModerationCommandHandler.ts`, `src/controllers/ConfigSubcommandHandler.ts`, `src/services/SecurityActionService.ts`, `src/utils/detectionResponseSettings.ts`, `src/utils/moderationActionCustomIds.ts`, `docs/moderation-permissions.md`.
- Invariants this PR must preserve: destructive actions must re-check moderator and bot permissions at execution time; case-opening should use Discord moderation permissions rather than configured case responder roles; selected source messages should remain attached when opening a case from a message context action.
- Manual test notes: local verification covered unit routing and service behavior only; no live Discord staging smoke was run.
- Questions for reviewers: None.

## Merge checklist
- [ ] All PR review threads resolved or explicitly addressed
