### PR TITLE
Add report thread admin actions button

### DIFF
--- a/src/__tests__/unit/InteractionHandler.unit.test.ts
+++ b/src/__tests__/unit/InteractionHandler.unit.test.ts
@@ -24,6 +24,7 @@ import { IAdminActionRepository } from '../../repositories/AdminActionRepository
 import {
   AdminActionType,
   DetectionType,
+  ReportIntakeStatus,
   VerificationEvent,
   VerificationStatus,
 } from '../../repositories/types';
@@ -48,6 +49,7 @@ import {
   buildOpenCaseContextModalCustomId,
   buildOpenCaseMessageContextModalCustomId,
 } from '../../controllers/CaseCommandHandler';
+import { buildReportIntakeAdminActionsCustomId } from '../../utils/reportIntakeAdminActions';
 
 const buildMember = (guildId: string, userId: string, displayName = 'test-user'): GuildMember =>
   ({
@@ -556,6 +558,73 @@ describe('InteractionHandler (unit)', () => {
       content: 'You need Moderate Members permission to open a case.',
       flags: MessageFlags.Ephemeral,
     });
+  });
+
+  it('routes report intake admin action buttons to the report handler', async () => {
+    const staffMember = {
+      ...buildMember('guild-1', 'staff-1'),
+      permissions: {
+        has: jest.fn((permission: bigint) => permission === PermissionFlagsBits.ModerateMembers),
+      },
+    } as unknown as GuildMember;
+    (client.guilds.fetch as jest.Mock).mockResolvedValueOnce({
+      id: 'guild-1',
+      members: { fetch: jest.fn().mockResolvedValue(staffMember) },
+    });
+    const reportIntakeService = {
+      findIntakeById: jest.fn().mockResolvedValue({
+        id: 'intake-1',
+        server_id: 'guild-1',
+        reporter_id: 'reporter-1',
+        thread_id: 'report-thread-1',
+        status: ReportIntakeStatus.COLLECTING_EVIDENCE,
+        summary: null,
+        confirmed_target_user_id: null,
+        created_at: null,
+        updated_at: null,
+        closed_at: null,
+        metadata: null,
+      }),
+    };
+    const handler = new InteractionHandler(
+      client,
+      notificationManager,
+      userModerationService,
+      securityActionService,
+      configService,
+      verificationEventRepository,
+      threadManager,
+      adminActionRepository,
+      undefined,
+      reportIntakeService as any
+    );
+    const interaction = buildInteraction(
+      buildReportIntakeAdminActionsCustomId('intake-1'),
+      'guild-1',
+      {
+        id: 'staff-1',
+      } as User
+    );
+    (interaction as any).channel = {
+      id: 'report-thread-1',
+      isThread: jest.fn().mockReturnValue(true),
+      send: jest.fn().mockResolvedValue(undefined),
+    };
+    (interaction as any).channelId = 'report-thread-1';
+
+    await handler.handleButtonInteraction(interaction);
+
+    expect(interaction.deferReply).toHaveBeenCalledWith({ flags: MessageFlags.Ephemeral });
+    expect((interaction.deferReply as jest.Mock).mock.invocationCallOrder[0]).toBeLessThan(
+      reportIntakeService.findIntakeById.mock.invocationCallOrder[0]
+    );
+    expect(reportIntakeService.findIntakeById).toHaveBeenCalledWith('intake-1');
+    expect(interaction.editReply).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: expect.stringContaining('Admin actions for report intake `intake-1`.'),
+      })
+    );
+    expect(interaction.reply).not.toHaveBeenCalled();
   });
 
   it('handles verify button by calling UserModerationService', async () => {

--- a/src/__tests__/unit/ReportInteractionHandler.unit.test.ts
+++ b/src/__tests__/unit/ReportInteractionHandler.unit.test.ts
@@ -53,6 +53,9 @@ const buildInteraction = (customId: string, guildId: string, user: User): Button
     user,
     deferred: false,
     replied: false,
+    deferUpdate: jest.fn().mockImplementation(async () => {
+      interaction.deferred = true;
+    }),
     deferReply: jest.fn().mockImplementation(async () => {
       interaction.deferred = true;
     }),
@@ -503,13 +506,21 @@ describe('ReportInteractionHandler (unit)', () => {
       content:
         'Opened a private report thread: https://discord.com/channels/report-thread-1\nAdd what happened there.',
     });
-    expect(adminChannel.send).toHaveBeenCalledWith({
-      embeds: [
-        expect.objectContaining({
-          data: expect.objectContaining({ title: 'Report Intake Started' }),
-        }),
-      ],
-      allowedMentions: { parse: [], roles: [], users: [], repliedUser: false },
+    expect(adminChannel.send).toHaveBeenCalledWith(
+      expect.objectContaining({
+        embeds: [
+          expect.objectContaining({
+            data: expect.objectContaining({ title: 'Report Intake Started' }),
+          }),
+        ],
+        allowedMentions: { parse: [], roles: [], users: [], repliedUser: false },
+      })
+    );
+    const adminMessage = (adminChannel.send as jest.Mock).mock.calls[0][0];
+    const adminButton = adminMessage.components[0].toJSON().components[0];
+    expect(adminButton).toMatchObject({
+      custom_id: buildReportIntakeAdminActionsCustomId('intake-1'),
+      label: 'Admin Actions',
     });
     expect(interaction.showModal).not.toHaveBeenCalled();
   });
@@ -751,6 +762,50 @@ describe('ReportInteractionHandler (unit)', () => {
     );
   });
 
+  it('shows the report intake admin menu from the admin notification button', async () => {
+    const staffMember = {
+      ...buildMember('guild-1', 'staff-1'),
+      permissions: {
+        has: jest.fn((permission: bigint) => permission === PermissionFlagsBits.ModerateMembers),
+      },
+    } as unknown as GuildMember;
+    (client.guilds.fetch as jest.Mock).mockResolvedValueOnce({
+      id: 'guild-1',
+      members: { fetch: jest.fn().mockResolvedValue(staffMember) },
+    });
+    const reportThread = {
+      id: 'report-thread-1',
+      isThread: jest.fn().mockReturnValue(true),
+      send: jest.fn().mockResolvedValue(undefined),
+    };
+    (client as any).channels = {
+      fetch: jest.fn().mockResolvedValue(reportThread),
+    };
+    configService.getAdminChannel.mockResolvedValue({ id: 'admin-channel-1' } as any);
+    const reportIntakeService = createReportIntakeService();
+    reportIntakeService.findIntakeById.mockResolvedValue(buildReportIntake());
+    const handler = createHandler(reportIntakeService);
+    const interaction = buildInteraction(
+      buildReportIntakeAdminActionsCustomId('intake-1'),
+      'guild-1',
+      {
+        id: 'staff-1',
+      } as User
+    );
+    (interaction as any).channel = { id: 'admin-channel-1', type: ChannelType.GuildText };
+    (interaction as any).channelId = 'admin-channel-1';
+
+    await handler.handleReportIntakeAdminAction(interaction, interaction.customId);
+
+    expect((client as any).channels.fetch).toHaveBeenCalledWith('report-thread-1');
+    expect(interaction.reply).toHaveBeenCalledWith(
+      expect.objectContaining({
+        flags: MessageFlags.Ephemeral,
+        content: expect.stringContaining('Admin actions for report intake `intake-1`.'),
+      })
+    );
+  });
+
   it('closes a report intake from the admin action confirmation', async () => {
     const staffMember = {
       ...buildMember('guild-1', 'staff-1'),
@@ -787,16 +842,21 @@ describe('ReportInteractionHandler (unit)', () => {
 
     await handler.handleReportIntakeAdminAction(interaction, interaction.customId);
 
+    expect(interaction.deferUpdate).toHaveBeenCalledTimes(1);
+    expect((interaction.deferUpdate as jest.Mock).mock.invocationCallOrder[0]).toBeLessThan(
+      reportIntakeService.closeIntakeForThread.mock.invocationCallOrder[0]
+    );
     expect(reportIntakeService.closeIntakeForThread).toHaveBeenCalledWith({
       threadId: 'report-thread-1',
       closedById: 'staff-1',
       closedByStaff: true,
     });
-    expect(interaction.update).toHaveBeenCalledWith({
+    expect(interaction.editReply).toHaveBeenCalledWith({
       content: 'Report intake closed.',
       components: [],
       allowedMentions: { parse: [] },
     });
+    expect(interaction.update).not.toHaveBeenCalled();
     expect(thread.send).toHaveBeenCalledWith({
       content: 'Report intake closed. No report has been filed.',
       allowedMentions: { parse: [] },

--- a/src/__tests__/unit/ReportInteractionHandler.unit.test.ts
+++ b/src/__tests__/unit/ReportInteractionHandler.unit.test.ts
@@ -713,15 +713,19 @@ describe('ReportInteractionHandler (unit)', () => {
 
     await handler.handleReportIntakeAdminAction(interaction, interaction.customId);
 
+    expect(interaction.deferReply).toHaveBeenCalledWith({ flags: MessageFlags.Ephemeral });
+    expect((interaction.deferReply as jest.Mock).mock.invocationCallOrder[0]).toBeLessThan(
+      reportIntakeService.findIntakeById.mock.invocationCallOrder[0]
+    );
     expect(reportIntakeService.findIntakeById).toHaveBeenCalledWith('intake-1');
-    expect(interaction.reply).toHaveBeenCalledWith(
+    expect(interaction.editReply).toHaveBeenCalledWith(
       expect.objectContaining({
-        flags: MessageFlags.Ephemeral,
         content: expect.stringContaining('Reporter: <@reporter-1>'),
         allowedMentions: { parse: [] },
       })
     );
-    const reply = (interaction.reply as jest.Mock).mock.calls[0][0];
+    expect(interaction.reply).not.toHaveBeenCalled();
+    const reply = (interaction.editReply as jest.Mock).mock.calls[0][0];
     const button = reply.components[0].toJSON().components[0];
     expect(button).toMatchObject({
       custom_id: buildReportIntakeAdminCloseCustomId('intake-1'),
@@ -754,12 +758,16 @@ describe('ReportInteractionHandler (unit)', () => {
 
     await handler.handleReportIntakeAdminAction(interaction, interaction.customId);
 
-    expect(interaction.reply).toHaveBeenCalledWith(
+    expect(interaction.deferReply).toHaveBeenCalledWith({ flags: MessageFlags.Ephemeral });
+    expect((interaction.deferReply as jest.Mock).mock.invocationCallOrder[0]).toBeLessThan(
+      reportIntakeService.findIntakeById.mock.invocationCallOrder[0]
+    );
+    expect(interaction.editReply).toHaveBeenCalledWith(
       expect.objectContaining({
-        flags: MessageFlags.Ephemeral,
         content: 'You need moderation permissions to use report admin actions.',
       })
     );
+    expect(interaction.reply).not.toHaveBeenCalled();
   });
 
   it('shows the report intake admin menu from the admin notification button', async () => {
@@ -797,13 +805,17 @@ describe('ReportInteractionHandler (unit)', () => {
 
     await handler.handleReportIntakeAdminAction(interaction, interaction.customId);
 
+    expect(interaction.deferReply).toHaveBeenCalledWith({ flags: MessageFlags.Ephemeral });
+    expect((interaction.deferReply as jest.Mock).mock.invocationCallOrder[0]).toBeLessThan(
+      reportIntakeService.findIntakeById.mock.invocationCallOrder[0]
+    );
     expect((client as any).channels.fetch).toHaveBeenCalledWith('report-thread-1');
-    expect(interaction.reply).toHaveBeenCalledWith(
+    expect(interaction.editReply).toHaveBeenCalledWith(
       expect.objectContaining({
-        flags: MessageFlags.Ephemeral,
         content: expect.stringContaining('Admin actions for report intake `intake-1`.'),
       })
     );
+    expect(interaction.reply).not.toHaveBeenCalled();
   });
 
   it('closes a report intake from the admin action confirmation', async () => {
@@ -843,6 +855,9 @@ describe('ReportInteractionHandler (unit)', () => {
     await handler.handleReportIntakeAdminAction(interaction, interaction.customId);
 
     expect(interaction.deferUpdate).toHaveBeenCalledTimes(1);
+    expect((interaction.deferUpdate as jest.Mock).mock.invocationCallOrder[0]).toBeLessThan(
+      reportIntakeService.findIntakeById.mock.invocationCallOrder[0]
+    );
     expect((interaction.deferUpdate as jest.Mock).mock.invocationCallOrder[0]).toBeLessThan(
       reportIntakeService.closeIntakeForThread.mock.invocationCallOrder[0]
     );

--- a/src/__tests__/unit/ReportInteractionHandler.unit.test.ts
+++ b/src/__tests__/unit/ReportInteractionHandler.unit.test.ts
@@ -15,10 +15,16 @@ import {
   ReportInteractionHandler,
 } from '../../controllers/ReportInteractionHandler';
 import { IConfigService } from '../../config/ConfigService';
+import { ReportIntake, ReportIntakeStatus } from '../../repositories/types';
 import { IReportIntakeService } from '../../services/ReportIntakeService';
 import { ReportSubmissionService } from '../../services/ReportSubmissionService';
 import { ISecurityActionService } from '../../services/SecurityActionService';
 import { IThreadManager } from '../../services/ThreadManager';
+import {
+  buildReportIntakeAdminActionsCustomId,
+  buildReportIntakeAdminCloseCustomId,
+  buildReportIntakeAdminConfirmCloseCustomId,
+} from '../../utils/reportIntakeAdminActions';
 import {
   REPORT_MESSAGE_MODAL_PREFIX,
   USER_REPORT_REASON_REQUIRED_SETTING_KEY,
@@ -43,6 +49,7 @@ const buildInteraction = (customId: string, guildId: string, user: User): Button
     customId,
     guildId,
     channel: { id: 'channel-1', type: ChannelType.GuildText },
+    channelId: 'channel-1',
     user,
     deferred: false,
     replied: false,
@@ -54,6 +61,9 @@ const buildInteraction = (customId: string, guildId: string, user: User): Button
     }),
     followUp: jest.fn().mockResolvedValue(undefined),
     reply: jest.fn().mockImplementation(async () => {
+      interaction.replied = true;
+    }),
+    update: jest.fn().mockImplementation(async () => {
       interaction.replied = true;
     }),
     showModal: jest.fn().mockResolvedValue(undefined),
@@ -82,9 +92,25 @@ const buildModalInteraction = (
     deferred: false,
   }) as unknown as ModalSubmitInteraction;
 
+const buildReportIntake = (overrides: Partial<ReportIntake> = {}): ReportIntake => ({
+  id: 'intake-1',
+  server_id: 'guild-1',
+  reporter_id: 'reporter-1',
+  thread_id: 'report-thread-1',
+  status: ReportIntakeStatus.COLLECTING_EVIDENCE,
+  summary: null,
+  confirmed_target_user_id: null,
+  created_at: null,
+  updated_at: null,
+  closed_at: null,
+  metadata: null,
+  ...overrides,
+});
+
 const createReportIntakeService = (): jest.Mocked<IReportIntakeService> => ({
-  openIntakeFromThread: jest.fn().mockResolvedValue({} as any),
+  openIntakeFromThread: jest.fn().mockResolvedValue(buildReportIntake()),
   findOpenIntakeForReporter: jest.fn().mockResolvedValue(null),
+  findIntakeById: jest.fn().mockResolvedValue(null),
   handleThreadMessage: jest.fn().mockResolvedValue(false),
   confirmCandidate: jest.fn().mockResolvedValue({ confirmed: false, message: '' }),
   rejectCandidates: jest.fn().mockResolvedValue({ rejected: false, message: '' }),
@@ -470,7 +496,8 @@ describe('ReportInteractionHandler (unit)', () => {
     });
     expect(threadManager.activateReportIntakeThread).toHaveBeenCalledWith(
       expect.objectContaining({ id: 'report-thread-1' }),
-      reporter
+      reporter,
+      'intake-1'
     );
     expect(interaction.editReply).toHaveBeenCalledWith({
       content:
@@ -629,13 +656,152 @@ describe('ReportInteractionHandler (unit)', () => {
       consoleError.mockRestore();
     }
 
-    expect(threadManager.activateReportIntakeThread).toHaveBeenCalledWith(thread, reporter);
+    expect(threadManager.activateReportIntakeThread).toHaveBeenCalledWith(
+      thread,
+      reporter,
+      'intake-1'
+    );
     expect(thread.delete).not.toHaveBeenCalled();
     expect(reportIntakeService.markOpenFailed).not.toHaveBeenCalled();
     expect(interaction.editReply).toHaveBeenLastCalledWith({
       content:
         'Opened a private report thread: https://discord.com/channels/report-thread-1\nAdd what happened there.',
     });
+  });
+
+  it('shows the report intake admin menu to staff from the report thread button', async () => {
+    const staffMember = {
+      ...buildMember('guild-1', 'staff-1'),
+      permissions: {
+        has: jest.fn((permission: bigint) => permission === PermissionFlagsBits.ModerateMembers),
+      },
+    } as unknown as GuildMember;
+    (client.guilds.fetch as jest.Mock).mockResolvedValueOnce({
+      id: 'guild-1',
+      members: { fetch: jest.fn().mockResolvedValue(staffMember) },
+    });
+    const reportIntakeService = createReportIntakeService();
+    reportIntakeService.findIntakeById.mockResolvedValue(
+      buildReportIntake({ confirmed_target_user_id: 'user-1' })
+    );
+    const handler = createHandler(reportIntakeService);
+    const interaction = buildInteraction(
+      buildReportIntakeAdminActionsCustomId('intake-1'),
+      'guild-1',
+      {
+        id: 'staff-1',
+      } as User
+    );
+    const thread = {
+      id: 'report-thread-1',
+      isThread: jest.fn().mockReturnValue(true),
+      send: jest.fn().mockResolvedValue(undefined),
+    };
+    (interaction as any).channel = thread;
+    (interaction as any).channelId = 'report-thread-1';
+
+    await handler.handleReportIntakeAdminAction(interaction, interaction.customId);
+
+    expect(reportIntakeService.findIntakeById).toHaveBeenCalledWith('intake-1');
+    expect(interaction.reply).toHaveBeenCalledWith(
+      expect.objectContaining({
+        flags: MessageFlags.Ephemeral,
+        content: expect.stringContaining('Reporter: <@reporter-1>'),
+        allowedMentions: { parse: [] },
+      })
+    );
+    const reply = (interaction.reply as jest.Mock).mock.calls[0][0];
+    const button = reply.components[0].toJSON().components[0];
+    expect(button).toMatchObject({
+      custom_id: buildReportIntakeAdminCloseCustomId('intake-1'),
+      label: 'Close Report',
+    });
+  });
+
+  it('denies report intake admin actions for non-staff members', async () => {
+    const viewerMember = buildMember('guild-1', 'viewer-1');
+    (client.guilds.fetch as jest.Mock).mockResolvedValueOnce({
+      id: 'guild-1',
+      members: { fetch: jest.fn().mockResolvedValue(viewerMember) },
+    });
+    const reportIntakeService = createReportIntakeService();
+    reportIntakeService.findIntakeById.mockResolvedValue(buildReportIntake());
+    const handler = createHandler(reportIntakeService);
+    const interaction = buildInteraction(
+      buildReportIntakeAdminActionsCustomId('intake-1'),
+      'guild-1',
+      {
+        id: 'viewer-1',
+      } as User
+    );
+    (interaction as any).channel = {
+      id: 'report-thread-1',
+      isThread: jest.fn().mockReturnValue(true),
+      send: jest.fn().mockResolvedValue(undefined),
+    };
+    (interaction as any).channelId = 'report-thread-1';
+
+    await handler.handleReportIntakeAdminAction(interaction, interaction.customId);
+
+    expect(interaction.reply).toHaveBeenCalledWith(
+      expect.objectContaining({
+        flags: MessageFlags.Ephemeral,
+        content: 'You need moderation permissions to use report admin actions.',
+      })
+    );
+  });
+
+  it('closes a report intake from the admin action confirmation', async () => {
+    const staffMember = {
+      ...buildMember('guild-1', 'staff-1'),
+      permissions: {
+        has: jest.fn((permission: bigint) => permission === PermissionFlagsBits.ModerateMembers),
+      },
+    } as unknown as GuildMember;
+    (client.guilds.fetch as jest.Mock).mockResolvedValueOnce({
+      id: 'guild-1',
+      members: { fetch: jest.fn().mockResolvedValue(staffMember) },
+    });
+    const reportIntakeService = createReportIntakeService();
+    reportIntakeService.findIntakeById.mockResolvedValue(buildReportIntake());
+    reportIntakeService.closeIntakeForThread.mockResolvedValue({
+      closed: true,
+      message: 'Report intake closed. No report has been filed.',
+      shouldArchiveThread: true,
+    });
+    const handler = createHandler(reportIntakeService);
+    const interaction = buildInteraction(
+      buildReportIntakeAdminConfirmCloseCustomId('intake-1'),
+      'guild-1',
+      { id: 'staff-1' } as User
+    );
+    const thread = {
+      id: 'report-thread-1',
+      isThread: jest.fn().mockReturnValue(true),
+      send: jest.fn().mockResolvedValue(undefined),
+      archived: false,
+      setArchived: jest.fn().mockResolvedValue(undefined),
+    };
+    (interaction as any).channel = thread;
+    (interaction as any).channelId = 'report-thread-1';
+
+    await handler.handleReportIntakeAdminAction(interaction, interaction.customId);
+
+    expect(reportIntakeService.closeIntakeForThread).toHaveBeenCalledWith({
+      threadId: 'report-thread-1',
+      closedById: 'staff-1',
+      closedByStaff: true,
+    });
+    expect(interaction.update).toHaveBeenCalledWith({
+      content: 'Report intake closed.',
+      components: [],
+      allowedMentions: { parse: [] },
+    });
+    expect(thread.send).toHaveBeenCalledWith({
+      content: 'Report intake closed. No report has been filed.',
+      allowedMentions: { parse: [] },
+    });
+    expect(thread.setArchived).toHaveBeenCalledWith(true, 'Report intake closed');
   });
 
   it('submits a confirmed report intake target through the user report workflow', async () => {

--- a/src/__tests__/unit/ThreadManager.unit.test.ts
+++ b/src/__tests__/unit/ThreadManager.unit.test.ts
@@ -20,6 +20,7 @@ import {
   renderVerificationPromptTemplate,
 } from '../../utils/verificationPromptTemplate';
 import { parseAdminActionCustomId } from '../../utils/adminActionCustomIds';
+import { parseReportIntakeAdminActionCustomId } from '../../utils/reportIntakeAdminActions';
 
 const buildMember = (
   guildId: string,
@@ -819,18 +820,26 @@ describe('ThreadManager (unit)', () => {
     );
     const reporter = buildMember('guild-1', 'reporter-1');
 
-    const activated = await manager.activateReportIntakeThread(thread, reporter);
+    const activated = await manager.activateReportIntakeThread(thread, reporter, 'intake-1');
 
     expect(activated).toBe(true);
     expect(thread.members.add).toHaveBeenCalledWith('reporter-1');
     expect(thread.send).toHaveBeenCalledWith({
       content: expect.stringContaining('Add what happened here.'),
+      components: expect.any(Array),
       allowedMentions: {
         parse: [],
         users: ['reporter-1'],
         roles: [],
         repliedUser: false,
       },
+    });
+    const message = (thread.send as jest.Mock).mock.calls[0][0];
+    const button = message.components[0].toJSON().components[0];
+    expect(button.label).toBe('Admin Actions');
+    expect(parseReportIntakeAdminActionCustomId(button.custom_id)).toEqual({
+      action: 'menu',
+      intakeId: 'intake-1',
     });
   });
 

--- a/src/__tests__/unit/adminActionCustomIds.unit.test.ts
+++ b/src/__tests__/unit/adminActionCustomIds.unit.test.ts
@@ -2,6 +2,11 @@ import {
   buildAdminActionCustomId,
   parseAdminActionCustomId,
 } from '../../utils/adminActionCustomIds';
+import {
+  buildReportIntakeAdminActionsCustomId,
+  buildReportIntakeAdminConfirmCloseCustomId,
+  parseReportIntakeAdminActionCustomId,
+} from '../../utils/reportIntakeAdminActions';
 
 describe('adminActionCustomIds (unit)', () => {
   it('keeps observed confirmation IDs under Discord custom_id limits', () => {
@@ -41,6 +46,24 @@ describe('adminActionCustomIds (unit)', () => {
       surface: 'observed',
       userId,
       detectionEventId,
+    });
+  });
+
+  it('keeps report intake admin action IDs under Discord custom_id limits', () => {
+    const intakeId = '12345678-1234-1234-1234-123456789012';
+
+    const menuCustomId = buildReportIntakeAdminActionsCustomId(intakeId);
+    const confirmCloseCustomId = buildReportIntakeAdminConfirmCloseCustomId(intakeId);
+
+    expect(menuCustomId.length).toBeLessThanOrEqual(100);
+    expect(confirmCloseCustomId.length).toBeLessThanOrEqual(100);
+    expect(parseReportIntakeAdminActionCustomId(menuCustomId)).toEqual({
+      action: 'menu',
+      intakeId,
+    });
+    expect(parseReportIntakeAdminActionCustomId(confirmCloseCustomId)).toEqual({
+      action: 'confirm_close',
+      intakeId,
     });
   });
 });

--- a/src/controllers/InteractionHandler.ts
+++ b/src/controllers/InteractionHandler.ts
@@ -242,6 +242,11 @@ export class InteractionHandler implements IInteractionHandler {
         return;
       }
 
+      if (this.reportInteractionHandler.isReportIntakeAdminActionCustomId(customId)) {
+        await this.reportInteractionHandler.handleReportIntakeAdminAction(interaction, customId);
+        return;
+      }
+
       if (isSlashCommandConfirmationCustomId(customId)) {
         await handleSlashCommandConfirmationButton(interaction);
         return;

--- a/src/controllers/ReportInteractionHandler.ts
+++ b/src/controllers/ReportInteractionHandler.ts
@@ -35,6 +35,7 @@ import {
 import { canModerateReportIntake } from '../utils/reportIntakeStaffAuthorization';
 import { messageAttachmentsToReportMetadata } from '../utils/reportAttachments';
 import {
+  buildReportIntakeAdminActionsCustomId,
   buildReportIntakeAdminCancelCustomId,
   buildReportIntakeAdminCloseCustomId,
   buildReportIntakeAdminConfirmCloseCustomId,
@@ -162,7 +163,7 @@ export class ReportInteractionHandler {
         content: `Opened a private report thread: ${thread.url}\nAdd what happened there.`,
       });
 
-      await this.notifyReportIntakeThreadOpened(guildId, reporter, thread);
+      await this.notifyReportIntakeThreadOpened(guildId, reporter, thread, intake.id);
     } catch (error) {
       console.error('Error opening report intake thread:', error);
       if (thread && !intakeActivated) {
@@ -631,7 +632,12 @@ export class ReportInteractionHandler {
     }
 
     const currentChannelId = interaction.channelId;
-    if (intake.thread_id && currentChannelId && currentChannelId !== intake.thread_id) {
+    if (
+      intake.thread_id &&
+      currentChannelId &&
+      currentChannelId !== intake.thread_id &&
+      !(await this.isReportIntakeAdminNotificationChannel(guildId, currentChannelId))
+    ) {
       await this.respondToReportIntakeAdminInteraction(
         interaction,
         { content: 'This report action does not match the current thread.', components: [] },
@@ -737,6 +743,10 @@ export class ReportInteractionHandler {
       return;
     }
 
+    if (!interaction.deferred && !interaction.replied) {
+      await interaction.deferUpdate();
+    }
+
     const result = await this.reportIntakeService.closeIntakeForThread({
       threadId: context.intake.thread_id,
       closedById: interaction.user.id,
@@ -837,6 +847,17 @@ export class ReportInteractionHandler {
     return isThread ? (channel as unknown as ReportIntakeThreadChannel) : null;
   }
 
+  private async isReportIntakeAdminNotificationChannel(
+    guildId: string,
+    channelId: string
+  ): Promise<boolean> {
+    const adminChannel = await this.configService.getAdminChannel(guildId).catch((error) => {
+      console.warn(`Failed to resolve admin channel for report intake admin action:`, error);
+      return null;
+    });
+    return adminChannel?.id === channelId;
+  }
+
   private buildExistingReportIntakeMessage(guildId: string, threadId: string | null): string {
     if (threadId) {
       return `You already have an open report thread: https://discord.com/channels/${guildId}/${threadId}\nPlease continue there, or use /close-report in that thread if it was opened by mistake.`;
@@ -869,7 +890,8 @@ export class ReportInteractionHandler {
   private async notifyReportIntakeThreadOpened(
     guildId: string,
     reporter: GuildMember,
-    thread: ThreadChannel
+    thread: ThreadChannel,
+    reportIntakeId: string
   ): Promise<void> {
     try {
       const adminChannel = await this.configService.getAdminChannel(guildId);
@@ -879,6 +901,14 @@ export class ReportInteractionHandler {
       await adminChannel?.send({
         ...(content ? { content } : {}),
         embeds: [this.presentationBuilder.createReportIntakeStartedEmbed(reporter, thread)],
+        components: [
+          new ActionRowBuilder<ButtonBuilder>().addComponents(
+            new ButtonBuilder()
+              .setCustomId(buildReportIntakeAdminActionsCustomId(reportIntakeId))
+              .setLabel('Admin Actions')
+              .setStyle(ButtonStyle.Primary)
+          ),
+        ],
         allowedMentions: this.presentationBuilder.createAdminAllowedMentions(roleIds),
       });
     } catch (error) {

--- a/src/controllers/ReportInteractionHandler.ts
+++ b/src/controllers/ReportInteractionHandler.ts
@@ -1,7 +1,11 @@
 import {
+  ActionRowBuilder,
+  ButtonBuilder,
   ButtonInteraction,
+  ButtonStyle,
   ChannelType,
   Client,
+  Guild,
   GuildMember,
   InteractionContextType,
   MessageFlags,
@@ -22,6 +26,7 @@ import { NotificationPresentationBuilder } from '../services/NotificationPresent
 import { type MessageReportAttachment } from '../services/SecurityActionService';
 import { ReportSubmissionService } from '../services/ReportSubmissionService';
 import { IThreadManager } from '../services/ThreadManager';
+import { ReportIntake } from '../repositories/types';
 import { formatDiscordUserIdentity } from '../utils/discordUserIdentity';
 import {
   REPORT_MESSAGE_REASON_FIELD_ID,
@@ -29,12 +34,29 @@ import {
 } from '../utils/userReportSettings';
 import { canModerateReportIntake } from '../utils/reportIntakeStaffAuthorization';
 import { messageAttachmentsToReportMetadata } from '../utils/reportAttachments';
+import {
+  buildReportIntakeAdminCancelCustomId,
+  buildReportIntakeAdminCloseCustomId,
+  buildReportIntakeAdminConfirmCloseCustomId,
+  isReportIntakeAdminActionCustomId,
+  parseReportIntakeAdminActionCustomId,
+} from '../utils/reportIntakeAdminActions';
 
 export const REPORT_USER_INITIATE_CUSTOM_ID = 'report_user_initiate';
 export const REPORT_USER_TYPED_MODAL_ID = 'report_user_modal_submit';
 
 const REPORT_USER_TARGET_FIELD_ID = 'report_target_user_input';
 const REPORT_USER_REASON_FIELD_ID = 'report_reason';
+
+type ReportIntakeThreadChannel = Pick<ThreadChannel, 'id' | 'send'> &
+  Partial<Pick<ThreadChannel, 'archived' | 'setArchived'>>;
+
+interface ReportIntakeAdminContext {
+  intake: ReportIntake;
+  thread: ReportIntakeThreadChannel | null;
+}
+
+type ReportIntakeAdminResponseMode = 'reply' | 'update';
 
 export class ReportInteractionHandler {
   private readonly userResolver: DiscordUserResolver;
@@ -116,7 +138,11 @@ export class ReportInteractionHandler {
         channelId: interaction.channel.id,
       });
 
-      const activated = await this.threadManager.activateReportIntakeThread(thread, reporter);
+      const activated = await this.threadManager.activateReportIntakeThread(
+        thread,
+        reporter,
+        intake.id
+      );
       if (!activated) {
         await this.reportIntakeService.markOpenFailed({
           intakeId: intake.id,
@@ -313,6 +339,72 @@ export class ReportInteractionHandler {
     }
   }
 
+  public isReportIntakeAdminActionCustomId(customId: string): boolean {
+    return isReportIntakeAdminActionCustomId(customId);
+  }
+
+  public async handleReportIntakeAdminAction(
+    interaction: ButtonInteraction,
+    customId: string
+  ): Promise<void> {
+    const parsed = parseReportIntakeAdminActionCustomId(customId);
+    const responseMode: ReportIntakeAdminResponseMode =
+      parsed?.action === 'menu' || !parsed ? 'reply' : 'update';
+
+    try {
+      if (!parsed) {
+        await this.respondToReportIntakeAdminInteraction(
+          interaction,
+          { content: 'Unknown report admin action.', components: [] },
+          responseMode
+        );
+        return;
+      }
+
+      if (parsed.action === 'cancel') {
+        await this.respondToReportIntakeAdminInteraction(
+          interaction,
+          { content: 'Cancelled.', components: [] },
+          'update'
+        );
+        return;
+      }
+
+      const context = await this.resolveReportIntakeAdminContext(
+        interaction,
+        parsed.intakeId,
+        responseMode
+      );
+      if (!context) {
+        return;
+      }
+
+      if (parsed.action === 'menu') {
+        await this.showReportIntakeAdminMenu(interaction, context);
+        return;
+      }
+
+      if (parsed.action === 'close') {
+        await this.showReportIntakeCloseConfirmation(interaction, context.intake);
+        return;
+      }
+
+      await this.closeReportIntakeFromAdminAction(interaction, context);
+    } catch (error) {
+      console.error('Error handling report intake admin action:', error);
+      await this.respondToReportIntakeAdminInteraction(
+        interaction,
+        {
+          content: 'An error occurred while processing this report admin action.',
+          components: [],
+        },
+        responseMode
+      ).catch((replyError) => {
+        console.warn('Failed to respond to report intake admin action error:', replyError);
+      });
+    }
+  }
+
   public async handleReportMessageModalSubmit(interaction: ModalSubmitInteraction): Promise<void> {
     const [, messageId, channelId, targetUserId, guildIdRaw, contextRaw] =
       interaction.customId.split(':');
@@ -504,6 +596,247 @@ export class ReportInteractionHandler {
     }
   }
 
+  private async resolveReportIntakeAdminContext(
+    interaction: ButtonInteraction,
+    intakeId: string,
+    responseMode: ReportIntakeAdminResponseMode
+  ): Promise<ReportIntakeAdminContext | null> {
+    if (!this.reportIntakeService) {
+      await this.respondToReportIntakeAdminInteraction(
+        interaction,
+        { content: 'Report intake tracking is not available.', components: [] },
+        responseMode
+      );
+      return null;
+    }
+
+    const guildId = interaction.guildId;
+    if (!guildId) {
+      await this.respondToReportIntakeAdminInteraction(
+        interaction,
+        { content: 'Report admin actions can only be used in a server.', components: [] },
+        responseMode
+      );
+      return null;
+    }
+
+    const intake = await this.reportIntakeService.findIntakeById(intakeId);
+    if (!intake || intake.server_id !== guildId) {
+      await this.respondToReportIntakeAdminInteraction(
+        interaction,
+        { content: 'This report intake could not be found.', components: [] },
+        responseMode
+      );
+      return null;
+    }
+
+    const currentChannelId = interaction.channelId;
+    if (intake.thread_id && currentChannelId && currentChannelId !== intake.thread_id) {
+      await this.respondToReportIntakeAdminInteraction(
+        interaction,
+        { content: 'This report action does not match the current thread.', components: [] },
+        responseMode
+      );
+      return null;
+    }
+
+    const guild = (interaction.guild as Guild | null) ?? (await this.client.guilds.fetch(guildId));
+    const canModerate = await canModerateReportIntake(
+      guild,
+      interaction.user.id,
+      this.configService
+    );
+    if (!canModerate) {
+      await this.respondToReportIntakeAdminInteraction(
+        interaction,
+        { content: 'You need moderation permissions to use report admin actions.', components: [] },
+        responseMode
+      );
+      return null;
+    }
+
+    const currentThread = this.getThreadChannel(interaction.channel);
+    const thread =
+      currentThread && (!intake.thread_id || currentThread.id === intake.thread_id)
+        ? currentThread
+        : await this.fetchReportIntakeThread(intake.thread_id);
+
+    return { intake, thread };
+  }
+
+  private async showReportIntakeAdminMenu(
+    interaction: ButtonInteraction,
+    context: ReportIntakeAdminContext
+  ): Promise<void> {
+    await this.respondToReportIntakeAdminInteraction(
+      interaction,
+      {
+        content: this.buildReportIntakeAdminMenuMessage(context.intake),
+        components: [
+          new ActionRowBuilder<ButtonBuilder>().addComponents(
+            new ButtonBuilder()
+              .setCustomId(buildReportIntakeAdminCloseCustomId(context.intake.id))
+              .setLabel('Close Report')
+              .setStyle(ButtonStyle.Secondary)
+              .setDisabled(!context.intake.thread_id)
+          ),
+        ],
+      },
+      'reply'
+    );
+  }
+
+  private async showReportIntakeCloseConfirmation(
+    interaction: ButtonInteraction,
+    intake: ReportIntake
+  ): Promise<void> {
+    await this.respondToReportIntakeAdminInteraction(
+      interaction,
+      {
+        content:
+          'Close this report intake thread? The reporter will see the closeout message and the thread will be archived.',
+        components: [
+          new ActionRowBuilder<ButtonBuilder>().addComponents(
+            new ButtonBuilder()
+              .setCustomId(buildReportIntakeAdminConfirmCloseCustomId(intake.id))
+              .setLabel('Confirm Close Report')
+              .setStyle(ButtonStyle.Danger),
+            new ButtonBuilder()
+              .setCustomId(buildReportIntakeAdminCancelCustomId(intake.id))
+              .setLabel('Cancel')
+              .setStyle(ButtonStyle.Secondary)
+          ),
+        ],
+      },
+      'update'
+    );
+  }
+
+  private async closeReportIntakeFromAdminAction(
+    interaction: ButtonInteraction,
+    context: ReportIntakeAdminContext
+  ): Promise<void> {
+    if (!this.reportIntakeService || !context.intake.thread_id) {
+      await this.respondToReportIntakeAdminInteraction(
+        interaction,
+        { content: 'This report intake cannot be closed from this button.', components: [] },
+        'update'
+      );
+      return;
+    }
+
+    if (!context.thread) {
+      await this.respondToReportIntakeAdminInteraction(
+        interaction,
+        {
+          content: 'Could not load this report thread, so the report was not closed.',
+          components: [],
+        },
+        'update'
+      );
+      return;
+    }
+
+    const result = await this.reportIntakeService.closeIntakeForThread({
+      threadId: context.intake.thread_id,
+      closedById: interaction.user.id,
+      closedByStaff: true,
+    });
+
+    if (!result.closed) {
+      await this.respondToReportIntakeAdminInteraction(
+        interaction,
+        { content: result.message, components: [] },
+        'update'
+      );
+      return;
+    }
+
+    await this.respondToReportIntakeAdminInteraction(
+      interaction,
+      { content: 'Report intake closed.', components: [] },
+      'update'
+    );
+
+    await context.thread
+      .send({
+        content: result.message,
+        allowedMentions: { parse: [] },
+      })
+      .catch((error) => {
+        console.warn(
+          `Failed to post report intake closeout message in thread ${context.thread?.id}:`,
+          error
+        );
+      });
+
+    if (result.shouldArchiveThread) {
+      await this.archiveReportIntakeThread(context.thread, 'Report intake closed');
+    }
+  }
+
+  private buildReportIntakeAdminMenuMessage(intake: ReportIntake): string {
+    const targetLine = intake.confirmed_target_user_id
+      ? `Target: <@${intake.confirmed_target_user_id}>`
+      : 'Target: not confirmed yet.';
+
+    return [
+      `Admin actions for report intake \`${intake.id}\`.`,
+      `Reporter: <@${intake.reporter_id}>`,
+      targetLine,
+      `Status: ${intake.status}`,
+    ].join('\n');
+  }
+
+  private async respondToReportIntakeAdminInteraction(
+    interaction: ButtonInteraction,
+    response: { content: string; components?: ActionRowBuilder<ButtonBuilder>[] },
+    mode: ReportIntakeAdminResponseMode
+  ): Promise<void> {
+    const responseWithMentions = {
+      ...response,
+      allowedMentions: { parse: [] },
+    };
+
+    if (mode === 'update') {
+      if (interaction.deferred || interaction.replied) {
+        await interaction.editReply(responseWithMentions);
+        return;
+      }
+
+      await interaction.update(responseWithMentions);
+      return;
+    }
+
+    if (interaction.deferred || interaction.replied) {
+      await interaction.editReply(responseWithMentions);
+      return;
+    }
+
+    await interaction.reply({
+      ...responseWithMentions,
+      flags: MessageFlags.Ephemeral,
+    });
+  }
+
+  private async fetchReportIntakeThread(
+    threadId: string | null
+  ): Promise<ReportIntakeThreadChannel | null> {
+    if (!threadId) {
+      return null;
+    }
+
+    const channels = (this.client as { channels?: Client['channels'] }).channels;
+    const channel = await channels?.fetch(threadId).catch(() => null);
+    const isThread = Boolean(
+      channel &&
+      'isThread' in channel &&
+      typeof channel.isThread === 'function' &&
+      channel.isThread()
+    );
+    return isThread ? (channel as unknown as ReportIntakeThreadChannel) : null;
+  }
+
   private buildExistingReportIntakeMessage(guildId: string, threadId: string | null): string {
     if (threadId) {
       return `You already have an open report thread: https://discord.com/channels/${guildId}/${threadId}\nPlease continue there, or use /close-report in that thread if it was opened by mistake.`;
@@ -573,20 +906,14 @@ export class ReportInteractionHandler {
 
   private getThreadChannel(
     channel: ButtonInteraction['channel']
-  ):
-    | (Pick<ThreadChannel, 'id' | 'send'> &
-        Partial<Pick<ThreadChannel, 'archived' | 'setArchived'>>)
-    | null {
+  ): ReportIntakeThreadChannel | null {
     const isThread = Boolean(
       channel &&
       'isThread' in channel &&
       typeof channel.isThread === 'function' &&
       channel.isThread()
     );
-    return isThread
-      ? (channel as unknown as Pick<ThreadChannel, 'id' | 'send'> &
-          Partial<Pick<ThreadChannel, 'archived' | 'setArchived'>>)
-      : null;
+    return isThread ? (channel as unknown as ReportIntakeThreadChannel) : null;
   }
 
   private formatReportTargetLabel(member: GuildMember): string {

--- a/src/controllers/ReportInteractionHandler.ts
+++ b/src/controllers/ReportInteractionHandler.ts
@@ -371,6 +371,8 @@ export class ReportInteractionHandler {
         return;
       }
 
+      await this.deferReportIntakeAdminInteraction(interaction, responseMode);
+
       const context = await this.resolveReportIntakeAdminContext(
         interaction,
         parsed.intakeId,
@@ -827,6 +829,22 @@ export class ReportInteractionHandler {
       ...responseWithMentions,
       flags: MessageFlags.Ephemeral,
     });
+  }
+
+  private async deferReportIntakeAdminInteraction(
+    interaction: ButtonInteraction,
+    mode: ReportIntakeAdminResponseMode
+  ): Promise<void> {
+    if (interaction.deferred || interaction.replied) {
+      return;
+    }
+
+    if (mode === 'reply') {
+      await interaction.deferReply({ flags: MessageFlags.Ephemeral });
+      return;
+    }
+
+    await interaction.deferUpdate();
   }
 
   private async fetchReportIntakeThread(

--- a/src/services/ReportIntakeService.ts
+++ b/src/services/ReportIntakeService.ts
@@ -61,6 +61,7 @@ export interface IReportIntakeService {
     serverId: string;
     reporterId: string;
   }): Promise<ReportIntake | null>;
+  findIntakeById(intakeId: string): Promise<ReportIntake | null>;
   handleThreadMessage(message: Message): Promise<boolean>;
   confirmCandidate(input: {
     intakeId: string;
@@ -150,6 +151,10 @@ export class ReportIntakeService implements IReportIntakeService {
       input.serverId,
       input.reporterId
     );
+  }
+
+  async findIntakeById(intakeId: string): Promise<ReportIntake | null> {
+    return this.reportIntakeRepository.findById(intakeId);
   }
 
   async handleThreadMessage(message: Message): Promise<boolean> {

--- a/src/services/ThreadManager.ts
+++ b/src/services/ThreadManager.ts
@@ -1,5 +1,8 @@
 import { injectable, inject } from 'inversify';
 import {
+  ActionRowBuilder,
+  ButtonBuilder,
+  ButtonStyle,
   Client,
   Guild,
   GuildMember,
@@ -26,6 +29,7 @@ import {
 import { DetectionResult } from './DetectionOrchestrator';
 import { getCaseResponderSettings } from '../utils/caseResponderSettings';
 import { NotificationPresentationBuilder } from './NotificationPresentationBuilder';
+import { buildReportIntakeAdminActionsCustomId } from '../utils/reportIntakeAdminActions';
 
 export const VERIFICATION_THREAD_TYPE_METADATA_KEY = 'thread_type';
 export const VERIFICATION_THREAD_TYPE = 'verification';
@@ -115,7 +119,11 @@ export interface IThreadManager {
     reporter: GuildMember
   ): Promise<ThreadChannel | null>;
 
-  activateReportIntakeThread(thread: ThreadChannel, reporter: GuildMember): Promise<boolean>;
+  activateReportIntakeThread(
+    thread: ThreadChannel,
+    reporter: GuildMember,
+    reportIntakeId?: string
+  ): Promise<boolean>;
 
   /**
    * Resolve a verification thread
@@ -1151,15 +1159,28 @@ export class ThreadManager implements IThreadManager {
 
   public async activateReportIntakeThread(
     thread: ThreadChannel,
-    reporter: GuildMember
+    reporter: GuildMember,
+    reportIntakeId?: string
   ): Promise<boolean> {
     try {
       await thread.members.add(reporter.id);
 
       await this.addCaseResponderMembers(reporter.guild, thread, [reporter.id]);
 
+      const components = reportIntakeId
+        ? [
+            new ActionRowBuilder<ButtonBuilder>().addComponents(
+              new ButtonBuilder()
+                .setCustomId(buildReportIntakeAdminActionsCustomId(reportIntakeId))
+                .setLabel('Admin Actions')
+                .setStyle(ButtonStyle.Primary)
+            ),
+          ]
+        : [];
+
       await thread.send({
         content: this.buildReportIntakeThreadMessage(reporter),
+        ...(components.length ? { components } : {}),
         allowedMentions: {
           parse: [],
           users: [reporter.id],

--- a/src/utils/reportIntakeAdminActions.ts
+++ b/src/utils/reportIntakeAdminActions.ts
@@ -1,0 +1,80 @@
+export const REPORT_INTAKE_ADMIN_ACTION_CUSTOM_ID_PREFIX = 'report_intake_admin';
+
+const DISCORD_CUSTOM_ID_MAX_LENGTH = 100;
+
+const ACTION_TO_CODE = {
+  menu: 'm',
+  close: 'c',
+  confirm_close: 'cc',
+  cancel: 'x',
+} as const;
+
+const CODE_TO_ACTION = Object.fromEntries(
+  Object.entries(ACTION_TO_CODE).map(([action, code]) => [code, action])
+) as Partial<Record<string, ReportIntakeAdminAction>>;
+
+export type ReportIntakeAdminAction = keyof typeof ACTION_TO_CODE;
+
+export interface ParsedReportIntakeAdminActionCustomId {
+  readonly action: ReportIntakeAdminAction;
+  readonly intakeId: string;
+}
+
+export function buildReportIntakeAdminActionsCustomId(intakeId: string): string {
+  return buildReportIntakeAdminActionCustomId('menu', intakeId);
+}
+
+export function buildReportIntakeAdminCloseCustomId(intakeId: string): string {
+  return buildReportIntakeAdminActionCustomId('close', intakeId);
+}
+
+export function buildReportIntakeAdminConfirmCloseCustomId(intakeId: string): string {
+  return buildReportIntakeAdminActionCustomId('confirm_close', intakeId);
+}
+
+export function buildReportIntakeAdminCancelCustomId(intakeId: string): string {
+  return buildReportIntakeAdminActionCustomId('cancel', intakeId);
+}
+
+export function isReportIntakeAdminActionCustomId(customId: string): boolean {
+  return customId.startsWith(`${REPORT_INTAKE_ADMIN_ACTION_CUSTOM_ID_PREFIX}:`);
+}
+
+export function parseReportIntakeAdminActionCustomId(
+  customId: string
+): ParsedReportIntakeAdminActionCustomId | null {
+  const [prefix, actionCode, intakeId] = customId.split(':');
+  if (prefix !== REPORT_INTAKE_ADMIN_ACTION_CUSTOM_ID_PREFIX || !actionCode || !intakeId) {
+    return null;
+  }
+
+  const action = CODE_TO_ACTION[actionCode] ?? parseLegacyAction(actionCode);
+  if (!action) {
+    return null;
+  }
+
+  return { action, intakeId };
+}
+
+function buildReportIntakeAdminActionCustomId(
+  action: ReportIntakeAdminAction,
+  intakeId: string
+): string {
+  return assertCustomIdLength(
+    [REPORT_INTAKE_ADMIN_ACTION_CUSTOM_ID_PREFIX, ACTION_TO_CODE[action], intakeId].join(':')
+  );
+}
+
+function parseLegacyAction(action: string): ReportIntakeAdminAction | null {
+  return action in ACTION_TO_CODE ? (action as ReportIntakeAdminAction) : null;
+}
+
+function assertCustomIdLength(customId: string): string {
+  if (customId.length > DISCORD_CUSTOM_ID_MAX_LENGTH) {
+    throw new Error(
+      `Report intake admin custom_id exceeds Discord's ${DISCORD_CUSTOM_ID_MAX_LENGTH}-character limit.`
+    );
+  }
+
+  return customId;
+}


### PR DESCRIPTION
[AGENT] Summary: Adds a visible Admin Actions button to report intake threads, with a staff-only close menu that reuses the report closeout/archive flow. Verification: npm run check; npm run format:check.