### PR TITLE
Add moderation inbox action receipts

### DIFF
--- a/apps/web/app/admin/guild/[guildId]/cases/actions.ts
+++ b/apps/web/app/admin/guild/[guildId]/cases/actions.ts
@@ -199,11 +199,12 @@ async function performQueueCaseAction(
   guildId: string,
   caseId: string,
   action: WebCaseAction,
-  formData?: FormData
+  formData?: FormData,
+  returnTo = `/admin/guild/${guildId}/cases/${caseId}`
 ): Promise<CaseActionQueueResult> {
   const [session, token] = await Promise.all([getCurrentAdminSession(), getCurrentDiscordToken()]);
   if (!session || !token) {
-    redirect(`/api/auth/discord?returnTo=/admin/guild/${guildId}/cases/${caseId}`);
+    redirect(`/api/auth/discord?returnTo=${returnTo}`);
   }
 
   const parsedAction = caseActionSchema.parse(action);
@@ -253,7 +254,13 @@ export async function queueInboxCaseAction(
   formData: FormData
 ): Promise<InboxActionState> {
   try {
-    const result = await performQueueCaseAction(guildId, caseId, action, formData);
+    const result = await performQueueCaseAction(
+      guildId,
+      caseId,
+      action,
+      formData,
+      `/admin/guild/${guildId}/inbox`
+    );
     if (!result.requestId) {
       return failedInboxActionState('Drasil did not return an action request receipt.');
     }

--- a/apps/web/app/admin/guild/[guildId]/cases/actions.ts
+++ b/apps/web/app/admin/guild/[guildId]/cases/actions.ts
@@ -3,7 +3,11 @@
 import { revalidatePath } from 'next/cache';
 import { redirect } from 'next/navigation';
 import { caseActionSchema, type CaseAction } from '@drasil/contracts';
-import { createActiveCaseDataAdapter, type WebCaseAction } from '@/lib/activeCaseDataAdapter';
+import {
+  createActiveCaseDataAdapter,
+  type CaseActionQueueResult,
+  type WebCaseAction,
+} from '@/lib/activeCaseDataAdapter';
 import { fetchGuildResources } from '@/lib/discordApi';
 import {
   DISCORD_PERMISSIONS,
@@ -14,6 +18,11 @@ import {
 import { getCurrentAdminSession, getCurrentDiscordToken } from '@/lib/session';
 import { createSetupDataAdapter } from '@/lib/setupDataAdapter';
 import { createSetupDashboardService } from '@/lib/setupDashboardService';
+import {
+  failedInboxActionState,
+  queuedInboxActionState,
+  type InboxActionState,
+} from '@/lib/inboxActionState';
 
 const queuedCaseActions = new Set<CaseAction>([
   'verify_user',
@@ -31,6 +40,7 @@ const queuedCaseActions = new Set<CaseAction>([
 const queueCaseActionErrorMessages = {
   already_handled: 'Case action already completed. Refresh the case queue and try again.',
   case_not_found: 'Case is no longer available. Refresh the case queue and try again.',
+  failed: 'Case action could not be queued. Refresh the inbox and try again.',
   not_allowed: 'Case action is not available for this case state.',
 } as const;
 
@@ -185,12 +195,12 @@ async function assertCanQueueCaseAction(
   return { reason };
 }
 
-export async function queueCaseAction(
+async function performQueueCaseAction(
   guildId: string,
   caseId: string,
   action: WebCaseAction,
   formData?: FormData
-): Promise<void> {
+): Promise<CaseActionQueueResult> {
   const [session, token] = await Promise.all([getCurrentAdminSession(), getCurrentDiscordToken()]);
   if (!session || !token) {
     redirect(`/api/auth/discord?returnTo=/admin/guild/${guildId}/cases/${caseId}`);
@@ -218,10 +228,37 @@ export async function queueCaseAction(
   revalidatePath(`/admin/guild/${guildId}/history`);
 
   if (result.status === 'queued') {
-    return;
+    return result;
   }
 
   throw new Error(
     queueCaseActionErrorMessages[result.status] ?? `Unsupported case action: ${parsedAction}`
   );
+}
+
+export async function queueCaseAction(
+  guildId: string,
+  caseId: string,
+  action: WebCaseAction,
+  formData?: FormData
+): Promise<void> {
+  await performQueueCaseAction(guildId, caseId, action, formData);
+}
+
+export async function queueInboxCaseAction(
+  guildId: string,
+  caseId: string,
+  action: WebCaseAction,
+  _previousState: InboxActionState,
+  formData: FormData
+): Promise<InboxActionState> {
+  try {
+    const result = await performQueueCaseAction(guildId, caseId, action, formData);
+    if (!result.requestId) {
+      return failedInboxActionState('Drasil did not return an action request receipt.');
+    }
+    return queuedInboxActionState({ id: result.requestId, status: 'queued' });
+  } catch (error) {
+    return failedInboxActionState(error);
+  }
 }

--- a/apps/web/app/admin/guild/[guildId]/inbox/actions.ts
+++ b/apps/web/app/admin/guild/[guildId]/inbox/actions.ts
@@ -19,6 +19,13 @@ import { getCurrentAdminSession, getCurrentDiscordToken } from '@/lib/session';
 import { createSetupDataAdapter } from '@/lib/setupDataAdapter';
 import { createSetupDashboardService } from '@/lib/setupDashboardService';
 import { createQueueAttentionActionAdapter } from '@/lib/queueAttentionActionAdapter';
+import {
+  completedInboxActionState,
+  failedInboxActionState,
+  queuedInboxActionState,
+  type InboxActionState,
+} from '@/lib/inboxActionState';
+import type { ModerationActionRequestReceipt } from '@/lib/moderationActionRequestQueue';
 
 type DestructiveObservedAlertAction = Extract<ObservedAlertWebAction, 'kick_user' | 'ban_user'>;
 
@@ -156,6 +163,20 @@ export async function acknowledgeQueueAttentionItem(
   revalidatePath(`/admin/guild/${guildId}/inbox`);
 }
 
+export async function acknowledgeInboxQueueAttentionItem(
+  guildId: string,
+  queueItemId: string,
+  _previousState: InboxActionState,
+  _formData: FormData
+): Promise<InboxActionState> {
+  try {
+    await acknowledgeQueueAttentionItem(guildId, queueItemId);
+    return completedInboxActionState('Reply acknowledged.');
+  } catch (error) {
+    return failedInboxActionState(error);
+  }
+}
+
 export async function acknowledgeQueueAttentionItems(
   guildId: string,
   formData: FormData
@@ -186,13 +207,32 @@ export async function acknowledgeQueueAttentionItems(
   revalidatePath(`/admin/guild/${guildId}/inbox`);
 }
 
-export async function queueObservedAlertAction(
+export async function acknowledgeInboxQueueAttentionItems(
+  guildId: string,
+  _previousState: InboxActionState,
+  formData: FormData
+): Promise<InboxActionState> {
+  try {
+    const queueItemCount = readQueueItemIds(formData).length;
+    if (queueItemCount === 0) {
+      throw new Error('Select at least one reply to acknowledge.');
+    }
+    await acknowledgeQueueAttentionItems(guildId, formData);
+    return completedInboxActionState(
+      `${queueItemCount} ${queueItemCount === 1 ? 'reply' : 'replies'} acknowledged.`
+    );
+  } catch (error) {
+    return failedInboxActionState(error);
+  }
+}
+
+async function performQueueObservedAlertAction(
   guildId: string,
   targetUserId: string,
   detectionEventId: string,
   action: ModerationInboxAction,
   formData?: FormData
-): Promise<void> {
+): Promise<ModerationActionRequestReceipt> {
   const [session, token] = await Promise.all([getCurrentAdminSession(), getCurrentDiscordToken()]);
   if (!session || !token) {
     redirect(`/api/auth/discord?returnTo=/admin/guild/${guildId}/inbox`);
@@ -206,7 +246,7 @@ export async function queueObservedAlertAction(
   const setupService = createSetupDashboardService();
   const guild = await setupService.assertCanManageGuild(guildId, token.accessToken);
   const options = await assertCanQueueObservedAlertAction(parsedAction, guild, formData);
-  const status = await queueObservedAlertActionRequest({
+  const receipt = await queueObservedAlertActionRequest({
     action: parsedAction,
     actorId: session.userId,
     actorSurface: 'web',
@@ -220,7 +260,41 @@ export async function queueObservedAlertAction(
   revalidatePath(`/admin/guild/${guildId}/cases`);
   revalidatePath(`/admin/guild/${guildId}/reports`);
 
-  if (status === 'failed') {
+  if (receipt.status === 'failed') {
     throw new Error('Observed alert action could not be queued. Refresh the inbox and try again.');
+  }
+
+  return receipt;
+}
+
+export async function queueObservedAlertAction(
+  guildId: string,
+  targetUserId: string,
+  detectionEventId: string,
+  action: ModerationInboxAction,
+  formData?: FormData
+): Promise<void> {
+  await performQueueObservedAlertAction(guildId, targetUserId, detectionEventId, action, formData);
+}
+
+export async function queueInboxObservedAlertAction(
+  guildId: string,
+  targetUserId: string,
+  detectionEventId: string,
+  action: ModerationInboxAction,
+  _previousState: InboxActionState,
+  formData: FormData
+): Promise<InboxActionState> {
+  try {
+    const receipt = await performQueueObservedAlertAction(
+      guildId,
+      targetUserId,
+      detectionEventId,
+      action,
+      formData
+    );
+    return queuedInboxActionState(receipt);
+  } catch (error) {
+    return failedInboxActionState(error);
   }
 }

--- a/apps/web/app/admin/guild/[guildId]/inbox/actions.ts
+++ b/apps/web/app/admin/guild/[guildId]/inbox/actions.ts
@@ -18,7 +18,10 @@ import {
 import { getCurrentAdminSession, getCurrentDiscordToken } from '@/lib/session';
 import { createSetupDataAdapter } from '@/lib/setupDataAdapter';
 import { createSetupDashboardService } from '@/lib/setupDashboardService';
-import { createQueueAttentionActionAdapter } from '@/lib/queueAttentionActionAdapter';
+import {
+  createQueueAttentionActionAdapter,
+  type QueueAttentionAcknowledgeStatus,
+} from '@/lib/queueAttentionActionAdapter';
 import {
   completedInboxActionState,
   failedInboxActionState,
@@ -26,6 +29,11 @@ import {
   type InboxActionState,
 } from '@/lib/inboxActionState';
 import type { ModerationActionRequestReceipt } from '@/lib/moderationActionRequestQueue';
+import {
+  formatQueueAttentionAcknowledgement,
+  summarizeQueueAttentionAcknowledgements,
+  type QueueAttentionAcknowledgementSummary,
+} from '@/lib/queueAttentionReceipt';
 
 type DestructiveObservedAlertAction = Extract<ObservedAlertWebAction, 'kick_user' | 'ban_user'>;
 
@@ -146,7 +154,7 @@ async function assertCanQueueObservedAlertAction(
 export async function acknowledgeQueueAttentionItem(
   guildId: string,
   queueItemId: string
-): Promise<void> {
+): Promise<QueueAttentionAcknowledgeStatus> {
   const [session, token] = await Promise.all([getCurrentAdminSession(), getCurrentDiscordToken()]);
   if (!session || !token) {
     redirect(`/api/auth/discord?returnTo=/admin/guild/${guildId}/inbox`);
@@ -154,13 +162,14 @@ export async function acknowledgeQueueAttentionItem(
 
   const setupService = createSetupDashboardService();
   await setupService.assertCanManageGuild(guildId, token.accessToken);
-  await createQueueAttentionActionAdapter().acknowledgeAttentionItem({
+  const result = await createQueueAttentionActionAdapter().acknowledgeAttentionItem({
     guildId,
     queueItemId,
     actor: { id: session.userId, surface: 'web' },
   });
 
   revalidatePath(`/admin/guild/${guildId}/inbox`);
+  return result.status;
 }
 
 export async function acknowledgeInboxQueueAttentionItem(
@@ -170,8 +179,10 @@ export async function acknowledgeInboxQueueAttentionItem(
   _formData: FormData
 ): Promise<InboxActionState> {
   try {
-    await acknowledgeQueueAttentionItem(guildId, queueItemId);
-    return completedInboxActionState('Reply acknowledged.');
+    const status = await acknowledgeQueueAttentionItem(guildId, queueItemId);
+    return completedInboxActionState(
+      formatQueueAttentionAcknowledgement(summarizeQueueAttentionAcknowledgements([status]))
+    );
   } catch (error) {
     return failedInboxActionState(error);
   }
@@ -180,10 +191,10 @@ export async function acknowledgeInboxQueueAttentionItem(
 export async function acknowledgeQueueAttentionItems(
   guildId: string,
   formData: FormData
-): Promise<void> {
+): Promise<QueueAttentionAcknowledgementSummary> {
   const queueItemIds = readQueueItemIds(formData);
   if (queueItemIds.length === 0) {
-    return;
+    return summarizeQueueAttentionAcknowledgements([]);
   }
 
   const [session, token] = await Promise.all([getCurrentAdminSession(), getCurrentDiscordToken()]);
@@ -195,16 +206,19 @@ export async function acknowledgeQueueAttentionItems(
   await setupService.assertCanManageGuild(guildId, token.accessToken);
   const adapter = createQueueAttentionActionAdapter();
   const actor = { id: session.userId, surface: 'web' as const };
+  const statuses: QueueAttentionAcknowledgeStatus[] = [];
 
   for (const queueItemId of queueItemIds) {
-    await adapter.acknowledgeAttentionItem({
+    const result = await adapter.acknowledgeAttentionItem({
       guildId,
       queueItemId,
       actor,
     });
+    statuses.push(result.status);
   }
 
   revalidatePath(`/admin/guild/${guildId}/inbox`);
+  return summarizeQueueAttentionAcknowledgements(statuses);
 }
 
 export async function acknowledgeInboxQueueAttentionItems(
@@ -217,10 +231,8 @@ export async function acknowledgeInboxQueueAttentionItems(
     if (queueItemCount === 0) {
       throw new Error('Select at least one reply to acknowledge.');
     }
-    await acknowledgeQueueAttentionItems(guildId, formData);
-    return completedInboxActionState(
-      `${queueItemCount} ${queueItemCount === 1 ? 'reply' : 'replies'} acknowledged.`
-    );
+    const summary = await acknowledgeQueueAttentionItems(guildId, formData);
+    return completedInboxActionState(formatQueueAttentionAcknowledgement(summary));
   } catch (error) {
     return failedInboxActionState(error);
   }
@@ -293,6 +305,9 @@ export async function queueInboxObservedAlertAction(
       action,
       formData
     );
+    if (receipt.status === 'completed') {
+      return completedInboxActionState('Action was already handled.', receipt.id);
+    }
     return queuedInboxActionState(receipt);
   } catch (error) {
     return failedInboxActionState(error);

--- a/apps/web/app/admin/guild/[guildId]/inbox/page.tsx
+++ b/apps/web/app/admin/guild/[guildId]/inbox/page.tsx
@@ -2,16 +2,18 @@ import { redirect } from 'next/navigation';
 import { ModerationInboxView } from '@/components/inbox/ModerationInboxView';
 import { createActiveCaseDataAdapter } from '@/lib/activeCaseDataAdapter';
 import { createModerationInboxDataAdapter } from '@/lib/moderationInboxDataAdapter';
+import { createModerationActionRequestDataAdapter } from '@/lib/moderationActionRequestDataAdapter';
 import { createReportQueueDataAdapter } from '@/lib/reportQueueDataAdapter';
+import { isWebE2eFixtureMode } from '@/lib/e2eFixtures';
 import { getCurrentAdminSession, getCurrentDiscordToken } from '@/lib/session';
 import { createSetupDashboardService } from '@/lib/setupDashboardService';
 import {
-  acknowledgeQueueAttentionItem,
-  acknowledgeQueueAttentionItems,
-  queueObservedAlertAction,
+  acknowledgeInboxQueueAttentionItem,
+  acknowledgeInboxQueueAttentionItems,
+  queueInboxObservedAlertAction,
 } from './actions';
-import { queueCaseAction } from '../cases/actions';
-import { closeSubmittedReport, openSubmittedReportCase } from '../reports/actions';
+import { queueCaseAction, queueInboxCaseAction } from '../cases/actions';
+import { closeInboxSubmittedReport, openInboxSubmittedReportCase } from '../reports/actions';
 
 type PageProps = {
   readonly params: Promise<{ readonly guildId: string }>;
@@ -28,22 +30,29 @@ export default async function ModerationInboxPage({ params }: PageProps) {
   const guild = await setupService.assertCanManageGuild(guildId, token.accessToken);
   const inboxAdapter = createModerationInboxDataAdapter();
   const activeCaseAdapter = createActiveCaseDataAdapter();
+  const actionRequestAdapter = createModerationActionRequestDataAdapter();
   const reportQueueAdapter = createReportQueueDataAdapter();
-  const items = await inboxAdapter.listInboxItems(guildId);
+  const [items, recentActionRequests] = await Promise.all([
+    inboxAdapter.listInboxItems(guildId),
+    actionRequestAdapter.listRecentRequests(guildId, 25),
+  ]);
 
   return (
     <ModerationInboxView
-      acknowledgeQueueItemAction={acknowledgeQueueAttentionItem}
-      acknowledgeQueueItemsAction={acknowledgeQueueAttentionItems}
+      acknowledgeQueueItemAction={acknowledgeInboxQueueAttentionItem}
+      acknowledgeQueueItemsAction={acknowledgeInboxQueueAttentionItems}
       canOpenReportCases={reportQueueAdapter.canOpenSubmittedReportCase()}
       canQueueCaseActions={activeCaseAdapter.canQueueCaseActions()}
-      closeReportAction={closeSubmittedReport}
+      closeReportAction={closeInboxSubmittedReport}
       guildId={guildId}
       guildName={guild.name}
       items={items}
-      openReportCaseAction={openSubmittedReportCase}
+      openReportCaseAction={openInboxSubmittedReportCase}
+      pollActionRequests={!isWebE2eFixtureMode()}
       queueCaseAction={queueCaseAction}
-      queueObservedAlertAction={queueObservedAlertAction}
+      queueInboxCaseAction={queueInboxCaseAction}
+      queueObservedAlertAction={queueInboxObservedAlertAction}
+      recentActionRequests={recentActionRequests}
       sessionUsername={session.username}
     />
   );

--- a/apps/web/app/admin/guild/[guildId]/inbox/page.tsx
+++ b/apps/web/app/admin/guild/[guildId]/inbox/page.tsx
@@ -34,7 +34,7 @@ export default async function ModerationInboxPage({ params }: PageProps) {
   const reportQueueAdapter = createReportQueueDataAdapter();
   const [items, recentActionRequests] = await Promise.all([
     inboxAdapter.listInboxItems(guildId),
-    actionRequestAdapter.listRecentRequests(guildId, 25),
+    actionRequestAdapter.listInboxRequests(guildId, 25),
   ]);
 
   return (

--- a/apps/web/app/admin/guild/[guildId]/operations/page.tsx
+++ b/apps/web/app/admin/guild/[guildId]/operations/page.tsx
@@ -27,7 +27,7 @@ export default async function OperationsPage({ params }: PageProps) {
   const queueChannelLabel = queueChannel ? `#${queueChannel.name}` : queueChannelId;
   const [integritySnapshot, recentRequests] = await Promise.all([
     createOperationsIntegrityDataAdapter().getSnapshot(guildId),
-    createModerationActionRequestDataAdapter().listRecentRequests(guildId),
+    createModerationActionRequestDataAdapter().listRecentRequests(guildId, 25),
   ]);
 
   return (

--- a/apps/web/app/admin/guild/[guildId]/reports/actions.ts
+++ b/apps/web/app/admin/guild/[guildId]/reports/actions.ts
@@ -9,6 +9,12 @@ import {
 } from '@/lib/reportQueueDataAdapter';
 import { getCurrentAdminSession, getCurrentDiscordToken } from '@/lib/session';
 import { createSetupDashboardService } from '@/lib/setupDashboardService';
+import {
+  completedInboxActionState,
+  failedInboxActionState,
+  queuedInboxActionState,
+  type InboxActionState,
+} from '@/lib/inboxActionState';
 
 const closureActions = new Set<ReportQueueAction>([
   'mark_actioned',
@@ -47,6 +53,21 @@ export async function closeSubmittedReport(
   revalidatePath(`/admin/guild/${guildId}/inbox`);
   revalidatePath(`/admin/guild/${guildId}/reports`);
   revalidatePath(`/admin/guild/${guildId}/reports/${reportId}`);
+}
+
+export async function closeInboxSubmittedReport(
+  guildId: string,
+  reportId: string,
+  action: ReportClosureAction,
+  _previousState: InboxActionState,
+  _formData: FormData
+): Promise<InboxActionState> {
+  try {
+    await closeSubmittedReport(guildId, reportId, action);
+    return completedInboxActionState('Report action completed.');
+  } catch (error) {
+    return failedInboxActionState(error);
+  }
 }
 
 const openCaseErrorMessages = {
@@ -93,4 +114,54 @@ export async function openSubmittedReportCase(guildId: string, reportId: string)
   throw new Error(
     openCaseErrorMessages[result.status] ?? `Unsupported report action: ${parsedAction}`
   );
+}
+
+export async function openInboxSubmittedReportCase(
+  guildId: string,
+  reportId: string,
+  _previousState: InboxActionState,
+  _formData: FormData
+): Promise<InboxActionState> {
+  try {
+    const [session, token] = await Promise.all([
+      getCurrentAdminSession(),
+      getCurrentDiscordToken(),
+    ]);
+    if (!session || !token) {
+      redirect(`/api/auth/discord?returnTo=/admin/guild/${guildId}/inbox`);
+    }
+
+    await createSetupDashboardService().assertCanManageGuild(guildId, token.accessToken);
+    const result = await createReportQueueDataAdapter().openCaseFromSubmittedReport({
+      guildId,
+      reportId,
+      adminId: session.userId,
+    });
+
+    revalidatePath(`/admin/guild/${guildId}/inbox`);
+    revalidatePath(`/admin/guild/${guildId}/cases`);
+    revalidatePath(`/admin/guild/${guildId}/reports`);
+    revalidatePath(`/admin/guild/${guildId}/reports/${reportId}`);
+
+    if (result.status === 'queued' && result.requestId) {
+      return queuedInboxActionState(
+        { id: result.requestId, status: 'queued' },
+        'Open case queued.'
+      );
+    }
+    if (result.status === 'queued') {
+      throw new Error('Drasil did not return an action request receipt.');
+    }
+    if (result.status === 'opened' || result.status === 'case_exists') {
+      return completedInboxActionState(
+        result.status === 'opened' ? 'Case opened.' : 'A linked case already exists.'
+      );
+    }
+
+    throw new Error(
+      openCaseErrorMessages[result.status] ?? `Unsupported report action: ${result.action}`
+    );
+  } catch (error) {
+    return failedInboxActionState(error);
+  }
 }

--- a/apps/web/app/admin/guild/[guildId]/reports/actions.ts
+++ b/apps/web/app/admin/guild/[guildId]/reports/actions.ts
@@ -22,14 +22,15 @@ const closureActions = new Set<ReportQueueAction>([
   'mark_false_positive',
 ]);
 
-export async function closeSubmittedReport(
+async function performCloseSubmittedReport(
   guildId: string,
   reportId: string,
-  action: ReportClosureAction
+  action: ReportClosureAction,
+  returnTo: string
 ): Promise<void> {
   const [session, token] = await Promise.all([getCurrentAdminSession(), getCurrentDiscordToken()]);
   if (!session || !token) {
-    redirect(`/api/auth/discord?returnTo=/admin/guild/${guildId}/reports`);
+    redirect(`/api/auth/discord?returnTo=${returnTo}`);
   }
 
   const parsedAction = reportQueueActionSchema.parse(action);
@@ -55,6 +56,14 @@ export async function closeSubmittedReport(
   revalidatePath(`/admin/guild/${guildId}/reports/${reportId}`);
 }
 
+export async function closeSubmittedReport(
+  guildId: string,
+  reportId: string,
+  action: ReportClosureAction
+): Promise<void> {
+  await performCloseSubmittedReport(guildId, reportId, action, `/admin/guild/${guildId}/reports`);
+}
+
 export async function closeInboxSubmittedReport(
   guildId: string,
   reportId: string,
@@ -63,7 +72,7 @@ export async function closeInboxSubmittedReport(
   _formData: FormData
 ): Promise<InboxActionState> {
   try {
-    await closeSubmittedReport(guildId, reportId, action);
+    await performCloseSubmittedReport(guildId, reportId, action, `/admin/guild/${guildId}/inbox`);
     return completedInboxActionState('Report action completed.');
   } catch (error) {
     return failedInboxActionState(error);

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -756,6 +756,13 @@ select {
   grid-template-columns: minmax(0, 1fr) minmax(160px, auto);
   gap: 16px;
   padding: 16px 18px;
+  scroll-margin-top: 16px;
+}
+
+.request-row:target,
+.request-row:focus {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
 }
 
 .request-row + .request-row {
@@ -959,6 +966,21 @@ select {
 .inbox-detail-section {
   display: grid;
   gap: 10px;
+}
+
+.action-receipt {
+  align-items: center;
+  display: flex;
+  flex-basis: 100%;
+  flex-wrap: wrap;
+  font-size: 0.82rem;
+  gap: 8px;
+  margin-top: 8px;
+  max-width: 34rem;
+}
+
+.action-receipt a {
+  font-weight: 700;
 }
 
 .inbox-empty-result {

--- a/apps/web/components/cases/CaseActionControls.tsx
+++ b/apps/web/components/cases/CaseActionControls.tsx
@@ -1,5 +1,8 @@
 import type { CaseAction } from '@drasil/contracts';
 import { formatCaseAction } from '@/lib/casePresentation';
+import { InboxActionForm, type InboxStateAction } from '@/components/inbox/InboxActionForm';
+import type { InboxActionState } from '@/lib/inboxActionState';
+import type { ModerationActionRequestSummary } from '@/lib/moderationActionRequestDataAdapter';
 
 export type WebCaseAction = Extract<
   CaseAction,
@@ -21,6 +24,14 @@ export type QueueCaseAction = (
   action: WebCaseAction,
   formData?: FormData
 ) => Promise<void>;
+
+export type QueueInboxCaseAction = (
+  guildId: string,
+  caseId: string,
+  action: WebCaseAction,
+  previousState: InboxActionState,
+  formData: FormData
+) => Promise<InboxActionState>;
 
 export const executableCaseActions: readonly WebCaseAction[] = [
   'verify_user',
@@ -44,16 +55,22 @@ export function isExecutableCaseAction(action: string): action is WebCaseAction 
 
 export function CaseActionControls({
   actions,
+  actionRequestsByAction,
   canQueueCaseActions,
   caseId,
   guildId,
   queueCaseAction,
+  queueInboxCaseAction,
 }: {
   readonly actions: readonly CaseAction[];
+  readonly actionRequestsByAction?: Partial<
+    Record<WebCaseAction, ModerationActionRequestSummary | null>
+  >;
   readonly canQueueCaseActions: boolean;
   readonly caseId: string;
   readonly guildId: string;
   readonly queueCaseAction: QueueCaseAction;
+  readonly queueInboxCaseAction?: QueueInboxCaseAction;
 }) {
   const executableActions = executableCaseActions.filter((action) => actions.includes(action));
   if (executableActions.length === 0) {
@@ -71,16 +88,29 @@ export function CaseActionControls({
     <div className="report-action-forms" aria-label="Case actions">
       {standardActions.map((action) =>
         canQueueCaseActions ? (
-          <form action={queueCaseAction.bind(null, guildId, caseId, action)} key={action}>
-            <button className="button secondary compact-button" type="submit">
-              {formatCaseAction(action)}
-            </button>
-          </form>
+          queueInboxCaseAction ? (
+            <InboxActionForm
+              action={queueInboxCaseAction.bind(null, guildId, caseId, action) as InboxStateAction}
+              buttonLabel={formatCaseAction(action)}
+              durableRequest={actionRequestsByAction?.[action]}
+              key={`${caseId}-${action}`}
+              requestBaseHref={`/admin/guild/${guildId}/operations`}
+            />
+          ) : (
+            <form
+              action={queueCaseAction.bind(null, guildId, caseId, action)}
+              key={`${caseId}-${action}`}
+            >
+              <button className="button secondary compact-button" type="submit">
+                {formatCaseAction(action)}
+              </button>
+            </form>
+          )
         ) : (
           <button
             className="button secondary compact-button"
             disabled
-            key={action}
+            key={`${caseId}-${action}`}
             title="Requires the bot-side case action worker"
             type="button"
           >
@@ -90,32 +120,54 @@ export function CaseActionControls({
       )}
       {destructiveActions.map((action) =>
         canQueueCaseActions ? (
-          <details className="destructive-action" key={action}>
+          <details className="destructive-action" key={`${caseId}-${action}`}>
             <summary className="button secondary compact-button destructive-summary">
               {formatCaseAction(action)}
             </summary>
-            <form
-              action={queueCaseAction.bind(null, guildId, caseId, action)}
-              className="destructive-action-panel"
-            >
-              <label className="field destructive-reason">
-                <span>Reason</span>
-                <textarea name="reason" rows={3} />
-              </label>
-              <label className="checkbox-field destructive-confirm">
-                <input name="confirmAction" type="checkbox" />
-                <span>Confirm {formatCaseAction(action)}</span>
-              </label>
-              <button className="button compact-button danger-button" type="submit">
-                Queue {formatCaseAction(action)}
-              </button>
-            </form>
+            {queueInboxCaseAction ? (
+              <InboxActionForm
+                action={
+                  queueInboxCaseAction.bind(null, guildId, caseId, action) as InboxStateAction
+                }
+                buttonClassName="button compact-button danger-button"
+                buttonLabel={`Queue ${formatCaseAction(action)}`}
+                durableRequest={actionRequestsByAction?.[action]}
+                formClassName="destructive-action-panel"
+                requestBaseHref={`/admin/guild/${guildId}/operations`}
+              >
+                <label className="field destructive-reason">
+                  <span>Reason</span>
+                  <textarea name="reason" rows={3} />
+                </label>
+                <label className="checkbox-field destructive-confirm">
+                  <input name="confirmAction" type="checkbox" />
+                  <span>Confirm {formatCaseAction(action)}</span>
+                </label>
+              </InboxActionForm>
+            ) : (
+              <form
+                action={queueCaseAction.bind(null, guildId, caseId, action)}
+                className="destructive-action-panel"
+              >
+                <label className="field destructive-reason">
+                  <span>Reason</span>
+                  <textarea name="reason" rows={3} />
+                </label>
+                <label className="checkbox-field destructive-confirm">
+                  <input name="confirmAction" type="checkbox" />
+                  <span>Confirm {formatCaseAction(action)}</span>
+                </label>
+                <button className="button compact-button danger-button" type="submit">
+                  Queue {formatCaseAction(action)}
+                </button>
+              </form>
+            )}
           </details>
         ) : (
           <button
             className="button secondary compact-button"
             disabled
-            key={action}
+            key={`${caseId}-${action}`}
             title="Requires the bot-side case action worker"
             type="button"
           >

--- a/apps/web/components/inbox/InboxActionForm.tsx
+++ b/apps/web/components/inbox/InboxActionForm.tsx
@@ -1,0 +1,139 @@
+'use client';
+
+import { useActionState, useEffect, useState } from 'react';
+import { useFormStatus } from 'react-dom';
+import type { ReactNode } from 'react';
+import {
+  initialInboxActionState,
+  type InboxActionState,
+  type InboxActionStatus,
+} from '@/lib/inboxActionState';
+import type { ModerationActionRequestSummary } from '@/lib/moderationActionRequestDataAdapter';
+
+export type InboxStateAction = (
+  previousState: InboxActionState,
+  formData: FormData
+) => Promise<InboxActionState>;
+
+function InboxSubmitButton({
+  blocked,
+  buttonClassName,
+  buttonLabel,
+  pendingLabel,
+  submitting,
+}: {
+  readonly blocked: boolean;
+  readonly buttonClassName: string;
+  readonly buttonLabel: string;
+  readonly pendingLabel: string;
+  readonly submitting: boolean;
+}) {
+  const { pending } = useFormStatus();
+
+  return (
+    <button className={buttonClassName} disabled={blocked || pending || submitting} type="submit">
+      {pending || submitting ? pendingLabel : buttonLabel}
+    </button>
+  );
+}
+
+function statusClass(status: InboxActionStatus): string {
+  switch (status) {
+    case 'completed':
+      return 'ok';
+    case 'failed':
+      return 'error';
+    case 'processing':
+      return 'info';
+    case 'queued':
+      return 'warning';
+    case 'idle':
+      return 'neutral';
+  }
+}
+
+function defaultMessage(status: InboxActionStatus): string {
+  switch (status) {
+    case 'completed':
+      return 'Action completed.';
+    case 'failed':
+      return 'Action failed.';
+    case 'processing':
+      return 'Drasil is processing this action.';
+    case 'queued':
+      return 'Action queued for Drasil.';
+    case 'idle':
+      return '';
+  }
+}
+
+export function InboxActionForm({
+  action,
+  buttonClassName = 'button secondary compact-button',
+  buttonLabel,
+  children,
+  durableRequest,
+  formClassName,
+  pendingLabel = 'Submitting...',
+  requestBaseHref,
+}: {
+  readonly action: InboxStateAction;
+  readonly buttonClassName?: string;
+  readonly buttonLabel: string;
+  readonly children?: ReactNode;
+  readonly durableRequest?: ModerationActionRequestSummary | null;
+  readonly formClassName?: string;
+  readonly pendingLabel?: string;
+  readonly requestBaseHref?: string;
+}) {
+  const [localState, formAction] = useActionState(action, initialInboxActionState);
+  const [submitting, setSubmitting] = useState(false);
+
+  useEffect(() => {
+    setSubmitting(false);
+  }, [localState]);
+  const durableApplies =
+    durableRequest !== null &&
+    durableRequest !== undefined &&
+    (localState.status === 'idle' || durableRequest.id === localState.requestId);
+  const status = durableApplies ? durableRequest.status : localState.status;
+  const requestId = durableApplies ? durableRequest.id : localState.requestId;
+  const message = durableApplies
+    ? (durableRequest.lastError ?? durableRequest.resultSummary ?? defaultMessage(status))
+    : (localState.message ?? defaultMessage(status));
+  const durableActionInFlight =
+    durableApplies &&
+    (durableRequest.status === 'queued' || durableRequest.status === 'processing');
+  const showReceipt = status !== 'idle';
+
+  return (
+    <form
+      action={formAction}
+      aria-label={`${buttonLabel} action`}
+      className={formClassName}
+      onSubmit={() => setSubmitting(true)}
+    >
+      {children}
+      <InboxSubmitButton
+        blocked={durableActionInFlight}
+        buttonClassName={buttonClassName}
+        buttonLabel={buttonLabel}
+        pendingLabel={pendingLabel}
+        submitting={submitting}
+      />
+      {showReceipt ? (
+        <div
+          aria-live="polite"
+          className={`action-receipt ${status === 'failed' ? 'danger-text' : ''}`}
+          role={status === 'failed' ? 'alert' : 'status'}
+        >
+          <span className={`status ${statusClass(status)}`}>{status}</span>
+          <span>{message}</span>
+          {requestId && requestBaseHref ? (
+            <a href={`${requestBaseHref}#request-${requestId}`}>View request</a>
+          ) : null}
+        </div>
+      ) : null}
+    </form>
+  );
+}

--- a/apps/web/components/inbox/InboxActionForm.tsx
+++ b/apps/web/components/inbox/InboxActionForm.tsx
@@ -9,6 +9,7 @@ import {
   type InboxActionStatus,
 } from '@/lib/inboxActionState';
 import type { ModerationActionRequestSummary } from '@/lib/moderationActionRequestDataAdapter';
+import { useInboxActionRequestPolling } from './InboxActionRequestPoller';
 
 export type InboxStateAction = (
   previousState: InboxActionState,
@@ -88,6 +89,7 @@ export function InboxActionForm({
 }) {
   const [localState, formAction] = useActionState(action, initialInboxActionState);
   const [submitting, setSubmitting] = useState(false);
+  const setLocalRequestActive = useInboxActionRequestPolling();
 
   useEffect(() => {
     setSubmitting(false);
@@ -103,6 +105,14 @@ export function InboxActionForm({
     : (localState.message ?? defaultMessage(status));
   const actionInFlight = status === 'queued' || status === 'processing';
   const showReceipt = status !== 'idle';
+
+  useEffect(() => {
+    if (!requestId) {
+      return;
+    }
+    setLocalRequestActive(requestId, actionInFlight);
+    return () => setLocalRequestActive(requestId, false);
+  }, [actionInFlight, requestId, setLocalRequestActive]);
 
   return (
     <form

--- a/apps/web/components/inbox/InboxActionForm.tsx
+++ b/apps/web/components/inbox/InboxActionForm.tsx
@@ -101,9 +101,7 @@ export function InboxActionForm({
   const message = durableApplies
     ? (durableRequest.lastError ?? durableRequest.resultSummary ?? defaultMessage(status))
     : (localState.message ?? defaultMessage(status));
-  const durableActionInFlight =
-    durableApplies &&
-    (durableRequest.status === 'queued' || durableRequest.status === 'processing');
+  const actionInFlight = status === 'queued' || status === 'processing';
   const showReceipt = status !== 'idle';
 
   return (
@@ -115,7 +113,7 @@ export function InboxActionForm({
     >
       {children}
       <InboxSubmitButton
-        blocked={durableActionInFlight}
+        blocked={actionInFlight}
         buttonClassName={buttonClassName}
         buttonLabel={buttonLabel}
         pendingLabel={pendingLabel}

--- a/apps/web/components/inbox/InboxActionForm.tsx
+++ b/apps/web/components/inbox/InboxActionForm.tsx
@@ -5,6 +5,7 @@ import { useFormStatus } from 'react-dom';
 import type { ReactNode } from 'react';
 import {
   initialInboxActionState,
+  isInboxActionSubmitBlocked,
   type InboxActionState,
   type InboxActionStatus,
 } from '@/lib/inboxActionState';
@@ -111,7 +112,6 @@ export function InboxActionForm({
       return;
     }
     setLocalRequestActive(requestId, actionInFlight);
-    return () => setLocalRequestActive(requestId, false);
   }, [actionInFlight, requestId, setLocalRequestActive]);
 
   return (
@@ -123,7 +123,7 @@ export function InboxActionForm({
     >
       {children}
       <InboxSubmitButton
-        blocked={actionInFlight}
+        blocked={isInboxActionSubmitBlocked(status)}
         buttonClassName={buttonClassName}
         buttonLabel={buttonLabel}
         pendingLabel={pendingLabel}

--- a/apps/web/components/inbox/InboxActionForm.tsx
+++ b/apps/web/components/inbox/InboxActionForm.tsx
@@ -1,11 +1,13 @@
 'use client';
 
-import { useActionState, useEffect, useState } from 'react';
+import { useActionState, useEffect, useRef, useState } from 'react';
 import { useFormStatus } from 'react-dom';
 import type { ReactNode } from 'react';
 import {
   initialInboxActionState,
+  isInboxActionInFlight,
   isInboxActionSubmitBlocked,
+  shouldUseDurableInboxActionState,
   type InboxActionState,
   type InboxActionStatus,
 } from '@/lib/inboxActionState';
@@ -90,6 +92,7 @@ export function InboxActionForm({
 }) {
   const [localState, formAction] = useActionState(action, initialInboxActionState);
   const [submitting, setSubmitting] = useState(false);
+  const durableUpdatedAtAtSubmit = useRef<string | null>(null);
   const setLocalRequestActive = useInboxActionRequestPolling();
 
   useEffect(() => {
@@ -98,13 +101,13 @@ export function InboxActionForm({
   const durableApplies =
     durableRequest !== null &&
     durableRequest !== undefined &&
-    (localState.status === 'idle' || durableRequest.id === localState.requestId);
+    shouldUseDurableInboxActionState(localState, durableRequest, durableUpdatedAtAtSubmit.current);
   const status = durableApplies ? durableRequest.status : localState.status;
   const requestId = durableApplies ? durableRequest.id : localState.requestId;
   const message = durableApplies
     ? (durableRequest.lastError ?? durableRequest.resultSummary ?? defaultMessage(status))
     : (localState.message ?? defaultMessage(status));
-  const actionInFlight = status === 'queued' || status === 'processing';
+  const actionInFlight = isInboxActionInFlight(status);
   const showReceipt = status !== 'idle';
 
   useEffect(() => {
@@ -119,7 +122,10 @@ export function InboxActionForm({
       action={formAction}
       aria-label={`${buttonLabel} action`}
       className={formClassName}
-      onSubmit={() => setSubmitting(true)}
+      onSubmit={() => {
+        durableUpdatedAtAtSubmit.current = durableRequest?.updatedAt ?? null;
+        setSubmitting(true);
+      }}
     >
       {children}
       <InboxSubmitButton

--- a/apps/web/components/inbox/InboxActionRequestPoller.tsx
+++ b/apps/web/components/inbox/InboxActionRequestPoller.tsx
@@ -1,12 +1,48 @@
 'use client';
 
-import { useEffect } from 'react';
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from 'react';
 import { useRouter } from 'next/navigation';
 
 const REFRESH_INTERVAL_MS = 2_000;
+type SetLocalRequestActive = (requestId: string, active: boolean) => void;
 
-export function InboxActionRequestPoller({ active }: { readonly active: boolean }) {
+const InboxActionRequestPollingContext = createContext<SetLocalRequestActive>(() => undefined);
+
+function EnabledInboxActionRequestPolling({
+  children,
+  serverActive,
+}: {
+  readonly children: ReactNode;
+  readonly serverActive: boolean;
+}) {
   const router = useRouter();
+  const [localActiveRequestIds, setLocalActiveRequestIds] = useState<ReadonlySet<string>>(
+    new Set()
+  );
+  const setLocalRequestActive = useCallback<SetLocalRequestActive>((requestId, active) => {
+    setLocalActiveRequestIds((previous) => {
+      if (previous.has(requestId) === active) {
+        return previous;
+      }
+
+      const next = new Set(previous);
+      if (active) {
+        next.add(requestId);
+      } else {
+        next.delete(requestId);
+      }
+      return next;
+    });
+  }, []);
+  const active = serverActive || localActiveRequestIds.size > 0;
 
   useEffect(() => {
     if (!active) {
@@ -17,5 +53,33 @@ export function InboxActionRequestPoller({ active }: { readonly active: boolean 
     return () => window.clearInterval(interval);
   }, [active, router]);
 
-  return null;
+  const contextValue = useMemo(() => setLocalRequestActive, [setLocalRequestActive]);
+  return (
+    <InboxActionRequestPollingContext.Provider value={contextValue}>
+      {children}
+    </InboxActionRequestPollingContext.Provider>
+  );
+}
+
+export function InboxActionRequestPollingProvider({
+  children,
+  enabled,
+  serverActive,
+}: {
+  readonly children: ReactNode;
+  readonly enabled: boolean;
+  readonly serverActive: boolean;
+}) {
+  if (!enabled) {
+    return children;
+  }
+  return (
+    <EnabledInboxActionRequestPolling serverActive={serverActive}>
+      {children}
+    </EnabledInboxActionRequestPolling>
+  );
+}
+
+export function useInboxActionRequestPolling(): SetLocalRequestActive {
+  return useContext(InboxActionRequestPollingContext);
 }

--- a/apps/web/components/inbox/InboxActionRequestPoller.tsx
+++ b/apps/web/components/inbox/InboxActionRequestPoller.tsx
@@ -1,0 +1,21 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+
+const REFRESH_INTERVAL_MS = 2_000;
+
+export function InboxActionRequestPoller({ active }: { readonly active: boolean }) {
+  const router = useRouter();
+
+  useEffect(() => {
+    if (!active) {
+      return;
+    }
+
+    const interval = window.setInterval(() => router.refresh(), REFRESH_INTERVAL_MS);
+    return () => window.clearInterval(interval);
+  }, [active, router]);
+
+  return null;
+}

--- a/apps/web/components/inbox/InboxActionRequestPoller.tsx
+++ b/apps/web/components/inbox/InboxActionRequestPoller.tsx
@@ -10,6 +10,11 @@ import {
   type ReactNode,
 } from 'react';
 import { useRouter } from 'next/navigation';
+import {
+  hasActiveInboxActionRequests,
+  reconcileLocalInboxActionRequestIds,
+} from '@/lib/inboxActionReceipts';
+import type { ModerationActionRequestSummary } from '@/lib/moderationActionRequestDataAdapter';
 
 const REFRESH_INTERVAL_MS = 2_000;
 type SetLocalRequestActive = (requestId: string, active: boolean) => void;
@@ -18,10 +23,10 @@ const InboxActionRequestPollingContext = createContext<SetLocalRequestActive>(()
 
 function EnabledInboxActionRequestPolling({
   children,
-  serverActive,
+  serverRequests,
 }: {
   readonly children: ReactNode;
-  readonly serverActive: boolean;
+  readonly serverRequests: readonly ModerationActionRequestSummary[];
 }) {
   const router = useRouter();
   const [localActiveRequestIds, setLocalActiveRequestIds] = useState<ReadonlySet<string>>(
@@ -42,7 +47,14 @@ function EnabledInboxActionRequestPolling({
       return next;
     });
   }, []);
+  const serverActive = hasActiveInboxActionRequests(serverRequests);
   const active = serverActive || localActiveRequestIds.size > 0;
+
+  useEffect(() => {
+    setLocalActiveRequestIds((previous) =>
+      reconcileLocalInboxActionRequestIds(previous, serverRequests)
+    );
+  }, [serverRequests]);
 
   useEffect(() => {
     if (!active) {
@@ -64,17 +76,17 @@ function EnabledInboxActionRequestPolling({
 export function InboxActionRequestPollingProvider({
   children,
   enabled,
-  serverActive,
+  serverRequests,
 }: {
   readonly children: ReactNode;
   readonly enabled: boolean;
-  readonly serverActive: boolean;
+  readonly serverRequests: readonly ModerationActionRequestSummary[];
 }) {
   if (!enabled) {
     return children;
   }
   return (
-    <EnabledInboxActionRequestPolling serverActive={serverActive}>
+    <EnabledInboxActionRequestPolling serverRequests={serverRequests}>
       {children}
     </EnabledInboxActionRequestPolling>
   );

--- a/apps/web/components/inbox/ModerationInboxView.stories.tsx
+++ b/apps/web/components/inbox/ModerationInboxView.stories.tsx
@@ -1,11 +1,10 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { ModerationInboxView } from './ModerationInboxView';
 import { fixtureModerationInboxItems } from '@/lib/inboxFixtures';
+import { completedInboxActionState } from '@/lib/inboxActionState';
 
-const noopAcknowledgeQueueItemAction = async () => undefined;
+const noopInboxAction = async () => completedInboxActionState('Fixture action completed.');
 const noopCaseAction = async () => undefined;
-const noopReportAction = async () => undefined;
-const noopQueueObservedAlertAction = async () => undefined;
 
 const meta = {
   title: 'Active Triage/Moderation Inbox',
@@ -19,18 +18,21 @@ const meta = {
     },
   },
   args: {
-    acknowledgeQueueItemAction: noopAcknowledgeQueueItemAction,
-    acknowledgeQueueItemsAction: noopAcknowledgeQueueItemAction,
+    acknowledgeQueueItemAction: noopInboxAction,
+    acknowledgeQueueItemsAction: noopInboxAction,
     canOpenReportCases: true,
     canQueueCaseActions: true,
-    closeReportAction: noopReportAction,
+    closeReportAction: noopInboxAction,
     guildId: 'guild-1',
     guildName: 'Fixture Guild',
     sessionUsername: 'Fixture Admin',
     items: fixtureModerationInboxItems(),
-    openReportCaseAction: noopReportAction,
+    openReportCaseAction: noopInboxAction,
+    pollActionRequests: false,
     queueCaseAction: noopCaseAction,
-    queueObservedAlertAction: noopQueueObservedAlertAction,
+    queueInboxCaseAction: noopInboxAction,
+    queueObservedAlertAction: noopInboxAction,
+    recentActionRequests: [],
   },
 } satisfies Meta<typeof ModerationInboxView>;
 

--- a/apps/web/components/inbox/ModerationInboxView.tsx
+++ b/apps/web/components/inbox/ModerationInboxView.tsx
@@ -11,9 +11,16 @@ import { ThemeToggle } from '@/components/ThemeToggle';
 import {
   CaseActionControls,
   isExecutableCaseAction,
+  type QueueInboxCaseAction,
   type QueueCaseAction,
+  type WebCaseAction,
 } from '@/components/cases/CaseActionControls';
+import { InboxActionForm, type InboxStateAction } from './InboxActionForm';
+import { InboxActionRequestPoller } from './InboxActionRequestPoller';
 import { formatDetectionType, formatUtc, freshnessStatusClass } from '@/lib/casePresentation';
+import type { InboxActionState } from '@/lib/inboxActionState';
+import { findInboxActionRequest, hasActiveInboxActionRequests } from '@/lib/inboxActionReceipts';
+import type { ModerationActionRequestSummary } from '@/lib/moderationActionRequestDataAdapter';
 import {
   buildModerationInboxExportText,
   getModerationInboxAttentionQueueItemIds,
@@ -40,11 +47,23 @@ interface ModerationInboxViewProps {
   readonly items: readonly ModerationInboxItem[];
   readonly openReportCaseAction: OpenReportCaseAction;
   readonly queueCaseAction: QueueCaseAction;
+  readonly queueInboxCaseAction: QueueInboxCaseAction;
   readonly queueObservedAlertAction: QueueObservedAlertAction;
+  readonly recentActionRequests: readonly ModerationActionRequestSummary[];
+  readonly pollActionRequests: boolean;
 }
 
-type AcknowledgeQueueItemAction = (guildId: string, queueItemId: string) => Promise<void>;
-type AcknowledgeQueueItemsAction = (guildId: string, formData: FormData) => Promise<void>;
+type AcknowledgeQueueItemAction = (
+  guildId: string,
+  queueItemId: string,
+  previousState: InboxActionState,
+  formData: FormData
+) => Promise<InboxActionState>;
+type AcknowledgeQueueItemsAction = (
+  guildId: string,
+  previousState: InboxActionState,
+  formData: FormData
+) => Promise<InboxActionState>;
 type ReportClosureAction = Extract<
   ModerationInboxAction,
   'mark_actioned' | 'dismiss_no_action' | 'mark_false_positive'
@@ -52,16 +71,24 @@ type ReportClosureAction = Extract<
 type CloseReportAction = (
   guildId: string,
   reportId: string,
-  action: ReportClosureAction
-) => Promise<void>;
-type OpenReportCaseAction = (guildId: string, reportId: string) => Promise<void>;
+  action: ReportClosureAction,
+  previousState: InboxActionState,
+  formData: FormData
+) => Promise<InboxActionState>;
+type OpenReportCaseAction = (
+  guildId: string,
+  reportId: string,
+  previousState: InboxActionState,
+  formData: FormData
+) => Promise<InboxActionState>;
 type QueueObservedAlertAction = (
   guildId: string,
   targetUserId: string,
   detectionEventId: string,
   action: ModerationInboxAction,
-  formData?: FormData
-) => Promise<void>;
+  previousState: InboxActionState,
+  formData: FormData
+) => Promise<InboxActionState>;
 
 interface ControlOption<TValue extends string> {
   readonly value: TValue;
@@ -239,17 +266,15 @@ function InboxControls({
             {hasSelection ? `${selectedCount} selected` : `${visibleCount} visible`}
           </span>
           {acknowledgeQueueItemIds.length > 0 ? (
-            <form
-              action={acknowledgeQueueItemsAction.bind(null, guildId)}
-              className="bulk-action-form"
+            <InboxActionForm
+              action={acknowledgeQueueItemsAction.bind(null, guildId) as InboxStateAction}
+              buttonLabel={acknowledgeButtonLabel}
+              formClassName="bulk-action-form"
             >
               {acknowledgeQueueItemIds.map((queueItemId) => (
                 <input key={queueItemId} name="queueItemId" type="hidden" value={queueItemId} />
               ))}
-              <button className="button secondary compact-button" type="submit">
-                {acknowledgeButtonLabel}
-              </button>
-            </form>
+            </InboxActionForm>
           ) : null}
           {exportItemsCount > 0 ? (
             <details className="inline-action export-action">
@@ -373,7 +398,9 @@ function InboxActions({
   item,
   openReportCaseAction,
   queueCaseAction,
+  queueInboxCaseAction,
   queueObservedAlertAction,
+  recentActionRequests,
 }: {
   readonly acknowledgeQueueItemAction: AcknowledgeQueueItemAction;
   readonly canOpenReportCases: boolean;
@@ -382,7 +409,9 @@ function InboxActions({
   readonly item: ModerationInboxItem;
   readonly openReportCaseAction: OpenReportCaseAction;
   readonly queueCaseAction: QueueCaseAction;
+  readonly queueInboxCaseAction: QueueInboxCaseAction;
   readonly queueObservedAlertAction: QueueObservedAlertAction;
+  readonly recentActionRequests: readonly ModerationActionRequestSummary[];
 }) {
   if (item.allowedActions.length === 0) {
     return <span className="muted">No actions available.</span>;
@@ -390,6 +419,12 @@ function InboxActions({
 
   const caseActions =
     item.kind === 'case' ? item.allowedActions.filter(isExecutableCaseAction) : [];
+  const actionRequestsByAction = Object.fromEntries(
+    caseActions.map((action) => [
+      action,
+      findInboxActionRequest(recentActionRequests, item, action),
+    ])
+  ) as Partial<Record<WebCaseAction, ModerationActionRequestSummary | null>>;
 
   return (
     <div className="pill-list action-form-list" aria-label={`Actions for ${item.title}`}>
@@ -413,14 +448,17 @@ function InboxActions({
             );
           }
           return (
-            <form
-              action={acknowledgeQueueItemAction.bind(null, item.guildId, item.queueItemId)}
+            <InboxActionForm
+              action={
+                acknowledgeQueueItemAction.bind(
+                  null,
+                  item.guildId,
+                  item.queueItemId
+                ) as InboxStateAction
+              }
+              buttonLabel={actionLabels[action]}
               key={`${item.id}-${action}`}
-            >
-              <button className="button secondary compact-button" type="submit">
-                {actionLabels[action]}
-              </button>
-            </form>
+            />
           );
         }
 
@@ -485,14 +523,15 @@ function InboxActions({
 
         if (item.kind === 'submitted_report' && action === 'open_case') {
           return canOpenReportCases ? (
-            <form
-              action={openReportCaseAction.bind(null, item.guildId, item.sourceId)}
+            <InboxActionForm
+              action={
+                openReportCaseAction.bind(null, item.guildId, item.sourceId) as InboxStateAction
+              }
+              buttonLabel={actionLabels[action]}
+              durableRequest={findInboxActionRequest(recentActionRequests, item, action)}
               key={`${item.id}-${action}`}
-            >
-              <button className="button secondary compact-button" type="submit">
-                {actionLabels[action]}
-              </button>
-            </form>
+              requestBaseHref={`/admin/guild/${item.guildId}/operations`}
+            />
           ) : (
             <button
               className="button secondary compact-button"
@@ -508,14 +547,18 @@ function InboxActions({
 
         if (item.kind === 'submitted_report' && isReportClosureAction(action)) {
           return (
-            <form
-              action={closeReportAction.bind(null, item.guildId, item.sourceId, action)}
+            <InboxActionForm
+              action={
+                closeReportAction.bind(
+                  null,
+                  item.guildId,
+                  item.sourceId,
+                  action
+                ) as InboxStateAction
+              }
+              buttonLabel={actionLabels[action]}
               key={`${item.id}-${action}`}
-            >
-              <button className="button secondary compact-button" type="submit">
-                {actionLabels[action]}
-              </button>
-            </form>
+            />
           );
         }
 
@@ -525,15 +568,21 @@ function InboxActions({
               <summary className="button secondary compact-button destructive-summary">
                 {actionLabels[action]}
               </summary>
-              <form
-                action={queueObservedAlertAction.bind(
-                  null,
-                  item.guildId,
-                  item.subject.userId,
-                  item.sourceId,
-                  action
-                )}
-                className="destructive-action-panel"
+              <InboxActionForm
+                action={
+                  queueObservedAlertAction.bind(
+                    null,
+                    item.guildId,
+                    item.subject.userId,
+                    item.sourceId,
+                    action
+                  ) as InboxStateAction
+                }
+                buttonClassName="button compact-button danger-button"
+                buttonLabel={`Queue ${actionLabels[action]}`}
+                durableRequest={findInboxActionRequest(recentActionRequests, item, action)}
+                formClassName="destructive-action-panel"
+                requestBaseHref={`/admin/guild/${item.guildId}/operations`}
               >
                 <label className="field destructive-reason">
                   <span>Reason</span>
@@ -543,10 +592,7 @@ function InboxActions({
                   <input name="confirmAction" type="checkbox" />
                   <span>Confirm {actionLabels[action]}</span>
                 </label>
-                <button className="button compact-button danger-button" type="submit">
-                  Queue {actionLabels[action]}
-                </button>
-              </form>
+              </InboxActionForm>
             </details>
           );
         }
@@ -558,20 +604,21 @@ function InboxActions({
             action === 'mark_false_positive')
         ) {
           return (
-            <form
-              action={queueObservedAlertAction.bind(
-                null,
-                item.guildId,
-                item.subject.userId,
-                item.sourceId,
-                action
-              )}
+            <InboxActionForm
+              action={
+                queueObservedAlertAction.bind(
+                  null,
+                  item.guildId,
+                  item.subject.userId,
+                  item.sourceId,
+                  action
+                ) as InboxStateAction
+              }
+              buttonLabel={actionLabels[action]}
+              durableRequest={findInboxActionRequest(recentActionRequests, item, action)}
               key={`${item.id}-${action}`}
-            >
-              <button className="button secondary compact-button" type="submit">
-                {actionLabels[action]}
-              </button>
-            </form>
+              requestBaseHref={`/admin/guild/${item.guildId}/operations`}
+            />
           );
         }
 
@@ -590,10 +637,12 @@ function InboxActions({
       {caseActions.length > 0 ? (
         <CaseActionControls
           actions={caseActions}
+          actionRequestsByAction={actionRequestsByAction}
           canQueueCaseActions={canQueueCaseActions}
           caseId={item.sourceId}
           guildId={item.guildId}
           queueCaseAction={queueCaseAction}
+          queueInboxCaseAction={queueInboxCaseAction}
         />
       ) : null}
     </div>
@@ -675,7 +724,9 @@ function InboxDetailPanel({
   item,
   openReportCaseAction,
   queueCaseAction,
+  queueInboxCaseAction,
   queueObservedAlertAction,
+  recentActionRequests,
 }: {
   readonly acknowledgeQueueItemAction: AcknowledgeQueueItemAction;
   readonly canOpenReportCases: boolean;
@@ -684,7 +735,9 @@ function InboxDetailPanel({
   readonly item: ModerationInboxItem | null;
   readonly openReportCaseAction: OpenReportCaseAction;
   readonly queueCaseAction: QueueCaseAction;
+  readonly queueInboxCaseAction: QueueInboxCaseAction;
   readonly queueObservedAlertAction: QueueObservedAlertAction;
+  readonly recentActionRequests: readonly ModerationActionRequestSummary[];
 }) {
   if (!item) {
     return (
@@ -740,7 +793,9 @@ function InboxDetailPanel({
           item={item}
           openReportCaseAction={openReportCaseAction}
           queueCaseAction={queueCaseAction}
+          queueInboxCaseAction={queueInboxCaseAction}
           queueObservedAlertAction={queueObservedAlertAction}
+          recentActionRequests={recentActionRequests}
         />
       </div>
     </aside>
@@ -758,8 +813,11 @@ export function ModerationInboxView({
   sessionUsername,
   items,
   openReportCaseAction,
+  pollActionRequests,
   queueCaseAction,
+  queueInboxCaseAction,
   queueObservedAlertAction,
+  recentActionRequests,
 }: ModerationInboxViewProps) {
   const [kind, setKind] = useState<ModerationInboxKindFilter>('all');
   const [freshness, setFreshness] = useState<ModerationInboxFreshnessFilter>('all');
@@ -837,6 +895,9 @@ export function ModerationInboxView({
 
   return (
     <main className="shell stack">
+      {pollActionRequests ? (
+        <InboxActionRequestPoller active={hasActiveInboxActionRequests(recentActionRequests)} />
+      ) : null}
       <nav className="topbar">
         <a className="brand" href="/admin">
           <span className="brand-mark" />
@@ -959,7 +1020,9 @@ export function ModerationInboxView({
               item={selectedItem}
               openReportCaseAction={openReportCaseAction}
               queueCaseAction={queueCaseAction}
+              queueInboxCaseAction={queueInboxCaseAction}
               queueObservedAlertAction={queueObservedAlertAction}
+              recentActionRequests={recentActionRequests}
             />
           </section>
         </>

--- a/apps/web/components/inbox/ModerationInboxView.tsx
+++ b/apps/web/components/inbox/ModerationInboxView.tsx
@@ -270,6 +270,7 @@ function InboxControls({
               action={acknowledgeQueueItemsAction.bind(null, guildId) as InboxStateAction}
               buttonLabel={acknowledgeButtonLabel}
               formClassName="bulk-action-form"
+              key={acknowledgeQueueItemIds.join(':')}
             >
               {acknowledgeQueueItemIds.map((queueItemId) => (
                 <input key={queueItemId} name="queueItemId" type="hidden" value={queueItemId} />

--- a/apps/web/components/inbox/ModerationInboxView.tsx
+++ b/apps/web/components/inbox/ModerationInboxView.tsx
@@ -19,7 +19,7 @@ import { InboxActionForm, type InboxStateAction } from './InboxActionForm';
 import { InboxActionRequestPollingProvider } from './InboxActionRequestPoller';
 import { formatDetectionType, formatUtc, freshnessStatusClass } from '@/lib/casePresentation';
 import type { InboxActionState } from '@/lib/inboxActionState';
-import { findInboxActionRequest, hasActiveInboxActionRequests } from '@/lib/inboxActionReceipts';
+import { findInboxActionRequest } from '@/lib/inboxActionReceipts';
 import type { ModerationActionRequestSummary } from '@/lib/moderationActionRequestDataAdapter';
 import {
   buildModerationInboxExportText,
@@ -1030,7 +1030,7 @@ export function ModerationInboxView({
   return (
     <InboxActionRequestPollingProvider
       enabled={pollActionRequests}
-      serverActive={hasActiveInboxActionRequests(recentActionRequests)}
+      serverRequests={recentActionRequests}
     >
       {content}
     </InboxActionRequestPollingProvider>

--- a/apps/web/components/inbox/ModerationInboxView.tsx
+++ b/apps/web/components/inbox/ModerationInboxView.tsx
@@ -16,7 +16,7 @@ import {
   type WebCaseAction,
 } from '@/components/cases/CaseActionControls';
 import { InboxActionForm, type InboxStateAction } from './InboxActionForm';
-import { InboxActionRequestPoller } from './InboxActionRequestPoller';
+import { InboxActionRequestPollingProvider } from './InboxActionRequestPoller';
 import { formatDetectionType, formatUtc, freshnessStatusClass } from '@/lib/casePresentation';
 import type { InboxActionState } from '@/lib/inboxActionState';
 import { findInboxActionRequest, hasActiveInboxActionRequests } from '@/lib/inboxActionReceipts';
@@ -893,11 +893,8 @@ export function ModerationInboxView({
   const staleCount = items.filter((item) => item.stale).length;
   const attentionCount = items.filter((item) => isModerationInboxAttentionKind(item.kind)).length;
 
-  return (
+  const content = (
     <main className="shell stack">
-      {pollActionRequests ? (
-        <InboxActionRequestPoller active={hasActiveInboxActionRequests(recentActionRequests)} />
-      ) : null}
       <nav className="topbar">
         <a className="brand" href="/admin">
           <span className="brand-mark" />
@@ -1028,5 +1025,14 @@ export function ModerationInboxView({
         </>
       )}
     </main>
+  );
+
+  return (
+    <InboxActionRequestPollingProvider
+      enabled={pollActionRequests}
+      serverActive={hasActiveInboxActionRequests(recentActionRequests)}
+    >
+      {content}
+    </InboxActionRequestPollingProvider>
   );
 }

--- a/apps/web/components/operations/OperationsView.tsx
+++ b/apps/web/components/operations/OperationsView.tsx
@@ -534,7 +534,12 @@ export function OperationsView({
         ) : (
           <div className="request-history" aria-label="Recent web requests">
             {recentRequests.map((request) => (
-              <article className="request-row" key={request.id}>
+              <article
+                className="request-row"
+                id={`request-${request.id}`}
+                key={request.id}
+                tabIndex={-1}
+              >
                 <div>
                   <span className={`status ${statusClass(request.status)}`}>{request.status}</span>
                   <h3>{formatRequestAction(request.actionType)}</h3>

--- a/apps/web/e2e/smoke.spec.ts
+++ b/apps/web/e2e/smoke.spec.ts
@@ -304,6 +304,7 @@ test('moderation inbox navigates and queues active case actions', async ({ page 
     'href',
     '/admin/guild/guild-1/operations#request-fixture-case-action-refresh_notification-case-stale'
   );
+  await expect(actions.getByRole('button', { name: 'Refresh Notification' })).toBeDisabled();
 
   const refreshedActions = detail.getByLabel('Actions for Pending moderation case');
   const banAction = refreshedActions

--- a/apps/web/e2e/smoke.spec.ts
+++ b/apps/web/e2e/smoke.spec.ts
@@ -296,6 +296,14 @@ test('moderation inbox navigates and queues active case actions', async ({ page 
   await actions.getByRole('button', { name: 'Refresh Notification' }).click();
   expect((await refreshResponsePromise).status()).toBeLessThan(400);
   await expect(detail.getByRole('heading', { name: /pending moderation case/i })).toBeVisible();
+  const refreshReceipt = actions
+    .getByRole('button', { name: 'Refresh Notification' })
+    .locator('..');
+  await expect(refreshReceipt.getByText('queued', { exact: true })).toBeVisible();
+  await expect(refreshReceipt.getByRole('link', { name: 'View request' })).toHaveAttribute(
+    'href',
+    '/admin/guild/guild-1/operations#request-fixture-case-action-refresh_notification-case-stale'
+  );
 
   const refreshedActions = detail.getByLabel('Actions for Pending moderation case');
   const banAction = refreshedActions
@@ -313,6 +321,72 @@ test('moderation inbox navigates and queues active case actions', async ({ page 
   await banAction.getByRole('button', { name: 'Queue Ban User' }).click();
   expect((await banResponsePromise).status()).toBeLessThan(400);
   await expect(detail.getByRole('heading', { name: /pending moderation case/i })).toBeVisible();
+});
+
+test('moderation inbox blocks duplicate submissions while an action is pending', async ({
+  page,
+}) => {
+  let postCount = 0;
+  let releaseRequest: () => void = () => undefined;
+  let signalIntercepted: () => void = () => undefined;
+  const requestIntercepted = new Promise<void>((resolve) => {
+    signalIntercepted = resolve;
+  });
+  const requestReleased = new Promise<void>((resolve) => {
+    releaseRequest = resolve;
+  });
+  await page.route('**/admin/guild/guild-1/inbox', async (route) => {
+    if (route.request().method() === 'POST') {
+      postCount += 1;
+      signalIntercepted();
+      await requestReleased;
+    }
+    await route.continue();
+  });
+  await page.goto('/admin/guild/guild-1/inbox');
+
+  const actions = page
+    .getByLabel('Selected inbox item')
+    .getByLabel('Actions for Pending moderation case');
+  const actionForm = actions.getByRole('form', { name: 'Refresh Notification action' });
+  const button = actions.getByRole('button', { name: 'Refresh Notification' });
+  const firstSubmission = button.click();
+
+  await requestIntercepted;
+  const pendingButton = actionForm.locator('button[type="submit"]');
+  await expect(pendingButton).toBeDisabled();
+  await expect(pendingButton).toHaveText('Submitting...');
+  await pendingButton.click({ force: true });
+  releaseRequest();
+  await firstSubmission;
+  expect(postCount).toBe(1);
+});
+
+test('moderation inbox renders destructive validation failures inline', async ({ page }) => {
+  await page.goto('/admin/guild/guild-1/inbox');
+
+  const detail = page.getByLabel('Selected inbox item');
+  const banAction = detail.locator('details.destructive-action').filter({ hasText: 'Ban User' });
+  await banAction.getByText('Ban User', { exact: true }).click();
+  await banAction.getByRole('button', { name: 'Queue Ban User' }).click();
+  await expect(banAction.getByRole('alert')).toContainText(
+    'Confirm the moderation action before queueing it.'
+  );
+
+  await banAction.getByLabel('Confirm Ban User').check();
+  await banAction.getByRole('button', { name: 'Queue Ban User' }).click();
+  await expect(banAction.getByRole('alert')).toContainText('Ban reason is required.');
+
+  await page.getByRole('button', { name: /observed alert pending review/i }).click();
+  const observedKickAction = detail
+    .locator('details.destructive-action')
+    .filter({ hasText: 'Kick User' });
+  await observedKickAction.getByText('Kick User', { exact: true }).click();
+  await observedKickAction.getByLabel('Confirm Kick User').check();
+  await observedKickAction.getByRole('button', { name: 'Queue Kick User' }).click();
+  await expect(observedKickAction.getByRole('alert')).toContainText(
+    'Observed alert kick actions are disabled for this server.'
+  );
 });
 
 test('moderation inbox queues submitted report actions', async ({ page }) => {
@@ -376,6 +450,7 @@ test('moderation inbox queues observed alert decisions through the shared action
   await banAction.getByText('Ban User', { exact: true }).click();
   await expect(banAction.getByLabel('Confirm Ban User')).toBeVisible();
 
+  await banAction.getByLabel('Reason').fill('Confirmed malicious activity.');
   await banAction.getByLabel('Confirm Ban User').check();
   await banAction.getByRole('button', { name: 'Queue Ban User' }).click();
   await expect(

--- a/apps/web/e2e/smoke.spec.ts
+++ b/apps/web/e2e/smoke.spec.ts
@@ -425,6 +425,7 @@ test('moderation inbox acknowledges attention items through the shared action pa
   await expect(detail.getByRole('heading', { name: /support reply needs review/i })).toBeVisible();
 
   await detail.getByRole('button', { name: 'Acknowledge' }).click();
+  await expect(detail.getByRole('status')).toContainText('Reply was already handled.');
   await expect(
     page.getByRole('heading', { name: /fixture guild moderation inbox/i })
   ).toBeVisible();
@@ -447,6 +448,10 @@ test('moderation inbox queues observed alert decisions through the shared action
   );
   await expect(detail.getByRole('button', { name: 'Dismiss No Action' })).toBeVisible();
   await expect(detail.getByRole('button', { name: 'False Positive' })).toBeVisible();
+  await detail.getByRole('button', { name: 'Dismiss No Action' }).click();
+  const dismissReceipt = detail.getByRole('button', { name: 'Dismiss No Action' }).locator('..');
+  await expect(dismissReceipt.getByText('completed', { exact: true })).toBeVisible();
+  await expect(dismissReceipt).toContainText('Action was already handled.');
   const banAction = detail.locator('details.destructive-action').filter({ hasText: 'Ban User' });
   await banAction.getByText('Ban User', { exact: true }).click();
   await expect(banAction.getByLabel('Confirm Ban User')).toBeVisible();

--- a/apps/web/lib/activeCaseDataAdapter.test.ts
+++ b/apps/web/lib/activeCaseDataAdapter.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   FixtureActiveCaseDataAdapter,
   parseCaseSummaryRow,
+  resolveCaseActionQueueStatus,
   resolveReportIntakeId,
 } from './activeCaseDataAdapter';
 
@@ -39,6 +40,13 @@ const baseRow = {
 };
 
 describe('activeCaseDataAdapter', () => {
+  it('preserves failed queue receipts for inline action feedback', () => {
+    expect(resolveCaseActionQueueStatus('queued')).toBe('queued');
+    expect(resolveCaseActionQueueStatus('processing')).toBe('queued');
+    expect(resolveCaseActionQueueStatus('completed')).toBe('already_handled');
+    expect(resolveCaseActionQueueStatus('failed')).toBe('failed');
+  });
+
   it('parses pending case summary rows with surface links and stale state', () => {
     const summary = parseCaseSummaryRow(baseRow, new Date('2026-06-03T01:00:00.000Z'));
 
@@ -237,6 +245,7 @@ describe('activeCaseDataAdapter', () => {
     ).resolves.toEqual({
       action: 'repair_thread',
       caseId: 'case-stale',
+      requestId: 'fixture-case-action-repair_thread-case-stale',
       status: 'queued',
     });
     await expect(
@@ -249,6 +258,7 @@ describe('activeCaseDataAdapter', () => {
     ).resolves.toEqual({
       action: 'refresh_notification',
       caseId: 'case-stale',
+      requestId: 'fixture-case-action-refresh_notification-case-stale',
       status: 'queued',
     });
     await expect(
@@ -261,6 +271,7 @@ describe('activeCaseDataAdapter', () => {
     ).resolves.toEqual({
       action: 'verify_user',
       caseId: 'case-left',
+      requestId: null,
       status: 'not_allowed',
     });
     await expect(
@@ -273,6 +284,7 @@ describe('activeCaseDataAdapter', () => {
     ).resolves.toEqual({
       action: 'sync_existing_ban',
       caseId: 'case-banned',
+      requestId: 'fixture-case-action-sync_existing_ban-case-banned',
       status: 'queued',
     });
   });

--- a/apps/web/lib/activeCaseDataAdapter.ts
+++ b/apps/web/lib/activeCaseDataAdapter.ts
@@ -23,8 +23,9 @@ import {
 import { discordDesktopUrl, discordMessageUrl } from './discordUrls';
 import { getPostgresPool } from './setupDataAdapter';
 import {
-  queueModerationActionRequest,
+  queueModerationActionRequestWithReceipt,
   type ModerationActionRequestActionType,
+  type ModerationActionRequestQueueStatus,
 } from './moderationActionRequestQueue';
 
 export type WebCaseAction = Extract<
@@ -41,11 +42,17 @@ export type WebCaseAction = Extract<
   | 'reopen_case'
 >;
 
-export type CaseActionQueueStatus = 'queued' | 'already_handled' | 'case_not_found' | 'not_allowed';
+export type CaseActionQueueStatus =
+  | 'queued'
+  | 'already_handled'
+  | 'case_not_found'
+  | 'not_allowed'
+  | 'failed';
 
 export interface CaseActionQueueResult {
   readonly action: WebCaseAction;
   readonly caseId: string;
+  readonly requestId: string | null;
   readonly status: CaseActionQueueStatus;
 }
 
@@ -63,6 +70,15 @@ export interface ActiveCaseDataAdapter {
     guildId: string;
     reason?: string | null;
   }): Promise<CaseActionQueueResult>;
+}
+
+export function resolveCaseActionQueueStatus(
+  status: ModerationActionRequestQueueStatus
+): CaseActionQueueStatus {
+  if (status === 'completed') {
+    return 'already_handled';
+  }
+  return status === 'failed' ? 'failed' : 'queued';
 }
 
 interface CaseSummaryRow {
@@ -713,13 +729,18 @@ export class PostgresActiveCaseDataAdapter implements ActiveCaseDataAdapter {
   }): Promise<CaseActionQueueResult> {
     const detail = await this.getCaseDetail(input.guildId, input.caseId);
     if (!detail) {
-      return { action: input.action, caseId: input.caseId, status: 'case_not_found' };
+      return {
+        action: input.action,
+        caseId: input.caseId,
+        requestId: null,
+        status: 'case_not_found',
+      };
     }
     if (!detail.allowedActions.includes(input.action)) {
-      return { action: input.action, caseId: input.caseId, status: 'not_allowed' };
+      return { action: input.action, caseId: input.caseId, requestId: null, status: 'not_allowed' };
     }
 
-    const queueStatus = await queueModerationActionRequest({
+    const receipt = await queueModerationActionRequestWithReceipt({
       actionType: requestTypeByCaseAction[input.action],
       actorId: input.adminId,
       actorSurface: 'web',
@@ -737,7 +758,8 @@ export class PostgresActiveCaseDataAdapter implements ActiveCaseDataAdapter {
     return {
       action: input.action,
       caseId: input.caseId,
-      status: queueStatus === 'completed' ? 'already_handled' : 'queued',
+      requestId: receipt.id,
+      status: resolveCaseActionQueueStatus(receipt.status),
     };
   }
 }
@@ -780,12 +802,22 @@ export class FixtureActiveCaseDataAdapter implements ActiveCaseDataAdapter {
   }): Promise<CaseActionQueueResult> {
     const detail = fixtureActiveCaseDetail(input.caseId);
     if (!detail) {
-      return { action: input.action, caseId: input.caseId, status: 'case_not_found' };
+      return {
+        action: input.action,
+        caseId: input.caseId,
+        requestId: null,
+        status: 'case_not_found',
+      };
     }
     if (!detail.allowedActions.includes(input.action)) {
-      return { action: input.action, caseId: input.caseId, status: 'not_allowed' };
+      return { action: input.action, caseId: input.caseId, requestId: null, status: 'not_allowed' };
     }
-    return { action: input.action, caseId: input.caseId, status: 'queued' };
+    return {
+      action: input.action,
+      caseId: input.caseId,
+      requestId: `fixture-case-action-${input.action}-${input.caseId}`,
+      status: 'queued',
+    };
   }
 }
 

--- a/apps/web/lib/e2eFixtures.ts
+++ b/apps/web/lib/e2eFixtures.ts
@@ -165,7 +165,7 @@ export function fixtureServerRecord(): SetupServerRecord {
       observed_detection_notification_window_minutes: 60,
       automatic_detection_exempt_moderators: true,
       admin_case_open_requires_reason: false,
-      moderator_ban_action_requires_reason: false,
+      moderator_ban_action_requires_reason: true,
       moderator_kick_action_requires_reason: false,
       moderator_ban_action_enabled: true,
       moderator_kick_action_enabled: true,

--- a/apps/web/lib/inboxActionReceipts.test.ts
+++ b/apps/web/lib/inboxActionReceipts.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest';
 import { fixtureModerationInboxItems } from './inboxFixtures';
-import { findInboxActionRequest, hasActiveInboxActionRequests } from './inboxActionReceipts';
+import {
+  findInboxActionRequest,
+  hasActiveInboxActionRequests,
+  reconcileLocalInboxActionRequestIds,
+} from './inboxActionReceipts';
 import type { ModerationActionRequestSummary } from './moderationActionRequestDataAdapter';
 
 function buildRequest(
@@ -89,5 +93,27 @@ describe('inboxActionReceipts', () => {
     expect(hasActiveInboxActionRequests([buildRequest({ status: 'queued' })])).toBe(true);
     expect(hasActiveInboxActionRequests([buildRequest({ status: 'completed' })])).toBe(false);
     expect(hasActiveInboxActionRequests([buildRequest({ status: 'failed' })])).toBe(false);
+  });
+
+  it('retains local polling ids until server data reports a terminal state', () => {
+    const localRequestIds = new Set([
+      'request-unobserved',
+      'request-active',
+      'request-completed',
+      'request-failed',
+    ]);
+
+    const whileActive = reconcileLocalInboxActionRequestIds(localRequestIds, [
+      buildRequest({ id: 'request-active', status: 'processing' }),
+    ]);
+    expect(whileActive).toBe(localRequestIds);
+
+    expect(
+      reconcileLocalInboxActionRequestIds(localRequestIds, [
+        buildRequest({ id: 'request-active', status: 'processing' }),
+        buildRequest({ id: 'request-completed', status: 'completed' }),
+        buildRequest({ id: 'request-failed', status: 'failed' }),
+      ])
+    ).toEqual(new Set(['request-unobserved', 'request-active']));
   });
 });

--- a/apps/web/lib/inboxActionReceipts.test.ts
+++ b/apps/web/lib/inboxActionReceipts.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest';
+import { fixtureModerationInboxItems } from './inboxFixtures';
+import { findInboxActionRequest, hasActiveInboxActionRequests } from './inboxActionReceipts';
+import type { ModerationActionRequestSummary } from './moderationActionRequestDataAdapter';
+
+function buildRequest(
+  overrides: Partial<ModerationActionRequestSummary>
+): ModerationActionRequestSummary {
+  return {
+    id: 'request-1',
+    actionType: 'refresh_case_notification',
+    actorSurface: 'web',
+    completedAt: null,
+    detectionEventId: null,
+    failedAt: null,
+    lastError: null,
+    requestedAt: '2026-06-08T01:00:00.000Z',
+    reportIntakeId: null,
+    requestedAction: null,
+    resultSummary: null,
+    status: 'queued',
+    targetUserId: 'user-100',
+    updatedAt: '2026-06-08T01:00:00.000Z',
+    verificationEventId: null,
+    ...overrides,
+  };
+}
+
+describe('inboxActionReceipts', () => {
+  const items = fixtureModerationInboxItems();
+  const caseItem = items.find((item) => item.kind === 'case');
+  const observedItem = items.find((item) => item.kind === 'observed_alert');
+  const reportItem = items.find((item) => item.kind === 'submitted_report');
+
+  it('matches requests by action family and durable subject id', () => {
+    expect(caseItem).toBeDefined();
+    expect(observedItem).toBeDefined();
+    expect(reportItem).toBeDefined();
+
+    const requests = [
+      buildRequest({ verificationEventId: caseItem?.sourceId ?? null }),
+      buildRequest({
+        id: 'request-2',
+        actionType: 'ban_observed_detection',
+        detectionEventId: observedItem?.sourceId ?? null,
+      }),
+      buildRequest({
+        id: 'request-3',
+        actionType: 'open_case_from_observed_detection',
+        reportIntakeId: reportItem?.sourceId ?? null,
+      }),
+    ];
+
+    expect(findInboxActionRequest(requests, caseItem!, 'refresh_notification')?.id).toBe(
+      'request-1'
+    );
+    expect(findInboxActionRequest(requests, observedItem!, 'ban_user')?.id).toBe('request-2');
+    expect(findInboxActionRequest(requests, reportItem!, 'open_case')?.id).toBe('request-3');
+    expect(findInboxActionRequest(requests, caseItem!, 'ban_user')).toBeNull();
+  });
+
+  it('uses request metadata to distinguish shared worker action types', () => {
+    expect(caseItem).toBeDefined();
+    const request = buildRequest({
+      actionType: 'repair_active_case',
+      requestedAction: 'create_thread',
+      verificationEventId: caseItem?.sourceId ?? null,
+    });
+
+    expect(findInboxActionRequest([request], caseItem!, 'create_thread')?.id).toBe('request-1');
+    expect(findInboxActionRequest([request], caseItem!, 'repair_thread')).toBeNull();
+  });
+
+  it('reports only queued and processing requests as active', () => {
+    expect(hasActiveInboxActionRequests([buildRequest({ status: 'processing' })])).toBe(true);
+    expect(hasActiveInboxActionRequests([buildRequest({ status: 'queued' })])).toBe(true);
+    expect(hasActiveInboxActionRequests([buildRequest({ status: 'completed' })])).toBe(false);
+    expect(hasActiveInboxActionRequests([buildRequest({ status: 'failed' })])).toBe(false);
+  });
+});

--- a/apps/web/lib/inboxActionReceipts.test.ts
+++ b/apps/web/lib/inboxActionReceipts.test.ts
@@ -71,6 +71,19 @@ describe('inboxActionReceipts', () => {
     expect(findInboxActionRequest([request], caseItem!, 'repair_thread')).toBeNull();
   });
 
+  it('does not share a report-open receipt with its observed-alert mirror', () => {
+    expect(observedItem).toBeDefined();
+    expect(reportItem).toBeDefined();
+    const reportRequest = buildRequest({
+      actionType: 'open_case_from_observed_detection',
+      detectionEventId: observedItem?.sourceId ?? null,
+      reportIntakeId: reportItem?.sourceId ?? null,
+    });
+
+    expect(findInboxActionRequest([reportRequest], reportItem!, 'open_case')?.id).toBe('request-1');
+    expect(findInboxActionRequest([reportRequest], observedItem!, 'open_case')).toBeNull();
+  });
+
   it('reports only queued and processing requests as active', () => {
     expect(hasActiveInboxActionRequests([buildRequest({ status: 'processing' })])).toBe(true);
     expect(hasActiveInboxActionRequests([buildRequest({ status: 'queued' })])).toBe(true);

--- a/apps/web/lib/inboxActionReceipts.ts
+++ b/apps/web/lib/inboxActionReceipts.ts
@@ -71,3 +71,16 @@ export function hasActiveInboxActionRequests(
       (request.status === 'queued' || request.status === 'processing')
   );
 }
+
+export function reconcileLocalInboxActionRequestIds(
+  localRequestIds: ReadonlySet<string>,
+  serverRequests: readonly ModerationActionRequestSummary[]
+): ReadonlySet<string> {
+  const next = new Set(localRequestIds);
+  for (const request of serverRequests) {
+    if (request.status === 'completed' || request.status === 'failed') {
+      next.delete(request.id);
+    }
+  }
+  return next.size === localRequestIds.size ? localRequestIds : next;
+}

--- a/apps/web/lib/inboxActionReceipts.ts
+++ b/apps/web/lib/inboxActionReceipts.ts
@@ -1,0 +1,73 @@
+import type { ModerationInboxAction, ModerationInboxItem } from '@drasil/contracts';
+import type { ModerationActionRequestSummary } from './moderationActionRequestDataAdapter';
+import type { ModerationActionRequestActionType } from './moderationActionRequestQueue';
+
+const requestTypeByAction: Partial<
+  Record<ModerationInboxAction, readonly ModerationActionRequestActionType[]>
+> = {
+  ban_by_id: ['ban_case_user_by_id'],
+  ban_user: ['ban_case_user', 'ban_observed_detection'],
+  close_no_action: ['close_case_no_action'],
+  create_thread: ['repair_active_case'],
+  dismiss_no_action: ['dismiss_observed_detection'],
+  kick_user: ['kick_case_user', 'kick_observed_detection'],
+  mark_false_positive: ['mark_observed_detection_false_positive'],
+  open_case: ['open_case_from_observed_detection'],
+  refresh_notification: ['refresh_case_notification'],
+  reopen_case: ['reopen_case'],
+  repair_thread: ['repair_active_case'],
+  sync_existing_ban: ['sync_existing_ban'],
+  verify_user: ['verify_case_user'],
+};
+
+const inboxRequestTypes = new Set(
+  Object.values(requestTypeByAction).flatMap((actionTypes) => actionTypes ?? [])
+);
+
+function requestMatchesItem(
+  request: ModerationActionRequestSummary,
+  item: ModerationInboxItem
+): boolean {
+  switch (item.kind) {
+    case 'case':
+      return request.verificationEventId === item.sourceId;
+    case 'observed_alert':
+      return request.detectionEventId === item.sourceId;
+    case 'submitted_report':
+      return request.reportIntakeId === item.sourceId;
+    case 'pending_screening':
+    case 'report_attention':
+    case 'support_attention':
+      return false;
+  }
+}
+
+export function findInboxActionRequest(
+  requests: readonly ModerationActionRequestSummary[],
+  item: ModerationInboxItem,
+  action: ModerationInboxAction
+): ModerationActionRequestSummary | null {
+  const actionTypes = requestTypeByAction[action];
+  if (!actionTypes) {
+    return null;
+  }
+
+  return (
+    requests.find(
+      (request) =>
+        actionTypes.includes(request.actionType) &&
+        (!request.requestedAction || request.requestedAction === action) &&
+        requestMatchesItem(request, item)
+    ) ?? null
+  );
+}
+
+export function hasActiveInboxActionRequests(
+  requests: readonly ModerationActionRequestSummary[]
+): boolean {
+  return requests.some(
+    (request) =>
+      inboxRequestTypes.has(request.actionType) &&
+      (request.status === 'queued' || request.status === 'processing')
+  );
+}

--- a/apps/web/lib/inboxActionReceipts.ts
+++ b/apps/web/lib/inboxActionReceipts.ts
@@ -32,7 +32,7 @@ function requestMatchesItem(
     case 'case':
       return request.verificationEventId === item.sourceId;
     case 'observed_alert':
-      return request.detectionEventId === item.sourceId;
+      return request.reportIntakeId === null && request.detectionEventId === item.sourceId;
     case 'submitted_report':
       return request.reportIntakeId === item.sourceId;
     case 'pending_screening':

--- a/apps/web/lib/inboxActionReceipts.ts
+++ b/apps/web/lib/inboxActionReceipts.ts
@@ -1,5 +1,6 @@
 import type { ModerationInboxAction, ModerationInboxItem } from '@drasil/contracts';
 import type { ModerationActionRequestSummary } from './moderationActionRequestDataAdapter';
+import { inboxModerationActionRequestTypes } from './inboxActionRequestTypes';
 import type { ModerationActionRequestActionType } from './moderationActionRequestQueue';
 
 const requestTypeByAction: Partial<
@@ -20,8 +21,8 @@ const requestTypeByAction: Partial<
   verify_user: ['verify_case_user'],
 };
 
-const inboxRequestTypes = new Set(
-  Object.values(requestTypeByAction).flatMap((actionTypes) => actionTypes ?? [])
+const inboxRequestTypes = new Set<ModerationActionRequestActionType>(
+  inboxModerationActionRequestTypes
 );
 
 function requestMatchesItem(

--- a/apps/web/lib/inboxActionRequestTypes.ts
+++ b/apps/web/lib/inboxActionRequestTypes.ts
@@ -1,0 +1,18 @@
+import type { ModerationActionRequestActionType } from './moderationActionRequestQueue';
+
+export const inboxModerationActionRequestTypes = [
+  'open_case_from_observed_detection',
+  'dismiss_observed_detection',
+  'mark_observed_detection_false_positive',
+  'kick_observed_detection',
+  'ban_observed_detection',
+  'verify_case_user',
+  'close_case_no_action',
+  'kick_case_user',
+  'ban_case_user',
+  'ban_case_user_by_id',
+  'repair_active_case',
+  'reopen_case',
+  'refresh_case_notification',
+  'sync_existing_ban',
+] as const satisfies readonly ModerationActionRequestActionType[];

--- a/apps/web/lib/inboxActionState.test.ts
+++ b/apps/web/lib/inboxActionState.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+import { isInboxActionSubmitBlocked } from './inboxActionState';
+
+describe('inboxActionState', () => {
+  it('blocks queued, processing, and completed actions from duplicate submission', () => {
+    expect(isInboxActionSubmitBlocked('queued')).toBe(true);
+    expect(isInboxActionSubmitBlocked('processing')).toBe(true);
+    expect(isInboxActionSubmitBlocked('completed')).toBe(true);
+  });
+
+  it('allows idle actions and failed actions that can be retried', () => {
+    expect(isInboxActionSubmitBlocked('idle')).toBe(false);
+    expect(isInboxActionSubmitBlocked('failed')).toBe(false);
+  });
+});

--- a/apps/web/lib/inboxActionState.test.ts
+++ b/apps/web/lib/inboxActionState.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { isInboxActionSubmitBlocked } from './inboxActionState';
+import {
+  isInboxActionInFlight,
+  isInboxActionSubmitBlocked,
+  shouldUseDurableInboxActionState,
+} from './inboxActionState';
 
 describe('inboxActionState', () => {
   it('blocks queued, processing, and completed actions from duplicate submission', () => {
@@ -11,5 +15,72 @@ describe('inboxActionState', () => {
   it('allows idle actions and failed actions that can be retried', () => {
     expect(isInboxActionSubmitBlocked('idle')).toBe(false);
     expect(isInboxActionSubmitBlocked('failed')).toBe(false);
+  });
+
+  it('reports only queued and processing states as in flight', () => {
+    expect(isInboxActionInFlight('queued')).toBe(true);
+    expect(isInboxActionInFlight('processing')).toBe(true);
+    expect(isInboxActionInFlight('completed')).toBe(false);
+    expect(isInboxActionInFlight('failed')).toBe(false);
+  });
+
+  it('keeps an active local retry ahead of a stale failed durable receipt', () => {
+    const localState = {
+      message: 'Action queued for Drasil.',
+      requestId: 'request-1',
+      status: 'queued' as const,
+    };
+
+    expect(
+      shouldUseDurableInboxActionState(
+        localState,
+        { id: 'request-1', status: 'failed', updatedAt: '2026-07-14T15:00:00.000Z' },
+        '2026-07-14T15:00:00.000Z'
+      )
+    ).toBe(false);
+    expect(
+      shouldUseDurableInboxActionState(
+        localState,
+        { id: 'request-1', status: 'processing', updatedAt: '2026-07-14T15:01:00.000Z' },
+        '2026-07-14T15:00:00.000Z'
+      )
+    ).toBe(true);
+    expect(
+      shouldUseDurableInboxActionState(
+        localState,
+        { id: 'request-1', status: 'completed', updatedAt: '2026-07-14T15:01:00.000Z' },
+        '2026-07-14T15:00:00.000Z'
+      )
+    ).toBe(true);
+    expect(
+      shouldUseDurableInboxActionState(
+        localState,
+        { id: 'request-1', status: 'failed', updatedAt: '2026-07-14T15:01:00.000Z' },
+        '2026-07-14T15:00:00.000Z'
+      )
+    ).toBe(true);
+  });
+
+  it('uses durable state for the initial render but not for a different local request', () => {
+    const durableRequest = {
+      id: 'request-1',
+      status: 'processing' as const,
+      updatedAt: '2026-07-14T15:01:00.000Z',
+    };
+
+    expect(
+      shouldUseDurableInboxActionState(
+        { message: null, requestId: null, status: 'idle' },
+        durableRequest,
+        null
+      )
+    ).toBe(true);
+    expect(
+      shouldUseDurableInboxActionState(
+        { message: 'Queued.', requestId: 'request-2', status: 'queued' },
+        durableRequest,
+        null
+      )
+    ).toBe(false);
   });
 });

--- a/apps/web/lib/inboxActionState.ts
+++ b/apps/web/lib/inboxActionState.ts
@@ -17,6 +17,10 @@ export const initialInboxActionState: InboxActionState = {
   status: 'idle',
 };
 
+export function isInboxActionSubmitBlocked(status: InboxActionStatus): boolean {
+  return status === 'queued' || status === 'processing' || status === 'completed';
+}
+
 export function completedInboxActionState(
   message: string,
   requestId: string | null = null

--- a/apps/web/lib/inboxActionState.ts
+++ b/apps/web/lib/inboxActionState.ts
@@ -1,0 +1,60 @@
+import type {
+  ModerationActionRequestQueueStatus,
+  ModerationActionRequestReceipt,
+} from './moderationActionRequestQueue';
+
+export type InboxActionStatus = 'idle' | ModerationActionRequestQueueStatus;
+
+export interface InboxActionState {
+  readonly message: string | null;
+  readonly requestId: string | null;
+  readonly status: InboxActionStatus;
+}
+
+export const initialInboxActionState: InboxActionState = {
+  message: null,
+  requestId: null,
+  status: 'idle',
+};
+
+export function completedInboxActionState(message: string): InboxActionState {
+  return {
+    message,
+    requestId: null,
+    status: 'completed',
+  };
+}
+
+export function queuedInboxActionState(
+  receipt: ModerationActionRequestReceipt,
+  message = 'Action queued for Drasil.'
+): InboxActionState {
+  return {
+    message,
+    requestId: receipt.id,
+    status: receipt.status,
+  };
+}
+
+export function failedInboxActionState(error: unknown): InboxActionState {
+  if (
+    error &&
+    typeof error === 'object' &&
+    'digest' in error &&
+    typeof error.digest === 'string' &&
+    error.digest.startsWith('NEXT_REDIRECT')
+  ) {
+    throw error;
+  }
+
+  return {
+    message:
+      error instanceof Error
+        ? error.message
+        : typeof error === 'string'
+          ? error
+          : 'The action could not be completed.',
+    requestId: null,
+    status: 'failed',
+  };
+}

--- a/apps/web/lib/inboxActionState.ts
+++ b/apps/web/lib/inboxActionState.ts
@@ -21,6 +21,32 @@ export function isInboxActionSubmitBlocked(status: InboxActionStatus): boolean {
   return status === 'queued' || status === 'processing' || status === 'completed';
 }
 
+export function isInboxActionInFlight(status: InboxActionStatus): boolean {
+  return status === 'queued' || status === 'processing';
+}
+
+export function shouldUseDurableInboxActionState(
+  localState: InboxActionState,
+  durableRequest: {
+    readonly id: string;
+    readonly status: InboxActionStatus;
+    readonly updatedAt: string;
+  },
+  durableUpdatedAtAtSubmit: string | null
+): boolean {
+  if (localState.status === 'idle') {
+    return true;
+  }
+  if (durableRequest.id !== localState.requestId) {
+    return false;
+  }
+  const staleFailedReceipt =
+    isInboxActionInFlight(localState.status) &&
+    durableRequest.status === 'failed' &&
+    durableRequest.updatedAt === durableUpdatedAtAtSubmit;
+  return !staleFailedReceipt;
+}
+
 export function completedInboxActionState(
   message: string,
   requestId: string | null = null

--- a/apps/web/lib/inboxActionState.ts
+++ b/apps/web/lib/inboxActionState.ts
@@ -17,10 +17,13 @@ export const initialInboxActionState: InboxActionState = {
   status: 'idle',
 };
 
-export function completedInboxActionState(message: string): InboxActionState {
+export function completedInboxActionState(
+  message: string,
+  requestId: string | null = null
+): InboxActionState {
   return {
     message,
-    requestId: null,
+    requestId,
     status: 'completed',
   };
 }

--- a/apps/web/lib/inboxFixtures.ts
+++ b/apps/web/lib/inboxFixtures.ts
@@ -141,6 +141,8 @@ export function fixtureModerationInboxItems(guildId = 'guild-1'): ModerationInbo
         'view_history',
         'dismiss_no_action',
         'mark_false_positive',
+        // Deliberately stale against fixture policy so E2E proves server-side denial is visible.
+        'kick_user',
         'ban_user',
         'open_discord',
       ],

--- a/apps/web/lib/moderationActionRequestDataAdapter.test.ts
+++ b/apps/web/lib/moderationActionRequestDataAdapter.test.ts
@@ -22,13 +22,17 @@ describe('moderationActionRequestDataAdapter', () => {
       actionType: 'clear_moderation_queue',
       actorSurface: 'web',
       completedAt: '2026-06-08T01:20:00.000Z',
+      detectionEventId: null,
       failedAt: null,
       lastError: null,
       requestedAt: '2026-06-08T01:16:00.000Z',
+      reportIntakeId: null,
+      requestedAction: null,
       resultSummary: 'Removed 3 queue items.',
       status: 'completed',
       targetUserId: null,
       updatedAt: '2026-06-08T01:20:00.000Z',
+      verificationEventId: null,
     });
   });
 
@@ -56,6 +60,25 @@ describe('moderationActionRequestDataAdapter', () => {
         updated_at: new Date('2026-06-08T01:20:00.000Z'),
       }).resultSummary
     ).toBe('Dry run found 4 closable; already closed 2; missing 3; failed 1.');
+  });
+
+  it('parses the requested inbox action from request metadata', () => {
+    expect(
+      parseModerationActionRequestRow({
+        id: 'request-repair',
+        action_type: 'repair_active_case',
+        actor_surface: 'web',
+        completed_at: null,
+        failed_at: null,
+        last_error: null,
+        metadata: { case_action: 'create_thread' },
+        requested_at: new Date('2026-06-08T01:16:00.000Z'),
+        result: null,
+        status: 'queued',
+        target_user_id: 'user-1',
+        updated_at: new Date('2026-06-08T01:16:00.000Z'),
+      }).requestedAction
+    ).toBe('create_thread');
   });
 
   it('summarizes lockdown apply results', () => {

--- a/apps/web/lib/moderationActionRequestDataAdapter.ts
+++ b/apps/web/lib/moderationActionRequestDataAdapter.ts
@@ -233,7 +233,7 @@ export class PostgresModerationActionRequestDataAdapter implements ModerationAct
          select id
          from moderation_action_requests
          where server_id = $1
-         order by requested_at desc
+         order by case when $3::boolean then updated_at else requested_at end desc
          limit $2
        ), inbox_request_ids as (
          select id from selected_request_ids

--- a/apps/web/lib/moderationActionRequestDataAdapter.ts
+++ b/apps/web/lib/moderationActionRequestDataAdapter.ts
@@ -10,13 +10,17 @@ export interface ModerationActionRequestSummary {
   readonly actionType: ModerationActionRequestActionType;
   readonly actorSurface: string;
   readonly completedAt: string | null;
+  readonly detectionEventId: string | null;
   readonly failedAt: string | null;
   readonly lastError: string | null;
   readonly requestedAt: string;
+  readonly reportIntakeId: string | null;
+  readonly requestedAction: string | null;
   readonly resultSummary: string | null;
   readonly status: ModerationActionRequestQueueStatus;
   readonly targetUserId: string | null;
   readonly updatedAt: string;
+  readonly verificationEventId: string | null;
 }
 
 export interface ModerationActionRequestDataAdapter {
@@ -28,13 +32,17 @@ interface ModerationActionRequestRow {
   readonly action_type: ModerationActionRequestActionType;
   readonly actor_surface: string;
   readonly completed_at: unknown;
+  readonly detection_event_id?: string | null;
   readonly failed_at: unknown;
   readonly last_error: string | null;
+  readonly metadata?: unknown;
   readonly requested_at: unknown;
+  readonly report_intake_id?: string | null;
   readonly result: unknown;
   readonly status: ModerationActionRequestQueueStatus;
   readonly target_user_id: string | null;
   readonly updated_at: unknown;
+  readonly verification_event_id?: string | null;
 }
 
 function toIsoString(value: unknown): string {
@@ -177,13 +185,21 @@ export function parseModerationActionRequestRow(
     actionType: row.action_type,
     actorSurface: row.actor_surface,
     completedAt: toNullableIsoString(row.completed_at),
+    detectionEventId: row.detection_event_id ?? null,
     failedAt: toNullableIsoString(row.failed_at),
     lastError: row.last_error,
     requestedAt: toIsoString(row.requested_at),
+    reportIntakeId: row.report_intake_id ?? null,
+    requestedAction:
+      row.metadata && typeof row.metadata === 'object' && !Array.isArray(row.metadata)
+        ? (readString((row.metadata as OperationResultRecord).case_action) ??
+          readString((row.metadata as OperationResultRecord).inbox_action))
+        : null,
     resultSummary: buildResultSummary(row.result),
     status: row.status,
     targetUserId: row.target_user_id,
     updatedAt: toIsoString(row.updated_at),
+    verificationEventId: row.verification_event_id ?? null,
   };
 }
 
@@ -199,13 +215,17 @@ export class PostgresModerationActionRequestDataAdapter implements ModerationAct
          action_type::text as action_type,
          actor_surface,
          completed_at,
+         detection_event_id::text,
          failed_at,
          last_error,
+         metadata,
          requested_at,
+         report_intake_id::text,
          result,
          status::text as status,
          target_user_id,
-         updated_at
+         updated_at,
+         verification_event_id::text
        from moderation_action_requests
        where server_id = $1
        order by requested_at desc
@@ -228,91 +248,119 @@ export class FixtureModerationActionRequestDataAdapter implements ModerationActi
         actionType: 'sync_moderation_queue',
         actorSurface: 'web',
         completedAt: fixtureTimestampIso,
+        detectionEventId: null,
         failedAt: null,
         lastError: null,
         requestedAt: fixtureTimestampIso,
+        reportIntakeId: null,
+        requestedAction: null,
         resultSummary: 'Queue sync completed.',
         status: 'completed',
         targetUserId: null,
         updatedAt: fixtureTimestampIso,
+        verificationEventId: null,
       },
       {
         id: 'fixture-action-request-2',
         actionType: 'refresh_case_notification',
         actorSurface: 'web',
-        completedAt: null,
+        completedAt: '2026-06-08T01:11:02.000Z',
+        detectionEventId: null,
         failedAt: null,
         lastError: null,
         requestedAt: '2026-06-08T01:10:02.000Z',
+        reportIntakeId: null,
+        requestedAction: 'refresh_notification',
         resultSummary: null,
-        status: 'queued',
+        status: 'completed',
         targetUserId: 'user-100',
-        updatedAt: '2026-06-08T01:10:02.000Z',
+        updatedAt: '2026-06-08T01:11:02.000Z',
+        verificationEventId: null,
       },
       {
         id: 'fixture-action-request-3',
         actionType: 'close_resolved_case_threads',
         actorSurface: 'web',
         completedAt: '2026-06-08T01:05:02.000Z',
+        detectionEventId: null,
         failedAt: null,
         lastError: null,
         requestedAt: '2026-06-08T01:04:02.000Z',
+        reportIntakeId: null,
+        requestedAction: null,
         resultSummary: 'Dry run found 4 closable; already closed 2; missing 1; failed 0.',
         status: 'completed',
         targetUserId: null,
         updatedAt: '2026-06-08T01:05:02.000Z',
+        verificationEventId: null,
       },
       {
         id: 'fixture-action-request-4',
         actionType: 'audit_case_role_lockdown',
         actorSurface: 'web',
         completedAt: '2026-06-08T00:59:02.000Z',
+        detectionEventId: null,
         failedAt: null,
         lastError: null,
         requestedAt: '2026-06-08T00:58:02.000Z',
+        reportIntakeId: null,
+        requestedAction: null,
         resultSummary: 'Audit found 0 errors, 2 warnings, and 3 planned writes.',
         status: 'completed',
         targetUserId: null,
         updatedAt: '2026-06-08T00:59:02.000Z',
+        verificationEventId: null,
       },
       {
         id: 'fixture-action-request-5',
         actionType: 'intake_role_members',
         actorSurface: 'web',
         completedAt: '2026-06-08T00:51:02.000Z',
+        detectionEventId: null,
         failedAt: null,
         lastError: null,
         requestedAt: '2026-06-08T00:50:02.000Z',
+        reportIntakeId: null,
+        requestedAction: null,
         resultSummary: 'Dry run Manual Intake: selected 8 of 10; skipped active 1; failed 0.',
         status: 'completed',
         targetUserId: null,
         updatedAt: '2026-06-08T00:51:02.000Z',
+        verificationEventId: null,
       },
       {
         id: 'fixture-action-request-6',
         actionType: 'complete_setup_verification',
         actorSurface: 'web',
         completedAt: '2026-06-08T00:48:02.000Z',
+        detectionEventId: null,
         failedAt: null,
         lastError: null,
         requestedAt: '2026-06-08T00:47:02.000Z',
+        reportIntakeId: null,
+        requestedAction: null,
         resultSummary: 'Core setup saved; verification channel configured.',
         status: 'completed',
         targetUserId: null,
         updatedAt: '2026-06-08T00:48:02.000Z',
+        verificationEventId: null,
       },
       {
         id: 'fixture-action-request-7',
         actionType: 'upsert_report_instructions',
         actorSurface: 'web',
         completedAt: '2026-06-08T00:46:02.000Z',
+        detectionEventId: null,
         failedAt: null,
         lastError: null,
         requestedAt: '2026-06-08T00:45:02.000Z',
+        reportIntakeId: null,
+        requestedAction: null,
         resultSummary: 'Report instructions updated in report-channel-1.',
         status: 'completed',
         targetUserId: null,
         updatedAt: '2026-06-08T00:46:02.000Z',
+        verificationEventId: null,
       },
     ];
   }

--- a/apps/web/lib/moderationActionRequestDataAdapter.ts
+++ b/apps/web/lib/moderationActionRequestDataAdapter.ts
@@ -1,3 +1,4 @@
+import { inboxModerationActionRequestTypes } from './inboxActionRequestTypes';
 import type {
   ModerationActionRequestActionType,
   ModerationActionRequestQueueStatus,
@@ -233,6 +234,7 @@ export class PostgresModerationActionRequestDataAdapter implements ModerationAct
          select id
          from moderation_action_requests
          where server_id = $1
+           and (not $3::boolean or action_type = any($4::moderation_action_request_type[]))
          order by case when $3::boolean then updated_at else requested_at end desc
          limit $2
        ), inbox_request_ids as (
@@ -242,6 +244,7 @@ export class PostgresModerationActionRequestDataAdapter implements ModerationAct
          from moderation_action_requests
          where $3::boolean
            and server_id = $1
+           and action_type = any($4::moderation_action_request_type[])
            and status in ('queued', 'processing')
        )
        select
@@ -263,7 +266,7 @@ export class PostgresModerationActionRequestDataAdapter implements ModerationAct
        from moderation_action_requests requests
        join inbox_request_ids selected on selected.id = requests.id
        order by requests.requested_at desc`,
-      [guildId, boundedLimit, includeAllActive]
+      [guildId, boundedLimit, includeAllActive, inboxModerationActionRequestTypes]
     );
 
     return result.rows.map(parseModerationActionRequestRow);

--- a/apps/web/lib/moderationActionRequestDataAdapter.ts
+++ b/apps/web/lib/moderationActionRequestDataAdapter.ts
@@ -24,6 +24,10 @@ export interface ModerationActionRequestSummary {
 }
 
 export interface ModerationActionRequestDataAdapter {
+  listInboxRequests(
+    guildId: string,
+    recentLimit?: number
+  ): Promise<ModerationActionRequestSummary[]>;
   listRecentRequests(guildId: string, limit?: number): Promise<ModerationActionRequestSummary[]>;
 }
 
@@ -204,33 +208,62 @@ export function parseModerationActionRequestRow(
 }
 
 export class PostgresModerationActionRequestDataAdapter implements ModerationActionRequestDataAdapter {
+  public async listInboxRequests(
+    guildId: string,
+    recentLimit = 8
+  ): Promise<ModerationActionRequestSummary[]> {
+    return this.listRequests(guildId, recentLimit, true);
+  }
+
   public async listRecentRequests(
     guildId: string,
     limit = 8
   ): Promise<ModerationActionRequestSummary[]> {
+    return this.listRequests(guildId, limit, false);
+  }
+
+  private async listRequests(
+    guildId: string,
+    limit: number,
+    includeAllActive: boolean
+  ): Promise<ModerationActionRequestSummary[]> {
     const boundedLimit = Math.max(1, Math.min(Math.floor(limit), 25));
     const result = await getPostgresPool().query<ModerationActionRequestRow>(
-      `select
-         id::text,
-         action_type::text as action_type,
-         actor_surface,
-         completed_at,
-         detection_event_id::text,
-         failed_at,
-         last_error,
-         metadata,
-         requested_at,
-         report_intake_id::text,
-         result,
-         status::text as status,
-         target_user_id,
-         updated_at,
-         verification_event_id::text
-       from moderation_action_requests
-       where server_id = $1
-       order by requested_at desc
-       limit $2`,
-      [guildId, boundedLimit]
+      `with selected_request_ids as (
+         select id
+         from moderation_action_requests
+         where server_id = $1
+         order by requested_at desc
+         limit $2
+       ), inbox_request_ids as (
+         select id from selected_request_ids
+         union
+         select id
+         from moderation_action_requests
+         where $3::boolean
+           and server_id = $1
+           and status in ('queued', 'processing')
+       )
+       select
+         requests.id::text,
+         requests.action_type::text as action_type,
+         requests.actor_surface,
+         requests.completed_at,
+         requests.detection_event_id::text,
+         requests.failed_at,
+         requests.last_error,
+         requests.metadata,
+         requests.requested_at,
+         requests.report_intake_id::text,
+         requests.result,
+         requests.status::text as status,
+         requests.target_user_id,
+         requests.updated_at,
+         requests.verification_event_id::text
+       from moderation_action_requests requests
+       join inbox_request_ids selected on selected.id = requests.id
+       order by requests.requested_at desc`,
+      [guildId, boundedLimit, includeAllActive]
     );
 
     return result.rows.map(parseModerationActionRequestRow);
@@ -238,6 +271,13 @@ export class PostgresModerationActionRequestDataAdapter implements ModerationAct
 }
 
 export class FixtureModerationActionRequestDataAdapter implements ModerationActionRequestDataAdapter {
+  public async listInboxRequests(
+    guildId: string,
+    recentLimit = 8
+  ): Promise<ModerationActionRequestSummary[]> {
+    return this.listRecentRequests(guildId, recentLimit);
+  }
+
   public async listRecentRequests(
     _guildId: string,
     _limit = 8

--- a/apps/web/lib/moderationActionRequestQueue.ts
+++ b/apps/web/lib/moderationActionRequestQueue.ts
@@ -34,6 +34,11 @@ export type ModerationActionRequestActionType =
 
 export type ModerationActionRequestQueueStatus = 'queued' | 'processing' | 'completed' | 'failed';
 
+export interface ModerationActionRequestReceipt {
+  readonly id: string;
+  readonly status: ModerationActionRequestQueueStatus;
+}
+
 export interface QueueModerationActionRequestInput {
   readonly actionType: ModerationActionRequestActionType;
   readonly actorId: string;
@@ -50,9 +55,13 @@ export interface QueueModerationActionRequestInput {
 export async function queueModerationActionRequest(
   input: QueueModerationActionRequestInput
 ): Promise<ModerationActionRequestQueueStatus> {
-  const result = await getPostgresPool().query<{
-    status: ModerationActionRequestQueueStatus;
-  }>(
+  return (await queueModerationActionRequestWithReceipt(input)).status;
+}
+
+export async function queueModerationActionRequestWithReceipt(
+  input: QueueModerationActionRequestInput
+): Promise<ModerationActionRequestReceipt> {
+  const result = await getPostgresPool().query<ModerationActionRequestReceipt>(
     `insert into moderation_action_requests (
        server_id,
        action_type,
@@ -89,7 +98,7 @@ export async function queueModerationActionRequest(
          failed_at = null,
          last_error = null,
          metadata = coalesce(moderation_action_requests.metadata, '{}'::jsonb) || excluded.metadata
-     returning status`,
+     returning id::text, status::text as status`,
     [
       input.serverId,
       input.actionType,
@@ -104,5 +113,10 @@ export async function queueModerationActionRequest(
     ]
   );
 
-  return result.rows[0]?.status ?? 'failed';
+  return (
+    result.rows[0] ?? {
+      id: input.idempotencyKey,
+      status: 'failed',
+    }
+  );
 }

--- a/apps/web/lib/observedAlertActionQueue.ts
+++ b/apps/web/lib/observedAlertActionQueue.ts
@@ -40,7 +40,7 @@ export async function queueObservedAlertActionRequest(input: {
   if (isWebE2eFixtureMode()) {
     return {
       id: `fixture-observed-action-${input.action}-${input.detectionEventId}`,
-      status: 'queued',
+      status: input.action === 'dismiss_no_action' ? 'completed' : 'queued',
     };
   }
 

--- a/apps/web/lib/observedAlertActionQueue.ts
+++ b/apps/web/lib/observedAlertActionQueue.ts
@@ -2,8 +2,10 @@ import type { ModerationInboxAction } from '@drasil/contracts';
 import { isWebE2eFixtureMode } from './e2eFixtures';
 import {
   queueModerationActionRequest,
+  queueModerationActionRequestWithReceipt,
   type ModerationActionRequestActionType,
   type ModerationActionRequestQueueStatus,
+  type ModerationActionRequestReceipt,
 } from './moderationActionRequestQueue';
 
 export type ObservedAlertWebAction = Extract<
@@ -34,12 +36,15 @@ export async function queueObservedAlertActionRequest(input: {
   readonly guildId: string;
   readonly reason?: string | null;
   readonly targetUserId: string;
-}): Promise<ModerationActionRequestQueueStatus> {
+}): Promise<ModerationActionRequestReceipt> {
   if (isWebE2eFixtureMode()) {
-    return 'queued';
+    return {
+      id: `fixture-observed-action-${input.action}-${input.detectionEventId}`,
+      status: 'queued',
+    };
   }
 
-  return queueModerationActionRequest({
+  return queueModerationActionRequestWithReceipt({
     actionType: observedAlertRequestTypes[input.action],
     actorId: input.actorId,
     actorSurface: input.actorSurface,

--- a/apps/web/lib/queueAttentionActionAdapter.ts
+++ b/apps/web/lib/queueAttentionActionAdapter.ts
@@ -9,6 +9,8 @@ import { deleteBotMessage } from './discordApi';
 import { isWebE2eFixtureMode } from './e2eFixtures';
 import { getPostgresPool } from './setupDataAdapter';
 
+export type { QueueAttentionAcknowledgeStatus } from '../../../src/services/QueueAttentionService';
+
 export interface QueueAttentionActionAdapter {
   acknowledgeAttentionItem(input: {
     guildId: string;
@@ -77,7 +79,7 @@ export class FixtureQueueAttentionActionAdapter implements QueueAttentionActionA
     return {
       actor: input.actor,
       itemId: input.queueItemId,
-      status: 'acknowledged',
+      status: input.queueItemId === 'queue-support-1' ? 'already_handled' : 'acknowledged',
     };
   }
 }

--- a/apps/web/lib/queueAttentionReceipt.test.ts
+++ b/apps/web/lib/queueAttentionReceipt.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import {
+  formatQueueAttentionAcknowledgement,
+  summarizeQueueAttentionAcknowledgements,
+} from './queueAttentionReceipt';
+
+describe('queueAttentionReceipt', () => {
+  it('formats single acknowledged and stale attention results accurately', () => {
+    expect(
+      formatQueueAttentionAcknowledgement(summarizeQueueAttentionAcknowledgements(['acknowledged']))
+    ).toBe('Reply acknowledged.');
+    expect(
+      formatQueueAttentionAcknowledgement(
+        summarizeQueueAttentionAcknowledgements(['already_handled'])
+      )
+    ).toBe('Reply was already handled.');
+  });
+
+  it('formats mixed bulk attention results with both counts', () => {
+    const summary = summarizeQueueAttentionAcknowledgements([
+      'acknowledged',
+      'already_handled',
+      'acknowledged',
+    ]);
+
+    expect(summary).toEqual({ acknowledgedCount: 2, alreadyHandledCount: 1 });
+    expect(formatQueueAttentionAcknowledgement(summary)).toBe(
+      '2 replies acknowledged; 1 already handled.'
+    );
+  });
+});

--- a/apps/web/lib/queueAttentionReceipt.ts
+++ b/apps/web/lib/queueAttentionReceipt.ts
@@ -1,0 +1,34 @@
+import type { QueueAttentionAcknowledgeStatus } from '../../../src/services/QueueAttentionService';
+
+export interface QueueAttentionAcknowledgementSummary {
+  readonly acknowledgedCount: number;
+  readonly alreadyHandledCount: number;
+}
+
+export function summarizeQueueAttentionAcknowledgements(
+  statuses: readonly QueueAttentionAcknowledgeStatus[]
+): QueueAttentionAcknowledgementSummary {
+  return statuses.reduce<QueueAttentionAcknowledgementSummary>(
+    (summary, status) => ({
+      acknowledgedCount: summary.acknowledgedCount + (status === 'acknowledged' ? 1 : 0),
+      alreadyHandledCount: summary.alreadyHandledCount + (status === 'already_handled' ? 1 : 0),
+    }),
+    { acknowledgedCount: 0, alreadyHandledCount: 0 }
+  );
+}
+
+export function formatQueueAttentionAcknowledgement(
+  summary: QueueAttentionAcknowledgementSummary
+): string {
+  const totalCount = summary.acknowledgedCount + summary.alreadyHandledCount;
+  if (totalCount === 1) {
+    return summary.acknowledgedCount === 1 ? 'Reply acknowledged.' : 'Reply was already handled.';
+  }
+  if (summary.alreadyHandledCount === 0) {
+    return `${summary.acknowledgedCount} replies acknowledged.`;
+  }
+  if (summary.acknowledgedCount === 0) {
+    return `${summary.alreadyHandledCount} replies were already handled.`;
+  }
+  return `${summary.acknowledgedCount} replies acknowledged; ${summary.alreadyHandledCount} already handled.`;
+}

--- a/apps/web/lib/reportQueueDataAdapter.ts
+++ b/apps/web/lib/reportQueueDataAdapter.ts
@@ -9,6 +9,7 @@ import type { QueueAttentionItemRecord } from '../../../src/services/QueueAttent
 import {
   ReportReviewService,
   type ReportCaseOpener,
+  type ReportCaseOpenResult,
   type ReportClosureAction,
   type OpenSubmittedReportCaseResult,
   type ReportOpenCaseCandidate,
@@ -22,7 +23,7 @@ import { deleteBotMessage } from './discordApi';
 import { fixtureSubmittedReports } from './reportFixtures';
 import { discordMessageUrl } from './discordUrls';
 import { isWebE2eFixtureMode } from './e2eFixtures';
-import { queueModerationActionRequest } from './moderationActionRequestQueue';
+import { queueModerationActionRequestWithReceipt } from './moderationActionRequestQueue';
 import { getPostgresPool } from './setupDataAdapter';
 
 export type { ReportClosureAction } from '../../../src/services/ReportReviewService';
@@ -190,8 +191,8 @@ class PostgresQueuedReportCaseOpener implements ReportCaseOpener {
     reportId?: string;
     serverId: string;
     userId: string;
-  }): Promise<{ status: 'queued' | 'already_handled' }> {
-    const status = await queueModerationActionRequest({
+  }): Promise<ReportCaseOpenResult> {
+    const receipt = await queueModerationActionRequestWithReceipt({
       actionType: 'open_case_from_observed_detection',
       actorId: input.actor.id,
       actorSurface: input.actor.surface,
@@ -205,7 +206,13 @@ class PostgresQueuedReportCaseOpener implements ReportCaseOpener {
       serverId: input.serverId,
       targetUserId: input.userId,
     });
-    return { status: status === 'completed' ? 'already_handled' : 'queued' };
+    if (receipt.status === 'failed') {
+      throw new Error('Report case action could not be queued. Refresh the inbox and try again.');
+    }
+    return {
+      requestId: receipt.id,
+      status: receipt.status === 'completed' ? 'already_handled' : 'queued',
+    };
   }
 }
 
@@ -342,6 +349,7 @@ export class FixtureReportQueueDataAdapter implements ReportQueueDataAdapter {
       caseId: report?.latestCaseId ?? `fixture-case-${input.reportId}`,
       detectionEventId: report?.latestDetectionId ?? null,
       reportId: input.reportId,
+      requestId: `fixture-report-open-case-${input.reportId}`,
       status: report?.targetUserId && report.latestDetectionId ? 'opened' : 'missing_detection',
       targetUserId: report?.targetUserId ?? null,
       queueCleanupStatus: 'skipped',

--- a/src/services/ReportReviewService.ts
+++ b/src/services/ReportReviewService.ts
@@ -71,6 +71,7 @@ export interface ReportCaseOpener {
 
 export interface ReportCaseOpenResult {
   readonly caseId?: string | null;
+  readonly requestId?: string | null;
   readonly status: ReportCaseOpenStatus;
 }
 
@@ -107,6 +108,7 @@ export interface OpenSubmittedReportCaseResult {
   readonly caseId: string | null;
   readonly detectionEventId: string | null;
   readonly reportId: string;
+  readonly requestId?: string | null;
   readonly status: OpenSubmittedReportCaseStatus;
   readonly targetUserId: string | null;
   readonly queueCleanupStatus: ReportQueueCleanupStatus;
@@ -224,6 +226,7 @@ export class ReportReviewService {
       return this.buildOpenCaseResult(input, {
         caseId: opened.caseId,
         detectionEventId: candidate.latest_detection_id,
+        requestId: opened.requestId,
         status: opened.status,
         targetUserId: candidate.confirmed_target_user_id,
       });
@@ -271,6 +274,7 @@ export class ReportReviewService {
       readonly caseId?: string | null;
       readonly detectionEventId?: string | null;
       readonly queueCleanupStatus?: ReportQueueCleanupStatus;
+      readonly requestId?: string | null;
       readonly status: OpenSubmittedReportCaseStatus;
       readonly targetUserId?: string | null;
     }
@@ -281,6 +285,7 @@ export class ReportReviewService {
       caseId: overrides.caseId ?? null,
       detectionEventId: overrides.detectionEventId ?? null,
       reportId: input.reportId,
+      ...(overrides.requestId ? { requestId: overrides.requestId } : {}),
       status: overrides.status,
       targetUserId: overrides.targetUserId ?? null,
       queueCleanupStatus: overrides.queueCleanupStatus ?? 'skipped',


### PR DESCRIPTION
[AGENT]

## What / Why

Moderators now get deterministic feedback for every executable inbox action instead of a silent form submission. Bot-owned actions return durable request IDs, show queued/processing/completed/failed state, prevent duplicate submissions, poll only while work is active, and link directly to the matching Operations record. Synchronous report and attention actions use the same inline pending, success, and error treatment.

The Playwright fixture flows now verify successful receipts, duplicate-submit blocking, missing confirmation, required reasons, and server-policy rejection.

## Linked issues

- Closes #184
- Refs #126

## Risk / rollout

The change reuses the existing moderation action request queue and worker contracts. No schema or deployment configuration changes are required. The main behavioral risk is stale request-to-action matching; matching is constrained by durable case, detection, or report IDs and by the requested action metadata when worker action types are shared.

## AI Review Packet (fresh-context friendly)

- Primary goal: make moderation inbox actions observable, non-duplicating, and traceable to durable bot requests.
- Non-goals: changing confirmation UX, moderation policy, worker execution semantics, or adding message deletion from #137.
- Key files changed: InboxActionForm, ModerationInboxView, case/report/observed server actions, moderation action request adapters, and Playwright smoke coverage.
- Invariants this PR must preserve: server-side permission/policy checks remain authoritative; destructive actions still require their existing inline confirmation and configured reason; direct action pages retain their existing behavior.
- Manual test notes: fixture Playwright holds one server action open and verifies a second forced click emits no second POST.
- Questions for reviewers: verify request matching cannot surface a receipt under the wrong inbox action, especially repair_thread versus create_thread.

## Merge checklist

- [x] All PR review threads resolved (or explicitly addressed)