### PR TITLE
[AGENT] Contain recoverable Discord event failures

### DIFF
--- a/src/__tests__/unit/EventHandler.unit.test.ts
+++ b/src/__tests__/unit/EventHandler.unit.test.ts
@@ -3,6 +3,7 @@ import {
   Events,
   GuildMember,
   Message,
+  MessageFlags,
   MessageType,
   PermissionFlagsBits,
   PermissionsBitField,
@@ -41,6 +42,7 @@ describe('EventHandler (unit)', () => {
     roleQuarantineService?: Record<string, jest.Mock>;
     verificationEventRepository?: Record<string, jest.Mock>;
     globalMessageWatchlistRepository?: Record<string, jest.Mock>;
+    interactionHandler?: Record<string, jest.Mock>;
   }): EventHandler {
     const client = overrides?.client ?? { on: jest.fn(), user: { id: 'bot-1' } };
     const detectionOrchestrator = overrides?.detectionOrchestrator ?? {
@@ -107,7 +109,11 @@ describe('EventHandler (unit)', () => {
         }),
       }) as any,
       { registerCommands: jest.fn() } as any,
-      { handleButtonInteraction: jest.fn(), handleModalSubmit: jest.fn() } as any,
+      (overrides?.interactionHandler ?? {
+        handleButtonInteraction: jest.fn(),
+        handleStringSelectMenuInteraction: jest.fn(),
+        handleModalSubmit: jest.fn(),
+      }) as any,
       { handleThreadMessage: jest.fn().mockResolvedValue(false) } as any,
       overrides?.productAnalyticsService as any,
       overrides?.setupDiagnosticsService as any,
@@ -203,6 +209,121 @@ describe('EventHandler (unit)', () => {
     expect(client.on).toHaveBeenCalledWith(Events.InteractionCreate, expect.any(Function));
     expect(client.on).toHaveBeenCalledWith(Events.GuildCreate, expect.any(Function));
     expect(client.on).not.toHaveBeenCalledWith('ready', expect.any(Function));
+  });
+
+  it('contains expired interactions without attempting another response', async () => {
+    const client = { on: jest.fn(), user: { id: 'bot-1' } };
+    const unknownInteractionError = Object.assign(new Error('Unknown interaction'), {
+      code: 10062,
+    });
+    const interactionHandler = {
+      handleButtonInteraction: jest.fn().mockRejectedValue(unknownInteractionError),
+      handleStringSelectMenuInteraction: jest.fn(),
+      handleModalSubmit: jest.fn(),
+    };
+    const consoleWarn = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const consoleError = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+    const handler = buildHandler({ client, interactionHandler });
+    await handler.setupEventHandlers();
+    const interactionCreateHandler = client.on.mock.calls.find(
+      ([event]) => event === Events.InteractionCreate
+    )?.[1];
+    const interaction = {
+      isChatInputCommand: jest.fn().mockReturnValue(false),
+      isUserContextMenuCommand: jest.fn().mockReturnValue(false),
+      isMessageContextMenuCommand: jest.fn().mockReturnValue(false),
+      isButton: jest.fn().mockReturnValue(true),
+      isStringSelectMenu: jest.fn().mockReturnValue(false),
+      isModalSubmit: jest.fn().mockReturnValue(false),
+      isRepliable: jest.fn().mockReturnValue(true),
+      replied: false,
+      deferred: false,
+      reply: jest.fn(),
+    };
+
+    await expect(interactionCreateHandler?.(interaction as any)).resolves.toBeUndefined();
+
+    expect(interaction.reply).not.toHaveBeenCalled();
+    expect(consoleWarn).toHaveBeenCalledWith(
+      'Discord interaction is no longer valid (10062); skipping fallback response.'
+    );
+    expect(consoleError).not.toHaveBeenCalled();
+
+    consoleWarn.mockRestore();
+    consoleError.mockRestore();
+  });
+
+  it('does not reject when the fallback interaction response has expired', async () => {
+    const client = { on: jest.fn(), user: { id: 'bot-1' } };
+    const interactionHandler = {
+      handleButtonInteraction: jest.fn().mockRejectedValue(new Error('button failed')),
+      handleStringSelectMenuInteraction: jest.fn(),
+      handleModalSubmit: jest.fn(),
+    };
+    const consoleWarn = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const consoleError = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+    const handler = buildHandler({ client, interactionHandler });
+    await handler.setupEventHandlers();
+    const interactionCreateHandler = client.on.mock.calls.find(
+      ([event]) => event === Events.InteractionCreate
+    )?.[1];
+    const interaction = {
+      isChatInputCommand: jest.fn().mockReturnValue(false),
+      isUserContextMenuCommand: jest.fn().mockReturnValue(false),
+      isMessageContextMenuCommand: jest.fn().mockReturnValue(false),
+      isButton: jest.fn().mockReturnValue(true),
+      isStringSelectMenu: jest.fn().mockReturnValue(false),
+      isModalSubmit: jest.fn().mockReturnValue(false),
+      isRepliable: jest.fn().mockReturnValue(true),
+      replied: false,
+      deferred: false,
+      reply: jest
+        .fn()
+        .mockRejectedValue(Object.assign(new Error('Unknown interaction'), { code: 10062 })),
+    };
+
+    await expect(interactionCreateHandler?.(interaction as any)).resolves.toBeUndefined();
+
+    expect(interaction.reply).toHaveBeenCalledWith({
+      content: 'An error occurred while processing this interaction.',
+      flags: MessageFlags.Ephemeral,
+    });
+    expect(consoleError).toHaveBeenCalledWith('Error handling interaction:', expect.any(Error));
+    expect(consoleWarn).toHaveBeenCalledWith(
+      'Discord interaction expired before the error response could be sent (10062).'
+    );
+
+    consoleWarn.mockRestore();
+    consoleError.mockRestore();
+  });
+
+  it('contains unexpected recoverable event handler rejections', async () => {
+    const client = { on: jest.fn(), user: { id: 'bot-1' } };
+    const handler = buildHandler({ client });
+    const eventError = new Error('event failed');
+    const consoleError = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+    (handler as any).handleMessage = jest.fn().mockRejectedValue(eventError);
+    await handler.setupEventHandlers();
+    const listener = client.on.mock.calls.find(([event]) => event === Events.MessageCreate)?.[1];
+
+    await expect(listener?.({})).resolves.toBeUndefined();
+
+    expect(consoleError).toHaveBeenCalledWith(
+      'Unexpected error in recoverable Discord event "messageCreate":',
+      eventError
+    );
+    consoleError.mockRestore();
+  });
+
+  it('keeps ready-time initialization outside the recoverable event boundary', async () => {
+    const client = { on: jest.fn(), user: { id: 'bot-1' } };
+    const handler = buildHandler({ client });
+    const startupError = new Error('startup failed');
+    (handler as any).handleReady = jest.fn().mockRejectedValue(startupError);
+    await handler.setupEventHandlers();
+    const readyListener = client.on.mock.calls.find(([event]) => event === Events.ClientReady)?.[1];
+
+    await expect(readyListener?.()).rejects.toBe(startupError);
   });
 
   it('opens a manual intake case when the configured trigger role remains after the grace period', async () => {

--- a/src/controllers/EventHandler.ts
+++ b/src/controllers/EventHandler.ts
@@ -47,7 +47,7 @@ import {
 import { IReportIntakeService } from '../services/ReportIntakeService';
 import { IReportIntakeAgentService } from '../services/ReportIntakeAgentService';
 import { ICaseReviewReminderService } from '../services/CaseReviewReminderService';
-import { isDiscordUnknownBanError } from '../utils/discordErrors';
+import { isDiscordUnknownBanError, isDiscordUnknownInteractionError } from '../utils/discordErrors';
 import { messageAttachmentsToReportMetadata } from '../utils/reportAttachments';
 import {
   findMessageWatchlistMatch,
@@ -214,14 +214,62 @@ export class EventHandler implements IEventHandler {
   }
 
   public async setupEventHandlers(): Promise<void> {
+    // Ready-time initialization is critical startup work and intentionally remains outside the
+    // recoverable operational event boundary.
     this.client.on(Events.ClientReady, this.handleReady.bind(this));
-    this.client.on(Events.MessageCreate, this.handleMessage.bind(this));
-    this.client.on(Events.GuildMemberAdd, this.handleGuildMemberAdd.bind(this));
-    this.client.on(Events.GuildMemberUpdate, this.handleGuildMemberUpdate.bind(this));
-    this.client.on(Events.GuildMemberRemove, this.handleGuildMemberRemove.bind(this));
-    this.client.on(Events.GuildBanAdd, this.handleGuildBanAdd.bind(this));
-    this.client.on(Events.InteractionCreate, this.handleInteraction.bind(this));
-    this.client.on(Events.GuildCreate, this.handleGuildCreate.bind(this));
+    this.client.on(
+      Events.MessageCreate,
+      this.createRecoverableEventHandler(Events.MessageCreate, this.handleMessage.bind(this))
+    );
+    this.client.on(
+      Events.GuildMemberAdd,
+      this.createRecoverableEventHandler(
+        Events.GuildMemberAdd,
+        this.handleGuildMemberAdd.bind(this)
+      )
+    );
+    this.client.on(
+      Events.GuildMemberUpdate,
+      this.createRecoverableEventHandler(
+        Events.GuildMemberUpdate,
+        this.handleGuildMemberUpdate.bind(this)
+      )
+    );
+    this.client.on(
+      Events.GuildMemberRemove,
+      this.createRecoverableEventHandler(
+        Events.GuildMemberRemove,
+        this.handleGuildMemberRemove.bind(this)
+      )
+    );
+    this.client.on(
+      Events.GuildBanAdd,
+      this.createRecoverableEventHandler(Events.GuildBanAdd, this.handleGuildBanAdd.bind(this))
+    );
+    this.client.on(
+      Events.InteractionCreate,
+      this.createRecoverableEventHandler(
+        Events.InteractionCreate,
+        this.handleInteraction.bind(this)
+      )
+    );
+    this.client.on(
+      Events.GuildCreate,
+      this.createRecoverableEventHandler(Events.GuildCreate, this.handleGuildCreate.bind(this))
+    );
+  }
+
+  private createRecoverableEventHandler<TArguments extends unknown[]>(
+    eventName: string,
+    handler: (...args: TArguments) => Promise<void>
+  ): (...args: TArguments) => Promise<void> {
+    return async (...args: TArguments): Promise<void> => {
+      try {
+        await handler(...args);
+      } catch (error) {
+        console.error(`Unexpected error in recoverable Discord event "${eventName}":`, error);
+      }
+    };
   }
 
   private async handleReady(): Promise<void> {
@@ -259,15 +307,35 @@ export class EventHandler implements IEventHandler {
         await this.interactionHandler.handleModalSubmit(interaction);
       }
     } catch (error) {
-      console.error('Error handling interaction:', error);
-
-      // Try to respond if the interaction hasn't been replied to
-      if (interaction.isRepliable() && !interaction.replied && !interaction.deferred) {
-        await interaction.reply({
-          content: 'An error occurred while processing this interaction.',
-          flags: MessageFlags.Ephemeral,
-        });
+      if (isDiscordUnknownInteractionError(error)) {
+        console.warn('Discord interaction is no longer valid (10062); skipping fallback response.');
+        return;
       }
+
+      console.error('Error handling interaction:', error);
+      await this.trySendInteractionErrorResponse(interaction);
+    }
+  }
+
+  private async trySendInteractionErrorResponse(interaction: Interaction): Promise<void> {
+    try {
+      if (!interaction.isRepliable() || interaction.replied || interaction.deferred) {
+        return;
+      }
+
+      await interaction.reply({
+        content: 'An error occurred while processing this interaction.',
+        flags: MessageFlags.Ephemeral,
+      });
+    } catch (error) {
+      if (isDiscordUnknownInteractionError(error)) {
+        console.warn(
+          'Discord interaction expired before the error response could be sent (10062).'
+        );
+        return;
+      }
+
+      console.warn('Failed to send interaction error response:', error);
     }
   }
 

--- a/src/utils/discordErrors.ts
+++ b/src/utils/discordErrors.ts
@@ -1,6 +1,7 @@
 export const DISCORD_UNKNOWN_CHANNEL_ERROR_CODE = 10003;
 export const DISCORD_UNKNOWN_MEMBER_ERROR_CODE = 10007;
 export const DISCORD_UNKNOWN_MESSAGE_ERROR_CODE = 10008;
+export const DISCORD_UNKNOWN_INTERACTION_ERROR_CODE = 10062;
 export const DISCORD_UNKNOWN_BAN_ERROR_CODE = 10026;
 
 export function getDiscordErrorCode(error: unknown): number | string | undefined {
@@ -15,6 +16,10 @@ export function isDiscordErrorCode(error: unknown, code: number): boolean {
 
 export function isDiscordUnknownBanError(error: unknown): boolean {
   return isDiscordErrorCode(error, DISCORD_UNKNOWN_BAN_ERROR_CODE);
+}
+
+export function isDiscordUnknownInteractionError(error: unknown): boolean {
+  return isDiscordErrorCode(error, DISCORD_UNKNOWN_INTERACTION_ERROR_CODE);
 }
 
 export function formatDiscordFetchError(error: unknown, maxLength = 180): string {


### PR DESCRIPTION
[AGENT]

## What / Why

- Treat Discord `10062` unknown/expired interactions as recoverable and skip a fallback response that cannot succeed.
- Contain failures from the fallback interaction response itself.
- Add a terminal async boundary around operational Discord event listeners so one event cannot terminate unrelated bot work.
- Keep ready-time initialization outside the recoverable boundary because it is critical startup work.

## Linked issues

- Closes #187

## How to test

- `npm test -- --runTestsByPath src/__tests__/unit/EventHandler.unit.test.ts --runInBand`
- The focused regression coverage reproduces both the original expired acknowledgement and the double-failure fallback path.

## Risk / rollout

Low and isolated to Discord event error handling. Expected successful event behavior is unchanged. The primary behavioral change is that recoverable event failures are logged and contained instead of reaching the process supervisor.

This PR does not change fatal shutdown/exit codes, background-job supervision, ECS health checks, or alerting.

## AI Review Packet (fresh-context friendly)

- Primary goal: prevent recoverable Discord interaction and event failures from restarting the bot.
- Non-goals: process supervisor semantics, background-task audit, infrastructure health checks, restart alarms, and moderation policy changes.
- Key files changed: `src/controllers/EventHandler.ts`, `src/utils/discordErrors.ts`, and `src/__tests__/unit/EventHandler.unit.test.ts`.
- Invariants this PR must preserve: ready-time initialization remains critical; successful interaction/event behavior is unchanged; unexpected failures remain visible in logs.
- Manual test notes: local build, lint, formatting, focused tests, and the full 808-test unit gate passed.
- Questions for reviewers: Is the ready-versus-operational event boundary clear and appropriately narrow?

## Merge checklist

- [ ] All PR review threads resolved (or explicitly addressed)
