### PR TITLE
[AGENT] Reconcile stale moderation queue messages

### DIFF
--- a/src/__tests__/unit/ModerationQueueService.unit.test.ts
+++ b/src/__tests__/unit/ModerationQueueService.unit.test.ts
@@ -19,6 +19,7 @@ import { ModerationQueueService } from '../../services/ModerationQueueService';
 class FakeDiscordMessage {
   public readonly id: string;
   public readonly channelId: string;
+  public readonly author: { id: string };
   public payload: Record<string, unknown>;
   public deleted = false;
   public edit = jest.fn(async (payload: MessageEditOptions) => {
@@ -30,10 +31,36 @@ class FakeDiscordMessage {
     return this as unknown as Message;
   });
 
-  constructor(id: string, channelId: string, payload: Record<string, unknown>) {
+  constructor(
+    id: string,
+    channelId: string,
+    payload: Record<string, unknown>,
+    authorId = 'bot-user'
+  ) {
     this.id = id;
     this.channelId = channelId;
     this.payload = payload;
+    this.author = { id: authorId };
+  }
+
+  public get embeds(): Array<{
+    title?: string;
+    fields: Array<{ name: string; value: string }>;
+  }> {
+    const embeds = Array.isArray(this.payload.embeds) ? this.payload.embeds : [];
+    return embeds.map((embed) => {
+      const serialized =
+        embed &&
+        typeof embed === 'object' &&
+        'toJSON' in embed &&
+        typeof embed.toJSON === 'function'
+          ? embed.toJSON()
+          : embed;
+      return serialized as {
+        title?: string;
+        fields: Array<{ name: string; value: string }>;
+      };
+    });
   }
 }
 
@@ -42,12 +69,21 @@ class FakeDiscordChannel {
   private nextMessageId = 0;
   public readonly sentMessages: FakeDiscordMessage[] = [];
   public readonly messages = {
-    fetch: jest.fn(async (messageId: string) => {
-      const message = this.sentMessages.find((entry) => entry.id === messageId);
-      if (!message) {
-        throw new Error(`Message ${messageId} not found`);
+    fetch: jest.fn(async (request: string | { limit: number; before?: string }) => {
+      if (typeof request === 'string') {
+        const message = this.sentMessages.find((entry) => entry.id === request && !entry.deleted);
+        if (!message) {
+          throw Object.assign(new Error(`Message ${request} not found`), { code: 10008 });
+        }
+        return message as unknown as Message;
       }
-      return message as unknown as Message;
+
+      const visibleMessages = this.sentMessages.filter((entry) => !entry.deleted).reverse();
+      const startIndex = request.before
+        ? Math.max(0, visibleMessages.findIndex((entry) => entry.id === request.before) + 1)
+        : 0;
+      const page = visibleMessages.slice(startIndex, startIndex + request.limit);
+      return new Map(page.map((message) => [message.id, message])) as unknown;
     }),
   };
   public readonly send = jest.fn(async (payload: MessageCreateOptions) => {
@@ -84,6 +120,16 @@ class FakeModerationQueueRepository implements IModerationQueueRepository {
     );
   }
 
+  async listByCase(verificationEventId: string): Promise<ModerationQueueItem[]> {
+    return this.items
+      .filter(
+        (item) =>
+          item.item_type === ModerationQueueItemType.CASE_MIRROR &&
+          item.verification_event_id === verificationEventId
+      )
+      .map((item) => ({ ...item }));
+  }
+
   async findByObservedAlert(detectionEventId: string): Promise<ModerationQueueItem | null> {
     return this.clone(
       this.items.find(
@@ -92,6 +138,22 @@ class FakeModerationQueueRepository implements IModerationQueueRepository {
           item.detection_event_id === detectionEventId
       ) ?? null
     );
+  }
+
+  async listByObservedAlert(detectionEventId: string): Promise<ModerationQueueItem[]> {
+    return this.items
+      .filter(
+        (item) =>
+          item.item_type === ModerationQueueItemType.OBSERVED_ALERT_MIRROR &&
+          item.detection_event_id === detectionEventId
+      )
+      .map((item) => ({ ...item }));
+  }
+
+  async listByReportIntake(reportIntakeId: string): Promise<ModerationQueueItem[]> {
+    return this.items
+      .filter((item) => item.report_intake_id === reportIntakeId)
+      .map((item) => ({ ...item }));
   }
 
   async findByPendingScreeningMember(
@@ -204,34 +266,6 @@ class FakeModerationQueueRepository implements IModerationQueueRepository {
     return { ...deleted };
   }
 
-  async deleteByCase(verificationEventId: string): Promise<ModerationQueueItem[]> {
-    return this.deleteMatching((item) => item.verification_event_id === verificationEventId);
-  }
-
-  async deleteByObservedAlert(detectionEventId: string): Promise<ModerationQueueItem[]> {
-    return this.deleteMatching(
-      (item) =>
-        item.item_type === ModerationQueueItemType.OBSERVED_ALERT_MIRROR &&
-        item.detection_event_id === detectionEventId
-    );
-  }
-
-  async deleteByPendingScreeningMember(
-    serverId: string,
-    userId: string
-  ): Promise<ModerationQueueItem[]> {
-    return this.deleteMatching(
-      (item) =>
-        item.item_type === ModerationQueueItemType.PENDING_SCREENING_MEMBER &&
-        item.server_id === serverId &&
-        item.user_id === userId
-    );
-  }
-
-  async deleteByReportIntake(reportIntakeId: string): Promise<ModerationQueueItem[]> {
-    return this.deleteMatching((item) => item.report_intake_id === reportIntakeId);
-  }
-
   private matches(
     item: ModerationQueueItem,
     data: Parameters<IModerationQueueRepository['upsert']>[0]
@@ -252,13 +286,6 @@ class FakeModerationQueueRepository implements IModerationQueueRepository {
         item.item_type === data.itemType &&
         item.source_thread_id === data.sourceThreadId)
     );
-  }
-
-  // eslint-disable-next-line no-unused-vars -- TypeScript requires a parameter name in this function type.
-  private deleteMatching(predicate: (item: ModerationQueueItem) => boolean): ModerationQueueItem[] {
-    const deleted = this.items.filter(predicate);
-    this.items = this.items.filter((item) => !predicate(item));
-    return deleted.map((item) => ({ ...item }));
   }
 
   private clone(item: ModerationQueueItem | null): ModerationQueueItem | null {
@@ -369,6 +396,7 @@ const buildService = (
     ),
   } as unknown as IDetectionEventsRepository;
   const client = {
+    user: { id: 'bot-user' },
     channels: {
       fetch: jest.fn(async (channelId: string) => (channelId === channel.id ? channel : null)),
     },
@@ -389,6 +417,15 @@ const buildService = (
 };
 
 describe('ModerationQueueService', () => {
+  const buildCaseMirrorMessagePayload = (caseId: string): Record<string, unknown> => ({
+    embeds: [
+      {
+        title: 'Pending Moderation Case',
+        fields: [{ name: 'Case', value: `\`${caseId}\`` }],
+      },
+    ],
+  });
+
   it('syncs pending cases and un-actioned observed alerts, then removes stale mirrors', async () => {
     const queueRepository = new FakeModerationQueueRepository();
     const stale = await queueRepository.upsert({
@@ -558,5 +595,100 @@ describe('ModerationQueueService', () => {
       expect.any(Error)
     );
     warnSpy.mockRestore();
+  });
+
+  it('retains a case queue pointer when Discord deletion fails so reconciliation can retry', async () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const { channel, queueRepository, service } = buildService();
+    await service.upsertCaseMirror(buildVerificationEvent());
+    channel.sentMessages[0].delete.mockRejectedValueOnce(new Error('Temporary Discord failure'));
+
+    await service.deleteCaseMirror('case-1');
+
+    expect(queueRepository.items).toHaveLength(1);
+    expect(queueRepository.items[0].queue_message_id).toBe(channel.sentMessages[0].id);
+
+    await service.deleteCaseMirror('case-1');
+
+    expect(channel.sentMessages[0].delete).toHaveBeenCalledTimes(2);
+    expect(queueRepository.items).toHaveLength(0);
+    warnSpy.mockRestore();
+  });
+
+  it('removes an orphaned bot-authored case card during queue sync', async () => {
+    const channel = new FakeDiscordChannel('queue-channel');
+    const orphanedMessage = new FakeDiscordMessage(
+      'orphaned-message',
+      channel.id,
+      buildCaseMirrorMessagePayload('resolved-case')
+    );
+    const moderatorMessage = new FakeDiscordMessage(
+      'moderator-message',
+      channel.id,
+      buildCaseMirrorMessagePayload('resolved-case'),
+      'moderator-user'
+    );
+    const unrelatedBotMessage = new FakeDiscordMessage('unrelated-bot-message', channel.id, {
+      embeds: [{ title: 'Queue instructions', fields: [] }],
+    });
+    channel.sentMessages.push(orphanedMessage, moderatorMessage, unrelatedBotMessage);
+    const { service } = buildService({ channel });
+
+    await service.syncServerQueue('guild-1');
+
+    expect(orphanedMessage.delete).toHaveBeenCalledTimes(1);
+    expect(orphanedMessage.deleted).toBe(true);
+    expect(moderatorMessage.delete).not.toHaveBeenCalled();
+    expect(unrelatedBotMessage.delete).not.toHaveBeenCalled();
+  });
+
+  it('removes duplicate case cards while keeping the database-tracked active card', async () => {
+    const channel = new FakeDiscordChannel('queue-channel');
+    const trackedMessage = new FakeDiscordMessage(
+      'tracked-message',
+      channel.id,
+      buildCaseMirrorMessagePayload('case-1')
+    );
+    const duplicateMessage = new FakeDiscordMessage(
+      'duplicate-message',
+      channel.id,
+      buildCaseMirrorMessagePayload('case-1')
+    );
+    channel.sentMessages.push(trackedMessage, duplicateMessage);
+    const queueRepository = new FakeModerationQueueRepository();
+    await queueRepository.upsert({
+      serverId: 'guild-1',
+      userId: 'user-1',
+      itemType: ModerationQueueItemType.CASE_MIRROR,
+      verificationEventId: 'case-1',
+      queueChannelId: channel.id,
+      queueMessageId: trackedMessage.id,
+    });
+    const { service } = buildService({
+      channel,
+      pendingCases: [buildVerificationEvent()],
+      queueRepository,
+    });
+
+    await service.syncServerQueue('guild-1');
+
+    expect(trackedMessage.delete).not.toHaveBeenCalled();
+    expect(duplicateMessage.delete).toHaveBeenCalledTimes(1);
+  });
+
+  it('runs the shared queue reconciliation at startup and once per day', async () => {
+    jest.useFakeTimers();
+    const { service } = buildService();
+    const syncSpy = jest.spyOn(service, 'syncAllActiveServerQueues').mockResolvedValue();
+
+    service.start();
+    expect(syncSpy).toHaveBeenCalledTimes(1);
+    await Promise.resolve();
+
+    jest.advanceTimersByTime(24 * 60 * 60 * 1000);
+    expect(syncSpy).toHaveBeenCalledTimes(2);
+
+    service.stop();
+    jest.useRealTimers();
   });
 });

--- a/src/__tests__/unit/ModerationQueueService.unit.test.ts
+++ b/src/__tests__/unit/ModerationQueueService.unit.test.ts
@@ -339,6 +339,7 @@ const buildService = (
     observedAlerts?: DetectionEvent[];
     queueRepository?: FakeModerationQueueRepository;
     channel?: FakeDiscordChannel;
+    channelFetchError?: unknown;
   } = {}
 ) => {
   const server = input.server ?? buildServer();
@@ -361,7 +362,12 @@ const buildService = (
   } as unknown as IDetectionEventsRepository;
   const client = {
     channels: {
-      fetch: jest.fn(async (channelId: string) => (channelId === channel.id ? channel : null)),
+      fetch: jest.fn(async (channelId: string) => {
+        if (input.channelFetchError !== undefined) {
+          throw input.channelFetchError;
+        }
+        return channelId === channel.id ? channel : null;
+      }),
     },
   } as unknown as Client;
 
@@ -566,6 +572,52 @@ describe('ModerationQueueService', () => {
 
     expect(channel.sentMessages[0].delete).toHaveBeenCalledTimes(2);
     expect(queueRepository.items).toHaveLength(0);
+    warnSpy.mockRestore();
+  });
+
+  it('clears a case queue pointer when its Discord channel no longer exists', async () => {
+    const queueRepository = new FakeModerationQueueRepository();
+    await queueRepository.upsert({
+      serverId: 'guild-1',
+      userId: 'user-1',
+      itemType: ModerationQueueItemType.CASE_MIRROR,
+      verificationEventId: 'case-1',
+      queueChannelId: 'deleted-channel',
+      queueMessageId: 'deleted-message',
+    });
+    const { service } = buildService({
+      queueRepository,
+      channelFetchError: Object.assign(new Error('Unknown Channel'), { code: 10003 }),
+    });
+
+    await service.deleteCaseMirror('case-1');
+
+    expect(queueRepository.items).toHaveLength(0);
+  });
+
+  it('retains a case queue pointer when the Discord channel fetch fails transiently', async () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const queueRepository = new FakeModerationQueueRepository();
+    await queueRepository.upsert({
+      serverId: 'guild-1',
+      userId: 'user-1',
+      itemType: ModerationQueueItemType.CASE_MIRROR,
+      verificationEventId: 'case-1',
+      queueChannelId: 'queue-channel',
+      queueMessageId: 'queue-message',
+    });
+    const { service } = buildService({
+      queueRepository,
+      channelFetchError: new Error('Temporary Discord failure'),
+    });
+
+    await service.deleteCaseMirror('case-1');
+
+    expect(queueRepository.items).toHaveLength(1);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Failed to fetch live moderation queue channel'),
+      expect.any(Error)
+    );
     warnSpy.mockRestore();
   });
 

--- a/src/__tests__/unit/ModerationQueueService.unit.test.ts
+++ b/src/__tests__/unit/ModerationQueueService.unit.test.ts
@@ -19,7 +19,6 @@ import { ModerationQueueService } from '../../services/ModerationQueueService';
 class FakeDiscordMessage {
   public readonly id: string;
   public readonly channelId: string;
-  public readonly author: { id: string };
   public payload: Record<string, unknown>;
   public deleted = false;
   public edit = jest.fn(async (payload: MessageEditOptions) => {
@@ -31,36 +30,10 @@ class FakeDiscordMessage {
     return this as unknown as Message;
   });
 
-  constructor(
-    id: string,
-    channelId: string,
-    payload: Record<string, unknown>,
-    authorId = 'bot-user'
-  ) {
+  constructor(id: string, channelId: string, payload: Record<string, unknown>) {
     this.id = id;
     this.channelId = channelId;
     this.payload = payload;
-    this.author = { id: authorId };
-  }
-
-  public get embeds(): Array<{
-    title?: string;
-    fields: Array<{ name: string; value: string }>;
-  }> {
-    const embeds = Array.isArray(this.payload.embeds) ? this.payload.embeds : [];
-    return embeds.map((embed) => {
-      const serialized =
-        embed &&
-        typeof embed === 'object' &&
-        'toJSON' in embed &&
-        typeof embed.toJSON === 'function'
-          ? embed.toJSON()
-          : embed;
-      return serialized as {
-        title?: string;
-        fields: Array<{ name: string; value: string }>;
-      };
-    });
   }
 }
 
@@ -69,21 +42,12 @@ class FakeDiscordChannel {
   private nextMessageId = 0;
   public readonly sentMessages: FakeDiscordMessage[] = [];
   public readonly messages = {
-    fetch: jest.fn(async (request: string | { limit: number; before?: string }) => {
-      if (typeof request === 'string') {
-        const message = this.sentMessages.find((entry) => entry.id === request && !entry.deleted);
-        if (!message) {
-          throw Object.assign(new Error(`Message ${request} not found`), { code: 10008 });
-        }
-        return message as unknown as Message;
+    fetch: jest.fn(async (messageId: string) => {
+      const message = this.sentMessages.find((entry) => entry.id === messageId && !entry.deleted);
+      if (!message) {
+        throw Object.assign(new Error(`Message ${messageId} not found`), { code: 10008 });
       }
-
-      const visibleMessages = this.sentMessages.filter((entry) => !entry.deleted).reverse();
-      const startIndex = request.before
-        ? Math.max(0, visibleMessages.findIndex((entry) => entry.id === request.before) + 1)
-        : 0;
-      const page = visibleMessages.slice(startIndex, startIndex + request.limit);
-      return new Map(page.map((message) => [message.id, message])) as unknown;
+      return message as unknown as Message;
     }),
   };
   public readonly send = jest.fn(async (payload: MessageCreateOptions) => {
@@ -396,7 +360,6 @@ const buildService = (
     ),
   } as unknown as IDetectionEventsRepository;
   const client = {
-    user: { id: 'bot-user' },
     channels: {
       fetch: jest.fn(async (channelId: string) => (channelId === channel.id ? channel : null)),
     },
@@ -417,15 +380,6 @@ const buildService = (
 };
 
 describe('ModerationQueueService', () => {
-  const buildCaseMirrorMessagePayload = (caseId: string): Record<string, unknown> => ({
-    embeds: [
-      {
-        title: 'Pending Moderation Case',
-        fields: [{ name: 'Case', value: `\`${caseId}\`` }],
-      },
-    ],
-  });
-
   it('syncs pending cases and un-actioned observed alerts, then removes stale mirrors', async () => {
     const queueRepository = new FakeModerationQueueRepository();
     const stale = await queueRepository.upsert({
@@ -613,67 +567,6 @@ describe('ModerationQueueService', () => {
     expect(channel.sentMessages[0].delete).toHaveBeenCalledTimes(2);
     expect(queueRepository.items).toHaveLength(0);
     warnSpy.mockRestore();
-  });
-
-  it('removes an orphaned bot-authored case card during queue sync', async () => {
-    const channel = new FakeDiscordChannel('queue-channel');
-    const orphanedMessage = new FakeDiscordMessage(
-      'orphaned-message',
-      channel.id,
-      buildCaseMirrorMessagePayload('resolved-case')
-    );
-    const moderatorMessage = new FakeDiscordMessage(
-      'moderator-message',
-      channel.id,
-      buildCaseMirrorMessagePayload('resolved-case'),
-      'moderator-user'
-    );
-    const unrelatedBotMessage = new FakeDiscordMessage('unrelated-bot-message', channel.id, {
-      embeds: [{ title: 'Queue instructions', fields: [] }],
-    });
-    channel.sentMessages.push(orphanedMessage, moderatorMessage, unrelatedBotMessage);
-    const { service } = buildService({ channel });
-
-    await service.syncServerQueue('guild-1');
-
-    expect(orphanedMessage.delete).toHaveBeenCalledTimes(1);
-    expect(orphanedMessage.deleted).toBe(true);
-    expect(moderatorMessage.delete).not.toHaveBeenCalled();
-    expect(unrelatedBotMessage.delete).not.toHaveBeenCalled();
-  });
-
-  it('removes duplicate case cards while keeping the database-tracked active card', async () => {
-    const channel = new FakeDiscordChannel('queue-channel');
-    const trackedMessage = new FakeDiscordMessage(
-      'tracked-message',
-      channel.id,
-      buildCaseMirrorMessagePayload('case-1')
-    );
-    const duplicateMessage = new FakeDiscordMessage(
-      'duplicate-message',
-      channel.id,
-      buildCaseMirrorMessagePayload('case-1')
-    );
-    channel.sentMessages.push(trackedMessage, duplicateMessage);
-    const queueRepository = new FakeModerationQueueRepository();
-    await queueRepository.upsert({
-      serverId: 'guild-1',
-      userId: 'user-1',
-      itemType: ModerationQueueItemType.CASE_MIRROR,
-      verificationEventId: 'case-1',
-      queueChannelId: channel.id,
-      queueMessageId: trackedMessage.id,
-    });
-    const { service } = buildService({
-      channel,
-      pendingCases: [buildVerificationEvent()],
-      queueRepository,
-    });
-
-    await service.syncServerQueue('guild-1');
-
-    expect(trackedMessage.delete).not.toHaveBeenCalled();
-    expect(duplicateMessage.delete).toHaveBeenCalledTimes(1);
   });
 
   it('runs the shared queue reconciliation at startup and once per day', async () => {

--- a/src/controllers/EventHandler.ts
+++ b/src/controllers/EventHandler.ts
@@ -236,9 +236,7 @@ export class EventHandler implements IEventHandler {
     await this.ensureConfigInitialized();
 
     await this.commandHandler.registerCommands();
-    void this.moderationQueueService?.syncAllActiveServerQueues().catch((error) => {
-      console.warn('Failed to sync live moderation queues on startup:', error);
-    });
+    this.moderationQueueService?.start();
     this.caseReviewReminderService?.start();
   }
 

--- a/src/repositories/ModerationQueueRepository.ts
+++ b/src/repositories/ModerationQueueRepository.ts
@@ -7,7 +7,10 @@ import { ModerationQueueItem, ModerationQueueItemType, ModerationQueueItemUpsert
 export interface IModerationQueueRepository {
   findById(id: string): Promise<ModerationQueueItem | null>;
   findByCase(verificationEventId: string): Promise<ModerationQueueItem | null>;
+  listByCase(verificationEventId: string): Promise<ModerationQueueItem[]>;
   findByObservedAlert(detectionEventId: string): Promise<ModerationQueueItem | null>;
+  listByObservedAlert(detectionEventId: string): Promise<ModerationQueueItem[]>;
+  listByReportIntake(reportIntakeId: string): Promise<ModerationQueueItem[]>;
   findByPendingScreeningMember(
     serverId: string,
     userId: string
@@ -28,10 +31,6 @@ export interface IModerationQueueRepository {
     queueMessageId: string | null
   ): Promise<ModerationQueueItem | null>;
   deleteById(id: string): Promise<ModerationQueueItem | null>;
-  deleteByCase(verificationEventId: string): Promise<ModerationQueueItem[]>;
-  deleteByObservedAlert(detectionEventId: string): Promise<ModerationQueueItem[]>;
-  deleteByPendingScreeningMember(serverId: string, userId: string): Promise<ModerationQueueItem[]>;
-  deleteByReportIntake(reportIntakeId: string): Promise<ModerationQueueItem[]>;
 }
 
 @injectable()
@@ -76,6 +75,20 @@ export class ModerationQueueRepository implements IModerationQueueRepository {
     }
   }
 
+  async listByCase(verificationEventId: string): Promise<ModerationQueueItem[]> {
+    try {
+      const items = await this.prisma.moderation_queue_items.findMany({
+        where: {
+          item_type: ModerationQueueItemType.CASE_MIRROR as moderation_queue_item_type,
+          verification_event_id: verificationEventId,
+        },
+      });
+      return items as ModerationQueueItem[];
+    } catch (error) {
+      this.handleError(error, 'listModerationQueueItemsByCase');
+    }
+  }
+
   async findByObservedAlert(detectionEventId: string): Promise<ModerationQueueItem | null> {
     try {
       const item = await this.prisma.moderation_queue_items.findFirst({
@@ -87,6 +100,31 @@ export class ModerationQueueRepository implements IModerationQueueRepository {
       return item as ModerationQueueItem | null;
     } catch (error) {
       this.handleError(error, 'findModerationQueueItemByObservedAlert');
+    }
+  }
+
+  async listByObservedAlert(detectionEventId: string): Promise<ModerationQueueItem[]> {
+    try {
+      const items = await this.prisma.moderation_queue_items.findMany({
+        where: {
+          item_type: ModerationQueueItemType.OBSERVED_ALERT_MIRROR as moderation_queue_item_type,
+          detection_event_id: detectionEventId,
+        },
+      });
+      return items as ModerationQueueItem[];
+    } catch (error) {
+      this.handleError(error, 'listModerationQueueItemsByObservedAlert');
+    }
+  }
+
+  async listByReportIntake(reportIntakeId: string): Promise<ModerationQueueItem[]> {
+    try {
+      const items = await this.prisma.moderation_queue_items.findMany({
+        where: { report_intake_id: reportIntakeId },
+      });
+      return items as ModerationQueueItem[];
+    } catch (error) {
+      this.handleError(error, 'listModerationQueueItemsByReportIntake');
     }
   }
 
@@ -209,50 +247,6 @@ export class ModerationQueueRepository implements IModerationQueueRepository {
         return null;
       }
       this.handleError(error, 'deleteModerationQueueItemById');
-    }
-  }
-
-  async deleteByCase(verificationEventId: string): Promise<ModerationQueueItem[]> {
-    return this.deleteMany({ verification_event_id: verificationEventId });
-  }
-
-  async deleteByObservedAlert(detectionEventId: string): Promise<ModerationQueueItem[]> {
-    return this.deleteMany({
-      item_type: ModerationQueueItemType.OBSERVED_ALERT_MIRROR as moderation_queue_item_type,
-      detection_event_id: detectionEventId,
-    });
-  }
-
-  async deleteByPendingScreeningMember(
-    serverId: string,
-    userId: string
-  ): Promise<ModerationQueueItem[]> {
-    return this.deleteMany({
-      server_id: serverId,
-      user_id: userId,
-      item_type: ModerationQueueItemType.PENDING_SCREENING_MEMBER as moderation_queue_item_type,
-    });
-  }
-
-  async deleteByReportIntake(reportIntakeId: string): Promise<ModerationQueueItem[]> {
-    return this.deleteMany({ report_intake_id: reportIntakeId });
-  }
-
-  private async deleteMany(
-    where: Prisma.moderation_queue_itemsWhereInput
-  ): Promise<ModerationQueueItem[]> {
-    try {
-      const items = await this.prisma.moderation_queue_items.findMany({ where });
-      if (items.length === 0) {
-        return [];
-      }
-
-      await this.prisma.moderation_queue_items.deleteMany({
-        where: { id: { in: items.map((item) => item.id) } },
-      });
-      return items as ModerationQueueItem[];
-    } catch (error) {
-      this.handleError(error, 'deleteModerationQueueItems');
     }
   }
 

--- a/src/services/ModerationQueueService.ts
+++ b/src/services/ModerationQueueService.ts
@@ -3,7 +3,6 @@ import {
   ButtonBuilder,
   ButtonStyle,
   Client,
-  type Collection,
   EmbedBuilder,
   Message,
   MessageCreateOptions,
@@ -35,16 +34,12 @@ const QUEUE_ACK_CUSTOM_ID_PREFIX = 'queue:ack';
 const DISCORD_EMBED_FIELD_MAX_LENGTH = 1024;
 const QUEUE_PREVIEW_MAX_LENGTH = 700;
 const MODERATION_QUEUE_RECONCILIATION_INTERVAL_MS = 24 * 60 * 60 * 1000;
-const MODERATION_QUEUE_RECONCILIATION_PAGE_SIZE = 100;
-const MODERATION_QUEUE_RECONCILIATION_MAX_MESSAGES = 1000;
-const CASE_MIRROR_TITLES = new Set(['Pending Moderation Case', 'Pending Case: Member Left Server']);
 
 interface QueueTextChannel {
   readonly id: string;
   send(options: MessageCreateOptions): Promise<Message>;
   messages: {
     fetch(messageId: string): Promise<Message>;
-    fetch(options: { limit: number; before?: string }): Promise<Collection<string, Message>>;
   };
 }
 
@@ -145,8 +140,7 @@ export class ModerationQueueService implements IModerationQueueService {
 
   public async syncServerQueue(serverId: string): Promise<void> {
     const serverConfig = await this.configService.getServerConfig(serverId);
-    const queueChannel = await this.getQueueChannel(serverConfig.settings);
-    if (!queueChannel) {
+    if (!getModerationQueueSettings(serverConfig.settings).channelId) {
       return;
     }
 
@@ -165,11 +159,6 @@ export class ModerationQueueService implements IModerationQueueService {
       serverId,
       new Set(pendingCases.map((event) => event.id)),
       new Set(observedAlerts.map((event) => event.id))
-    );
-    await this.reconcileCaseMirrorMessages(
-      serverId,
-      queueChannel,
-      new Set(pendingCases.map((event) => event.id))
     );
   }
 
@@ -483,104 +472,6 @@ export class ModerationQueueService implements IModerationQueueService {
     } finally {
       this.reconciliationRunning = false;
     }
-  }
-
-  private async reconcileCaseMirrorMessages(
-    serverId: string,
-    queueChannel: QueueTextChannel,
-    activeCaseIds: Set<string>
-  ): Promise<void> {
-    const botUserId = this.client.user?.id;
-    if (!botUserId) {
-      return;
-    }
-
-    const trackedCaseItems = await this.moderationQueueRepository.listByServerAndTypes(serverId, [
-      ModerationQueueItemType.CASE_MIRROR,
-    ]);
-    const trackedItemByCaseId = new Map(
-      trackedCaseItems
-        .filter(
-          (
-            item
-          ): item is ModerationQueueItem & {
-            verification_event_id: string;
-            queue_message_id: string;
-          } => Boolean(item.verification_event_id && item.queue_message_id)
-        )
-        .map((item) => [item.verification_event_id, item])
-    );
-
-    let before: string | undefined;
-    let inspected = 0;
-    while (inspected < MODERATION_QUEUE_RECONCILIATION_MAX_MESSAGES) {
-      const limit = Math.min(
-        MODERATION_QUEUE_RECONCILIATION_PAGE_SIZE,
-        MODERATION_QUEUE_RECONCILIATION_MAX_MESSAGES - inspected
-      );
-      let page: Collection<string, Message>;
-      try {
-        page = await queueChannel.messages.fetch({ limit, ...(before ? { before } : {}) });
-      } catch (error) {
-        console.warn(
-          `Failed to inspect live moderation queue history for guild ${serverId}:`,
-          error
-        );
-        return;
-      }
-
-      const messages = [...page.values()];
-      if (messages.length === 0) {
-        return;
-      }
-
-      for (const message of messages) {
-        const caseId = this.readCaseMirrorId(message);
-        if (!caseId || message.author.id !== botUserId) {
-          continue;
-        }
-
-        const trackedItem = trackedItemByCaseId.get(caseId);
-        const isCurrentTrackedMessage =
-          activeCaseIds.has(caseId) && trackedItem?.queue_message_id === message.id;
-        if (!isCurrentTrackedMessage) {
-          const deleted = await this.deleteDiscordMessage(
-            message,
-            `orphaned or duplicate case mirror ${caseId} in guild ${serverId}`
-          );
-          if (
-            deleted &&
-            !activeCaseIds.has(caseId) &&
-            trackedItem?.queue_message_id === message.id
-          ) {
-            await this.moderationQueueRepository.deleteById(trackedItem.id);
-          }
-        }
-      }
-
-      inspected += messages.length;
-      if (messages.length < limit) {
-        return;
-      }
-      before = messages[messages.length - 1].id;
-    }
-
-    console.warn(
-      `Stopped live moderation queue history reconciliation for guild ${serverId} after ${MODERATION_QUEUE_RECONCILIATION_MAX_MESSAGES} messages.`
-    );
-  }
-
-  private readCaseMirrorId(message: Message): string | null {
-    const embed = message.embeds.find((candidate) =>
-      candidate.title ? CASE_MIRROR_TITLES.has(candidate.title) : false
-    );
-    const caseField = embed?.fields.find((field) => field.name === 'Case');
-    if (!caseField) {
-      return null;
-    }
-
-    const match = caseField.value.match(/`([^`]+)`/);
-    return match?.[1] ?? null;
   }
 
   private async upsertAttentionItem(input: {

--- a/src/services/ModerationQueueService.ts
+++ b/src/services/ModerationQueueService.ts
@@ -352,10 +352,11 @@ export class ModerationQueueService implements IModerationQueueService {
   }
 
   public async deletePendingScreeningMember(serverId: string, userId: string): Promise<void> {
-    const items = await this.moderationQueueRepository.listByServerAndTypes(serverId, [
-      ModerationQueueItemType.PENDING_SCREENING_MEMBER,
-    ]);
-    await this.deleteQueueItems(items.filter((item) => item.user_id === userId));
+    const item = await this.moderationQueueRepository.findByPendingScreeningMember(
+      serverId,
+      userId
+    );
+    await this.deleteQueueItems(item ? [item] : []);
   }
 
   public async recordSupportThreadAttention(
@@ -837,6 +838,9 @@ export class ModerationQueueService implements IModerationQueueService {
           ? (fetchedChannel as unknown as QueueTextChannel)
           : null;
     } catch (error) {
+      if (this.isUnknownDiscordResource(error)) {
+        return true;
+      }
       console.warn(`Failed to fetch live moderation queue channel for item ${item.id}:`, error);
       return false;
     }

--- a/src/services/ModerationQueueService.ts
+++ b/src/services/ModerationQueueService.ts
@@ -3,6 +3,7 @@ import {
   ButtonBuilder,
   ButtonStyle,
   Client,
+  type Collection,
   EmbedBuilder,
   Message,
   MessageCreateOptions,
@@ -33,12 +34,17 @@ import { QueueAttentionService } from './QueueAttentionService';
 const QUEUE_ACK_CUSTOM_ID_PREFIX = 'queue:ack';
 const DISCORD_EMBED_FIELD_MAX_LENGTH = 1024;
 const QUEUE_PREVIEW_MAX_LENGTH = 700;
+const MODERATION_QUEUE_RECONCILIATION_INTERVAL_MS = 24 * 60 * 60 * 1000;
+const MODERATION_QUEUE_RECONCILIATION_PAGE_SIZE = 100;
+const MODERATION_QUEUE_RECONCILIATION_MAX_MESSAGES = 1000;
+const CASE_MIRROR_TITLES = new Set(['Pending Moderation Case', 'Pending Case: Member Left Server']);
 
 interface QueueTextChannel {
   readonly id: string;
   send(options: MessageCreateOptions): Promise<Message>;
   messages: {
     fetch(messageId: string): Promise<Message>;
+    fetch(options: { limit: number; before?: string }): Promise<Collection<string, Message>>;
   };
 }
 
@@ -50,6 +56,8 @@ interface QueueMessagePayload {
 }
 
 export interface IModerationQueueService {
+  start(): void;
+  stop(): void;
   syncAllActiveServerQueues(): Promise<void>;
   syncServerQueue(serverId: string): Promise<void>;
   clearServerQueue(serverId: string): Promise<number>;
@@ -82,6 +90,8 @@ export interface IModerationQueueService {
 @injectable()
 export class ModerationQueueService implements IModerationQueueService {
   private readonly presentationBuilder = new NotificationPresentationBuilder();
+  private reconciliationTimer: ReturnType<typeof setInterval> | null = null;
+  private reconciliationRunning = false;
 
   constructor(
     @inject(TYPES.DiscordClient) private client: Client,
@@ -104,6 +114,26 @@ export class ModerationQueueService implements IModerationQueueService {
     return customId.startsWith(prefix) ? customId.slice(prefix.length) : null;
   }
 
+  public start(): void {
+    if (this.reconciliationTimer) {
+      return;
+    }
+
+    void this.runScheduledReconciliation();
+    this.reconciliationTimer = setInterval(() => {
+      void this.runScheduledReconciliation();
+    }, MODERATION_QUEUE_RECONCILIATION_INTERVAL_MS);
+  }
+
+  public stop(): void {
+    if (!this.reconciliationTimer) {
+      return;
+    }
+
+    clearInterval(this.reconciliationTimer);
+    this.reconciliationTimer = null;
+  }
+
   public async syncAllActiveServerQueues(): Promise<void> {
     const servers = await this.serverRepository.findAllActive();
     for (const server of servers) {
@@ -115,7 +145,8 @@ export class ModerationQueueService implements IModerationQueueService {
 
   public async syncServerQueue(serverId: string): Promise<void> {
     const serverConfig = await this.configService.getServerConfig(serverId);
-    if (!getModerationQueueSettings(serverConfig.settings).channelId) {
+    const queueChannel = await this.getQueueChannel(serverConfig.settings);
+    if (!queueChannel) {
       return;
     }
 
@@ -135,13 +166,22 @@ export class ModerationQueueService implements IModerationQueueService {
       new Set(pendingCases.map((event) => event.id)),
       new Set(observedAlerts.map((event) => event.id))
     );
+    await this.reconcileCaseMirrorMessages(
+      serverId,
+      queueChannel,
+      new Set(pendingCases.map((event) => event.id))
+    );
   }
 
   public async clearServerQueue(serverId: string): Promise<number> {
     const items = await this.moderationQueueRepository.listByServer(serverId);
-    await Promise.all(items.map((item) => this.deleteQueueMessage(item)));
-    await Promise.all(items.map((item) => this.moderationQueueRepository.deleteById(item.id)));
-    return items.length;
+    const deletedCount = await this.deleteQueueItems(items);
+    if (deletedCount !== items.length) {
+      throw new Error(
+        `Failed to delete ${items.length - deletedCount} live moderation queue message(s); queue configuration was preserved for retry.`
+      );
+    }
+    return deletedCount;
   }
 
   public async upsertCaseMirror(verificationEvent: VerificationEvent): Promise<void> {
@@ -181,8 +221,8 @@ export class ModerationQueueService implements IModerationQueueService {
   }
 
   public async deleteCaseMirror(verificationEventId: string): Promise<void> {
-    const items = await this.moderationQueueRepository.deleteByCase(verificationEventId);
-    await Promise.all(items.map((item) => this.deleteQueueMessage(item)));
+    const items = await this.moderationQueueRepository.listByCase(verificationEventId);
+    await this.deleteQueueItems(items);
   }
 
   public async upsertObservedAlertMirror(detectionEvent: DetectionEvent): Promise<void> {
@@ -232,8 +272,8 @@ export class ModerationQueueService implements IModerationQueueService {
   }
 
   public async deleteObservedAlertMirror(detectionEventId: string): Promise<void> {
-    const items = await this.moderationQueueRepository.deleteByObservedAlert(detectionEventId);
-    await Promise.all(items.map((item) => this.deleteQueueMessage(item)));
+    const items = await this.moderationQueueRepository.listByObservedAlert(detectionEventId);
+    await this.deleteQueueItems(items);
   }
 
   public async upsertPendingScreeningMember(
@@ -323,11 +363,10 @@ export class ModerationQueueService implements IModerationQueueService {
   }
 
   public async deletePendingScreeningMember(serverId: string, userId: string): Promise<void> {
-    const items = await this.moderationQueueRepository.deleteByPendingScreeningMember(
-      serverId,
-      userId
-    );
-    await Promise.all(items.map((item) => this.deleteQueueMessage(item)));
+    const items = await this.moderationQueueRepository.listByServerAndTypes(serverId, [
+      ModerationQueueItemType.PENDING_SCREENING_MEMBER,
+    ]);
+    await this.deleteQueueItems(items.filter((item) => item.user_id === userId));
   }
 
   public async recordSupportThreadAttention(
@@ -371,8 +410,8 @@ export class ModerationQueueService implements IModerationQueueService {
   }
 
   public async deleteReportThreadAttention(reportIntakeId: string): Promise<void> {
-    const items = await this.moderationQueueRepository.deleteByReportIntake(reportIntakeId);
-    await Promise.all(items.map((item) => this.deleteQueueMessage(item)));
+    const items = await this.moderationQueueRepository.listByReportIntake(reportIntakeId);
+    await this.deleteQueueItems(items);
   }
 
   public async acknowledgeAttentionItem(
@@ -381,7 +420,11 @@ export class ModerationQueueService implements IModerationQueueService {
     actorId: string
   ): Promise<boolean> {
     const service = new QueueAttentionService(this.moderationQueueRepository, {
-      deleteQueueMessage: (item): Promise<void> => this.deleteQueueMessage(item),
+      deleteQueueMessage: async (item): Promise<void> => {
+        if (!(await this.deleteQueueMessage(item))) {
+          throw new Error(`Failed to delete live moderation queue message for item ${item.id}.`);
+        }
+      },
     });
     const result = await service.acknowledgeAttentionItem({
       actor: { id: actorId, surface: 'discord_interaction' },
@@ -408,10 +451,136 @@ export class ModerationQueueService implements IModerationQueueService {
         item.item_type === ModerationQueueItemType.OBSERVED_ALERT_MIRROR &&
         (!item.detection_event_id || !activeObservedIds.has(item.detection_event_id));
       if (staleCase || staleObserved) {
-        await this.deleteQueueMessage(item);
-        await this.moderationQueueRepository.deleteById(item.id);
+        await this.deleteQueueItems([item]);
       }
     }
+  }
+
+  private async deleteQueueItems(items: ModerationQueueItem[]): Promise<number> {
+    const results = await Promise.all(
+      items.map(async (item) => {
+        if (!(await this.deleteQueueMessage(item))) {
+          return false;
+        }
+
+        await this.moderationQueueRepository.deleteById(item.id);
+        return true;
+      })
+    );
+    return results.filter(Boolean).length;
+  }
+
+  private async runScheduledReconciliation(): Promise<void> {
+    if (this.reconciliationRunning) {
+      return;
+    }
+
+    this.reconciliationRunning = true;
+    try {
+      await this.syncAllActiveServerQueues();
+    } catch (error) {
+      console.warn('Failed to reconcile live moderation queues:', error);
+    } finally {
+      this.reconciliationRunning = false;
+    }
+  }
+
+  private async reconcileCaseMirrorMessages(
+    serverId: string,
+    queueChannel: QueueTextChannel,
+    activeCaseIds: Set<string>
+  ): Promise<void> {
+    const botUserId = this.client.user?.id;
+    if (!botUserId) {
+      return;
+    }
+
+    const trackedCaseItems = await this.moderationQueueRepository.listByServerAndTypes(serverId, [
+      ModerationQueueItemType.CASE_MIRROR,
+    ]);
+    const trackedItemByCaseId = new Map(
+      trackedCaseItems
+        .filter(
+          (
+            item
+          ): item is ModerationQueueItem & {
+            verification_event_id: string;
+            queue_message_id: string;
+          } => Boolean(item.verification_event_id && item.queue_message_id)
+        )
+        .map((item) => [item.verification_event_id, item])
+    );
+
+    let before: string | undefined;
+    let inspected = 0;
+    while (inspected < MODERATION_QUEUE_RECONCILIATION_MAX_MESSAGES) {
+      const limit = Math.min(
+        MODERATION_QUEUE_RECONCILIATION_PAGE_SIZE,
+        MODERATION_QUEUE_RECONCILIATION_MAX_MESSAGES - inspected
+      );
+      let page: Collection<string, Message>;
+      try {
+        page = await queueChannel.messages.fetch({ limit, ...(before ? { before } : {}) });
+      } catch (error) {
+        console.warn(
+          `Failed to inspect live moderation queue history for guild ${serverId}:`,
+          error
+        );
+        return;
+      }
+
+      const messages = [...page.values()];
+      if (messages.length === 0) {
+        return;
+      }
+
+      for (const message of messages) {
+        const caseId = this.readCaseMirrorId(message);
+        if (!caseId || message.author.id !== botUserId) {
+          continue;
+        }
+
+        const trackedItem = trackedItemByCaseId.get(caseId);
+        const isCurrentTrackedMessage =
+          activeCaseIds.has(caseId) && trackedItem?.queue_message_id === message.id;
+        if (!isCurrentTrackedMessage) {
+          const deleted = await this.deleteDiscordMessage(
+            message,
+            `orphaned or duplicate case mirror ${caseId} in guild ${serverId}`
+          );
+          if (
+            deleted &&
+            !activeCaseIds.has(caseId) &&
+            trackedItem?.queue_message_id === message.id
+          ) {
+            await this.moderationQueueRepository.deleteById(trackedItem.id);
+          }
+        }
+      }
+
+      inspected += messages.length;
+      if (messages.length < limit) {
+        return;
+      }
+      before = messages[messages.length - 1].id;
+    }
+
+    console.warn(
+      `Stopped live moderation queue history reconciliation for guild ${serverId} after ${MODERATION_QUEUE_RECONCILIATION_MAX_MESSAGES} messages.`
+    );
+  }
+
+  private readCaseMirrorId(message: Message): string | null {
+    const embed = message.embeds.find((candidate) =>
+      candidate.title ? CASE_MIRROR_TITLES.has(candidate.title) : false
+    );
+    const caseField = embed?.fields.find((field) => field.name === 'Case');
+    if (!caseField) {
+      return null;
+    }
+
+    const match = caseField.value.match(/`([^`]+)`/);
+    return match?.[1] ?? null;
   }
 
   private async upsertAttentionItem(input: {
@@ -764,14 +933,56 @@ export class ModerationQueueService implements IModerationQueueService {
 
   private async deleteQueueMessage(
     item: Pick<ModerationQueueItem, 'id' | 'queue_channel_id' | 'queue_message_id'>
-  ): Promise<void> {
+  ): Promise<boolean> {
     if (!item.queue_channel_id || !item.queue_message_id) {
-      return;
+      return true;
     }
 
-    const channel = await this.getTextChannel(item.queue_channel_id);
-    const message = await channel?.messages.fetch(item.queue_message_id).catch(() => null);
-    await message?.delete().catch(() => null);
+    let channel: QueueTextChannel | null;
+    try {
+      const fetchedChannel = await this.client.channels.fetch(item.queue_channel_id);
+      channel =
+        fetchedChannel && 'send' in fetchedChannel && 'messages' in fetchedChannel
+          ? (fetchedChannel as unknown as QueueTextChannel)
+          : null;
+    } catch (error) {
+      console.warn(`Failed to fetch live moderation queue channel for item ${item.id}:`, error);
+      return false;
+    }
+    if (!channel) {
+      return true;
+    }
+
+    let message: Message;
+    try {
+      message = await channel.messages.fetch(item.queue_message_id);
+    } catch (error) {
+      if (this.isUnknownDiscordResource(error)) {
+        return true;
+      }
+      console.warn(`Failed to fetch live moderation queue message for item ${item.id}:`, error);
+      return false;
+    }
+
+    return this.deleteDiscordMessage(message, `queue item ${item.id}`);
+  }
+
+  private async deleteDiscordMessage(message: Message, subject: string): Promise<boolean> {
+    try {
+      await message.delete();
+      return true;
+    } catch (error) {
+      if (this.isUnknownDiscordResource(error)) {
+        return true;
+      }
+      console.warn(`Failed to delete live moderation queue message for ${subject}:`, error);
+      return false;
+    }
+  }
+
+  private isUnknownDiscordResource(error: unknown): boolean {
+    const code = (error as { code?: unknown } | null)?.code;
+    return code === 10003 || code === 10008;
   }
 
   private async getQueueChannel(


### PR DESCRIPTION
[AGENT]

## What / Why

A transient Discord fetch or delete failure could leave a resolved case card visible after Drasil had already deleted its database queue pointer.

- Delete Discord queue messages before removing their database pointers, retaining failed items for retry.
- Run the existing shared queue sync at startup and every 24 hours; operator-triggered queue sync uses the same path.
- Prevent overlapping scheduled reconciliation runs.
- Do not inspect queue-channel history or heuristically identify messages.

## Linked issues

- Closes #191

## How to test

- Force a transient case-card deletion failure and confirm the queue database pointer remains.
- Restore Discord access and run queue sync; the tracked message and pointer should then be removed.
- Start the queue service and confirm it invokes the same shared sync immediately and again after 24 hours.

## Risk / rollout

Reconciliation only operates on tracked queue records. A message orphaned before this fix must be deleted manually because its database pointer is already gone.

## AI Review Packet (fresh-context friendly)

- Primary goal: make live moderation queue cleanup retryable using existing tracked records.
- Non-goals: moderation decision changes, case status changes, queue-channel history scans, or heuristic orphan discovery.
- Key files changed: ModerationQueueService, ModerationQueueRepository, EventHandler, and focused unit coverage.
- Invariants this PR must preserve: pending cases remain mirrored; failed Discord cleanup does not discard its retry pointer; moderation resolution remains non-blocking.
- Manual test notes: no live Discord mutation was performed from this development session.
- Questions for reviewers: verify deletion ordering and scheduled-reconciliation lifecycle.

## Merge checklist

- [ ] All PR review threads resolved (or explicitly addressed)