### PR TITLE
[AGENT] Allow Claude to read trusted review context

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -313,6 +313,8 @@ jobs:
             --safe-mode
             --max-turns 100
             --tools "Read"
+            --allowedTools "Read"
+            --add-dir "${{ runner.temp }}/claude-review"
 
       - name: Extract Claude review Markdown
         id: extract_review

--- a/docs/dev/claude-review.md
+++ b/docs/dev/claude-review.md
@@ -68,16 +68,19 @@ GitHub loads their definitions from the trusted base branch before granting a
 repository token or the Claude secret. The review job checks out the exact PR
 head with persisted credentials disabled, but it never executes repository
 scripts or actions from that checkout. Generated context lives under the runner
-temporary directory rather than a PR-controlled path.
+temporary directory rather than a PR-controlled path, and that exact directory
+is explicitly added to Claude's readable roots.
 
-Claude is restricted to the `Read` tool and denied shell, file writes, edits,
-GitHub comment tools, `.git`, `/proc`, and runner credential/config paths. The
-checkout does not persist credentials. Pull-request-provided Claude hooks,
-skills, plugins, MCP servers, memory, and `CLAUDE.md` customizations are disabled
-by safe mode. The review contract is loaded with `git show` from the trusted
-base commit; a PR's edits to `REVIEW.md` are reviewed as diff content but cannot
-calibrate their own review. Line-specific findings use file and line references
-in the sticky comment rather than independent review threads.
+Claude is restricted to the `Read` tool, which is pre-authorized for the
+noninteractive review. The generated runner-temporary context directory is the
+only extra readable root added beyond the checkout. Shell, file writes, edits,
+GitHub comment tools, `.git`, `/proc`, and runner credential/config paths remain
+denied. The checkout does not persist credentials. Pull-request-provided Claude
+hooks, skills, plugins, MCP servers, memory, and `CLAUDE.md` customizations are
+disabled by safe mode. The review contract is loaded with `git show` from the
+trusted base commit; a PR's edits to `REVIEW.md` are reviewed as diff content
+but cannot calibrate their own review. Line-specific findings use file and line
+references in the sticky comment rather than independent review threads.
 
 The Claude CLI is capped at 100 turns. If it hits the cap or fails to produce a
 review, treat the failed job and sticky-comment notice as missing review


### PR DESCRIPTION
[AGENT]

## What / Why

The first trusted-base Claude review run on PR #192 completed its workflow jobs, but Claude could not read either the checked-out repository or the generated context under the runner temporary directory. Explicitly add that one trusted context directory to Claude's readable roots and pre-authorize the existing Read-only tool.

## Linked issues

- Closes #193

## Risk / rollout

This changes reviewer tooling only. Safe mode, the Read-only tool set, all sensitive-path denies, and the PR-controlled-path boundary remain in place. If the allowance is ineffective, the reviewer will continue publishing a missing-review notice rather than changing application behavior.

## AI Review Packet

- Primary goal: Let Claude read the checked-out PR and trusted generated review context without broadening its tool surface.
- Non-goals: Broaden repository writes, shell access, or application behavior.
- Key files changed: `.github/workflows/claude-review.yml`, `docs/dev/claude-review.md`.
- Invariants: The secret-backed workflow remains trusted-base; PR code is not executed; sensitive paths remain denied.
- Manual test notes: Official CLI options confirm `--allowedTools` and `--add-dir`; Prettier, actionlint, lint, build, 63 unit suites, and agent-tooling validation pass.
- Post-merge verification: Refresh PR #192 and confirm prepare, generation, and publishing produce a substantive review.

Because `pull_request_target` loads this workflow from `main`, PR #194 cannot exercise its own corrected workflow definition before merge.