### PR TITLE
[AGENT] Add on-demand Vercel preview deploy workflows

### DIFF
--- a/.github/workflows/vercel-preview-comment.yml
+++ b/.github/workflows/vercel-preview-comment.yml
@@ -9,13 +9,14 @@ permissions:
   actions: write
   contents: read
   issues: write
-  pull-requests: write
+  pull-requests: read
 
 jobs:
   queue-preview:
     if: >-
       ${{ github.event.issue.pull_request
       && github.event.comment.user.type != 'Bot'
+      && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
       && (contains(github.event.comment.body, '@drasil preview')
       || contains(github.event.comment.body, '/vercel-preview')) }}
     runs-on: ubuntu-latest

--- a/.github/workflows/vercel-preview-comment.yml
+++ b/.github/workflows/vercel-preview-comment.yml
@@ -1,0 +1,130 @@
+name: Trigger Manual Vercel Preview
+
+on:
+  issue_comment:
+    types:
+      - created
+
+permissions:
+  actions: write
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  queue-preview:
+    if: >-
+      ${{ github.event.issue.pull_request
+      && github.event.comment.user.type != 'Bot'
+      && (contains(github.event.comment.body, '@drasil preview')
+      || contains(github.event.comment.body, '/vercel-preview')) }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate trigger and load PR metadata
+        id: pr
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const allowedAssociations = new Set(['OWNER', 'MEMBER', 'COLLABORATOR']);
+            const authorAssociation = context.payload.comment.author_association || 'NONE';
+            if (!allowedAssociations.has(authorAssociation)) {
+              core.setFailed(
+                `Manual preview deploys may only be triggered by trusted collaborators. Got: ${authorAssociation}`,
+              );
+              return;
+            }
+
+            const { data: pull } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+            });
+
+            if (pull.head.repo?.full_name !== `${context.repo.owner}/${context.repo.repo}`) {
+              core.setFailed(
+                'Manual preview deploys only run for PR branches inside this repository. Fork PRs must be mirrored to a trusted branch first.',
+              );
+              return;
+            }
+
+            if (pull.state !== 'open') {
+              core.setFailed(`Manual preview deploys only run for open PRs. This PR is ${pull.state}.`);
+              return;
+            }
+
+            core.setOutput('comment_id', String(context.payload.comment.id));
+            core.setOutput('pr_number', String(pull.number));
+
+      - name: Add eyes reaction
+        if: success()
+        uses: actions/github-script@v9
+        env:
+          COMMENT_ID: ${{ steps.pr.outputs.comment_id }}
+        with:
+          script: |
+            try {
+              await github.rest.reactions.createForIssueComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: Number(process.env.COMMENT_ID),
+                content: 'eyes',
+              });
+            } catch (error) {
+              core.warning(`Unable to add reaction: ${error}`);
+            }
+
+      - name: Dispatch preview deployment workflow
+        if: success()
+        uses: actions/github-script@v9
+        env:
+          COMMENT_ID: ${{ steps.pr.outputs.comment_id }}
+          PR_NUMBER: ${{ steps.pr.outputs.pr_number }}
+        with:
+          script: |
+            await github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'vercel-preview-deploy.yml',
+              ref: context.payload.repository.default_branch,
+              inputs: {
+                pull_number: process.env.PR_NUMBER,
+                comment_id: process.env.COMMENT_ID,
+              },
+            });
+
+      - name: Report queue failure on PR
+        if: failure() && steps.pr.outcome == 'success'
+        uses: actions/github-script@v9
+        env:
+          COMMENT_ID: ${{ steps.pr.outputs.comment_id }}
+          PR_NUMBER: ${{ steps.pr.outputs.pr_number }}
+        with:
+          script: |
+            const runUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const body = [
+              '<!-- manual-vercel-preview-queue-failure-comment -->',
+              'Manual Vercel preview request could not be queued.',
+              `Check the workflow logs: ${runUrl}`,
+            ].join('\n');
+
+            try {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: Number(process.env.PR_NUMBER),
+                body,
+              });
+            } catch (error) {
+              core.warning(`Unable to post queue failure comment: ${error}`);
+            }
+
+            try {
+              await github.rest.reactions.createForIssueComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: Number(process.env.COMMENT_ID),
+                content: 'confused',
+              });
+            } catch (error) {
+              core.warning(`Unable to add failure reaction: ${error}`);
+            }

--- a/.github/workflows/vercel-preview-deploy.yml
+++ b/.github/workflows/vercel-preview-deploy.yml
@@ -1,0 +1,311 @@
+name: Manual Vercel Preview Deploy
+
+# Deliberately has no `push` or `pull_request` trigger. A preview deploy only
+# happens when a human asks for one: either the PR-comment workflow dispatches
+# this, someone dispatches it from the Actions UI, or another workflow calls it.
+
+on:
+  workflow_dispatch:
+    inputs:
+      pull_number:
+        description: 'Pull request number to deploy'
+        required: false
+        type: string
+      git_ref:
+        description: 'Branch, tag, or SHA to deploy when no pull_number is supplied'
+        required: false
+        type: string
+      comment_id:
+        description: 'Issue comment id that triggered the preview'
+        required: false
+        type: string
+  workflow_call:
+    inputs:
+      pull_number:
+        description: 'Pull request number to deploy'
+        required: false
+        type: string
+      git_ref:
+        description: 'Branch, tag, or SHA to deploy when no pull_number is supplied'
+        required: false
+        type: string
+      comment_id:
+        description: 'Issue comment id that triggered the preview'
+        required: false
+        type: string
+    outputs:
+      deployment_url:
+        description: 'Preview deployment URL'
+        value: ${{ jobs.deploy-preview.outputs.deployment_url }}
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  deploy-preview:
+    runs-on: ubuntu-latest
+    outputs:
+      deployment_url: ${{ steps.deploy.outputs.deployment_url }}
+    concurrency:
+      group: vercel-preview-${{ inputs.pull_number || inputs.git_ref || github.run_id }}
+      cancel-in-progress: true
+    steps:
+      - name: Resolve deploy target
+        id: pr
+        uses: actions/github-script@v9
+        env:
+          INPUT_PULL_NUMBER: ${{ inputs.pull_number }}
+          INPUT_GIT_REF: ${{ inputs.git_ref }}
+          INPUT_COMMENT_ID: ${{ inputs.comment_id }}
+        with:
+          script: |
+            const pullNumberInput = String(process.env.INPUT_PULL_NUMBER || '').trim();
+            const gitRefInput = String(process.env.INPUT_GIT_REF || '').trim();
+
+            core.setOutput('comment_id', String(process.env.INPUT_COMMENT_ID || ''));
+
+            if (!pullNumberInput && !gitRefInput) {
+              core.setFailed('Supply either pull_number or git_ref.');
+              return;
+            }
+
+            if (!pullNumberInput) {
+              if (gitRefInput) {
+                core.info(`Deploying git_ref ${gitRefInput} with no PR context.`);
+              }
+              let commit;
+              try {
+                ({ data: commit } = await github.rest.repos.getCommit({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  ref: gitRefInput,
+                }));
+              } catch (error) {
+                const status = error.status ? ` (HTTP ${error.status})` : '';
+                core.setFailed(
+                  `Unable to resolve git_ref \`${gitRefInput}\` as a branch, tag, or commit${status}.`,
+                );
+                return;
+              }
+
+              core.setOutput('head_sha', commit.sha);
+              core.setOutput('head_ref', gitRefInput);
+              core.setOutput('pr_number', '');
+              return;
+            }
+
+            if (gitRefInput) {
+              core.warning('Both pull_number and git_ref were supplied; git_ref is ignored.');
+            }
+
+            const pullNumber = Number(pullNumberInput);
+            if (!Number.isInteger(pullNumber) || pullNumber <= 0) {
+              core.setFailed('pull_number must be a positive integer.');
+              return;
+            }
+
+            const { data: pull } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pullNumber,
+            });
+
+            if (pull.head.repo?.full_name !== `${context.repo.owner}/${context.repo.repo}`) {
+              core.setFailed(
+                'Manual preview deploys only run for PR branches inside this repository. Fork PRs must be mirrored to a trusted branch first.',
+              );
+              return;
+            }
+
+            if (pull.state !== 'open') {
+              core.setFailed(`Manual preview deploys only run for open PRs. This PR is ${pull.state}.`);
+              return;
+            }
+
+            core.setOutput('head_sha', pull.head.sha);
+            core.setOutput('head_ref', pull.head.ref);
+            core.setOutput('pr_number', String(pull.number));
+
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ steps.pr.outputs.head_sha }}
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Validate Vercel configuration
+        shell: bash
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ vars.VERCEL_PROJECT_ID }}
+        run: |
+          set -euo pipefail
+          : "${VERCEL_TOKEN:?Set VERCEL_TOKEN secret}"
+          : "${VERCEL_ORG_ID:?Set VERCEL_ORG_ID variable}"
+          : "${VERCEL_PROJECT_ID:?Set VERCEL_PROJECT_ID variable}"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Vercel CLI
+        run: npm install --global vercel@50.32.5
+
+      - name: Pull preview environment
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ vars.VERCEL_PROJECT_ID }}
+        run: vercel pull --yes --environment=preview --token="$VERCEL_TOKEN"
+
+      - name: Build preview deployment
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ vars.VERCEL_PROJECT_ID }}
+        run: vercel build --token="$VERCEL_TOKEN"
+
+      - name: Deploy preview
+        id: deploy
+        shell: bash
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ vars.VERCEL_PROJECT_ID }}
+        run: |
+          set -euo pipefail
+          vercel deploy --prebuilt --archive=tgz --token="$VERCEL_TOKEN" > deployment-url.txt
+          DEPLOYMENT_URL="$(awk 'NF { line=$0 } END { gsub(/\r/, "", line); print line }' deployment-url.txt)"
+          : "${DEPLOYMENT_URL:?Unable to determine deployment URL}"
+          echo "deployment_url=$DEPLOYMENT_URL" >> "$GITHUB_OUTPUT"
+
+      - name: Post preview comment
+        if: success() && steps.pr.outputs.pr_number != ''
+        uses: actions/github-script@v9
+        env:
+          DEPLOYMENT_URL: ${{ steps.deploy.outputs.deployment_url }}
+          HEAD_REF: ${{ steps.pr.outputs.head_ref }}
+          PR_NUMBER: ${{ steps.pr.outputs.pr_number }}
+        with:
+          script: |
+            const marker = '<!-- manual-vercel-preview-comment -->';
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const issue_number = Number(process.env.PR_NUMBER);
+
+            const body = [
+              marker,
+              '## Manual Vercel Preview',
+              `Branch \`${process.env.HEAD_REF}\`.`,
+              `Preview URL: ${process.env.DEPLOYMENT_URL}`,
+              '',
+              'Comment `@drasil preview` or `/vercel-preview` on this PR for a fresh preview deployment.',
+            ].join('\n');
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number,
+              per_page: 100,
+            });
+
+            const existing = comments.find(
+              (comment) => comment.user?.type === 'Bot' && comment.body?.includes(marker),
+            );
+
+            if (existing) {
+              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number, body });
+            }
+
+      - name: Add rocket reaction
+        if: success() && steps.pr.outputs.comment_id != ''
+        uses: actions/github-script@v9
+        env:
+          COMMENT_ID: ${{ steps.pr.outputs.comment_id }}
+        with:
+          script: |
+            try {
+              await github.rest.reactions.createForIssueComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: Number(process.env.COMMENT_ID),
+                content: 'rocket',
+              });
+            } catch (error) {
+              core.warning(`Unable to add success reaction: ${error}`);
+            }
+
+      - name: Report failure on PR
+        if: failure() && steps.pr.outputs.pr_number != ''
+        uses: actions/github-script@v9
+        env:
+          COMMENT_ID: ${{ steps.pr.outputs.comment_id }}
+          PR_NUMBER: ${{ steps.pr.outputs.pr_number }}
+        with:
+          script: |
+            const marker = '<!-- manual-vercel-preview-failure-comment -->';
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const issue_number = Number(process.env.PR_NUMBER);
+            const runUrl = `https://github.com/${owner}/${repo}/actions/runs/${context.runId}`;
+            const body = [
+              marker,
+              'Manual Vercel preview deploy failed.',
+              `Check the workflow logs: ${runUrl}`,
+            ].join('\n');
+
+            try {
+              const comments = await github.paginate(github.rest.issues.listComments, {
+                owner,
+                repo,
+                issue_number,
+                per_page: 100,
+              });
+              const existing = comments.find(
+                (comment) => comment.user?.type === 'Bot' && comment.body?.includes(marker),
+              );
+              if (existing) {
+                await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+              } else {
+                await github.rest.issues.createComment({ owner, repo, issue_number, body });
+              }
+            } catch (error) {
+              core.warning(`Unable to post failure comment: ${error}`);
+            }
+
+            try {
+              const commentId = Number(process.env.COMMENT_ID || '0');
+              if (commentId > 0) {
+                await github.rest.reactions.createForIssueComment({
+                  owner,
+                  repo,
+                  comment_id: commentId,
+                  content: 'confused',
+                });
+              }
+            } catch (error) {
+              core.warning(`Unable to add failure reaction: ${error}`);
+            }
+
+      - name: Deployment summary
+        if: always() && steps.pr.outcome == 'success'
+        shell: bash
+        env:
+          DEPLOYMENT_URL: ${{ steps.deploy.outputs.deployment_url }}
+          HEAD_REF: ${{ steps.pr.outputs.head_ref }}
+          HEAD_SHA: ${{ steps.pr.outputs.head_sha }}
+          RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          {
+            echo "## Manual Vercel Preview"
+            echo "- Ref: \`$HEAD_REF\`"
+            echo "- Commit SHA: \`$HEAD_SHA\`"
+            echo "- Preview URL: ${DEPLOYMENT_URL:-not produced}"
+            echo "- Workflow run: $RUN_URL"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/vercel-preview-deploy.yml
+++ b/.github/workflows/vercel-preview-deploy.yml
@@ -41,7 +41,7 @@ on:
 permissions:
   contents: read
   issues: write
-  pull-requests: write
+  pull-requests: read
 
 jobs:
   deploy-preview:
@@ -71,6 +71,11 @@ jobs:
               return;
             }
 
+            // git_ref is trusted-operator-only and deliberately unguarded. Unlike the
+            // pull_number path below, it applies no same-repo check: repos.getCommit
+            // resolves commits anywhere in the fork network, so a fork SHA passed here
+            // will be checked out and built. Dispatching requires repo write access,
+            // so the only risk is a maintainer being handed a SHA to "just preview".
             if (!pullNumberInput) {
               if (gitRefInput) {
                 core.info(`Deploying git_ref ${gitRefInput} with no PR context.`);

--- a/docs/web-dashboard.md
+++ b/docs/web-dashboard.md
@@ -222,6 +222,8 @@ Preview deploys are opt-in per PR. Nothing deploys a preview automatically.
 
 Before the first preview run, confirm in the Vercel project that the Preview environment variables are scoped to Preview and do not inherit production values. `DATABASE_URL`, `DRASIL_WEB_BOT_TOKEN`, `DRASIL_SESSION_SECRET`, and `DRASIL_OAUTH_ENCRYPTION_KEY` set to "All Environments" would point preview deployments at the production database and the live bot token.
 
+This repository is public and the deploy workflow posts the preview URL as a PR comment, so a preview address becomes world-readable the moment it is produced. Confirm Vercel Deployment Protection is enabled for the Preview environment before the trigger is used. Without it, that published URL is an unauthenticated door to whatever the preview is wired to.
+
 ## Day-One Quality Gates
 
 The web package starts with the same style of quality gates that proved useful in Perkcord and Chronote:

--- a/docs/web-dashboard.md
+++ b/docs/web-dashboard.md
@@ -212,6 +212,16 @@ GitHub Actions production deploy variables/secrets:
 
 In Vercel, set the project root to `apps/web`. The checked-in `apps/web/vercel.json` disables Git-triggered deploys so GitHub Actions remains the production authority.
 
+## On-Demand Preview Deploys
+
+Preview deploys are opt-in per PR. Nothing deploys a preview automatically.
+
+- Comment `@drasil preview` or `/vercel-preview` on a PR. `.github/workflows/vercel-preview-comment.yml` checks the commenter's `author_association` (`OWNER`, `MEMBER`, or `COLLABORATOR`), rejects fork branches and closed PRs, then dispatches the deploy workflow.
+- `.github/workflows/vercel-preview-deploy.yml` runs on `workflow_dispatch` and `workflow_call` only. It has no `push` or `pull_request` trigger, so it cannot fire on its own. It exposes `deployment_url` as a `workflow_call` output for jobs that need to run against a preview.
+- It reuses the same `VERCEL_TOKEN` / `VERCEL_ORG_ID` / `VERCEL_PROJECT_ID` as the production deploy, and the same repo-root `vercel pull|build|deploy` invocation, differing only in `--environment=preview` and the absence of `--prod`.
+
+Before the first preview run, confirm in the Vercel project that the Preview environment variables are scoped to Preview and do not inherit production values. `DATABASE_URL`, `DRASIL_WEB_BOT_TOKEN`, `DRASIL_SESSION_SECRET`, and `DRASIL_OAUTH_ENCRYPTION_KEY` set to "All Environments" would point preview deployments at the production database and the live bot token.
+
 ## Day-One Quality Gates
 
 The web package starts with the same style of quality gates that proved useful in Perkcord and Chronote:


### PR DESCRIPTION
Ports PerkCord's on-demand preview deploy to drasil, adapted to a single Vercel project.

## Correction to the premise this task was assigned under

The recon note that prompted this work said drasil has "no Vercel project connected and Vercel deploys disabled," and that `deploy-prod.yml` is the only deploy path. **That is wrong**, and it changes what this PR is.

drasil already deploys `apps/web` to Vercel production on every push to `main`, via the `deploy-web-prod` job in `.github/workflows/ci.yml`. Evidence, from the most recent `main` push (run [29798819422](https://github.com/BASIC-BIT/drasil/actions/runs/29798819422)):

```
build-test:       completed/success
metrics:          completed/success
deploy-web-prod:  completed/success
snapshot-preview: completed/skipped
```

and inside `deploy-web-prod`, every Vercel step ran green:

```
4. Validate Vercel configuration: success
7. Pull production environment:   success
8. Build production deployment:   success
9. Deploy production web:         success
```

Step 4 is `: "${VERCEL_TOKEN:?...}"` on all three of `VERCEL_TOKEN`, `VERCEL_ORG_ID`, `VERCEL_PROJECT_ID`. It cannot pass unless all three are set. So the project is connected and the credentials exist.

The `deploymentEnabled: false` in `apps/web/vercel.json` disables **Vercel's own Git integration**, not Vercel. `docs/web-dashboard.md` line 213 already said so: it exists "so GitHub Actions remains the production authority." That is the opposite of Vercel being off.

So this is not inert scaffolding. It is expected to work on the first run, subject to the two gaps below.

## What changed

Two new workflows, plus one docs section. Nothing outside `.github/workflows/` and `docs/web-dashboard.md`.

**`.github/workflows/vercel-preview-comment.yml`**

- Fires on `issue_comment: created`.
- Job-level `if` requires: the comment is on a PR, the commenter is not a Bot, the commenter's `author_association` is in `{OWNER, MEMBER, COLLABORATOR}`, and the body contains `@drasil preview` or `/vercel-preview`.
- The first step re-checks `author_association` for the named error, then checks that the PR head is in this repo (no fork branches) and that the PR is open.
- Adds an eyes reaction, dispatches the deploy workflow, and on failure posts a comment plus a confused reaction.

**`.github/workflows/vercel-preview-deploy.yml`**

- `workflow_dispatch` and `workflow_call` only. No `push`, no `pull_request`, no `pull_request_target`.
- Exposes `deployment_url` as a `workflow_call` output.
- Resolves either `pull_number` (with the same fork and open-PR checks) or a bare `git_ref`.
- Deploys, then posts or updates a single marked PR comment with the preview URL, adds a rocket reaction, and writes a step summary.

Both workflows declare `pull-requests: read`, not `write`. Every API call was enumerated and nothing consumes the write scope: `pulls.get` and `repos.getCommit` are reads, and the comment and reaction calls are issue-scoped and covered by `issues: write`.

The Vercel invocation is copied from drasil's own working `deploy-web-prod` job rather than from PerkCord: node 24, `npm ci`, `vercel@50.32.5`, `vercel pull|build|deploy` from the repo root. The only differences are `--environment=preview` and the absence of `--prod`. Deviating from the path already proven in this repo is where this would most likely break, so it does not deviate.

**Docs**: one new subsection in `docs/web-dashboard.md` under the existing Vercel deploy notes.

## Can `apps/web` be a standalone Vercel target?

Yes, and this needs no project-structure decision from anyone. It is already decided and already in production:

- The Vercel project root is `apps/web` (documented at `docs/web-dashboard.md:213`).
- The CLI runs from the repo root so npm workspaces resolve, and `vercel build` honors the project's configured root directory.
- `apps/web/next.config.mjs` already handles the monorepo: `outputFileTracingRoot` and `turbopack.root` point at the repo root, `transpilePackages: ['@drasil/contracts']` and `experimental.externalDir` handle the `file:../../packages/contracts` dependency.

The production deploy exercises exactly this every time `main` moves. Preview uses the identical path.

## What a human still has to do

Three things, and none of them is something an agent may touch.

**1. Confirm the Vercel credentials are reachable from a job with no `environment:`.** `deploy-web-prod` declares `environment: Deploy - web-prod`. This preview job deliberately does not, because previews should not sit behind the production approval gate or inherit production scope. If `VERCEL_TOKEN` / `VERCEL_ORG_ID` / `VERCEL_PROJECT_ID` turn out to be scoped to that environment rather than to the repo, this job fails at the `Validate Vercel configuration` step with a named error telling you which one is missing. I did not check the scoping, because reading repo secrets is outside what I am allowed to do. The fix, if it fires, is a repo-level secret or variable, or a dedicated preview environment.

**2. Check the Vercel project's Preview environment variables before anyone runs the trigger.** This is the one I would actually worry about on a live moderation product. `apps/web` talks to Postgres via `pg` and to Discord with a bot token. `vercel pull --environment=preview` takes whatever the Vercel project has for Preview. Any of `DATABASE_URL`, `DRASIL_WEB_BOT_TOKEN` / `DISCORD_TOKEN`, `DRASIL_SESSION_SECRET`, `DRASIL_OAUTH_ENCRYPTION_KEY` that is set to "All Environments" in Vercel will hand a preview deployment the production database and the live bot token. There is no staging tier in this repo to fall back on. That is a real blast radius, it is invisible from inside the repo, and it has to be eyeballed in the Vercel dashboard.

**3. Confirm Vercel Deployment Protection is enabled for the Preview environment.** This repo is public and the deploy workflow posts the preview URL as a PR comment, so the address is world-readable the instant it is produced. Inspecting the Vercel dashboard afterwards does not close that window: one premature run publishes the URL permanently. Combined with (2), an unprotected preview URL is a public unauthenticated door to whatever the preview is wired to. Now documented in `docs/web-dashboard.md`.

Until (2) and (3) are confirmed, treat the trigger as unsafe to use even though the workflow itself is wired correctly.

## How it was verified locally

Re-run after the review fixes, on the final tree.

`actionlint v1.7.12`, on the two new files and then across the whole workflow directory:

```
$ actionlint .github/workflows/vercel-preview-comment.yml .github/workflows/vercel-preview-deploy.yml
actionlint exit=0
$ actionlint
repo-wide actionlint exit=0
```

Both files parse, and the trigger surface and permission scopes are asserted programmatically rather than checked by eye:

```
$ python -c "yaml.safe_load(...); assert ..."
vercel-preview-comment.yml -> triggers: ['issue_comment'] | permissions: {'actions': 'write', 'contents': 'read', 'issues': 'write', 'pull-requests': 'read'}
vercel-preview-deploy.yml  -> triggers: ['workflow_call', 'workflow_dispatch'] | permissions: {'contents': 'read', 'issues': 'write', 'pull-requests': 'read'}
all assertions passed
```

The assertions: the deploy workflow's triggers are exactly `{workflow_call, workflow_dispatch}` with no `push` / `pull_request` / `pull_request_target`; `deployment_url` is exposed as a job output; the comment workflow's triggers are exactly `{issue_comment}`; its job-level `if` contains `author_association`; both workflows declare `pull-requests: read`.

Prettier, matching the pinned `^3.5.3` and the root `format:check` glob, which covers `.md` but not `.yml`:

```
$ npx prettier@3.5.3 --check docs/web-dashboard.md
All matched files use Prettier code style!
```

I did not run `npm run check:ci`. It installs Playwright browsers and runs the full e2e and visual suite, and it touches none of the three changed files: no TypeScript changed, and prettier's glob excludes `.yml`. The one file it would have checked, `docs/web-dashboard.md`, I checked directly with the pinned prettier above.

### Trigger paths, traced by hand

`vercel-preview-deploy.yml` cannot fire on a push or a PR. Its `on:` block contains exactly two keys, `workflow_dispatch` and `workflow_call`, asserted above. GitHub only starts a workflow for events named in `on:`, so `push`, `pull_request`, and `pull_request_target` have no path to it. The only three ways it runs:

1. `vercel-preview-comment.yml` calls `createWorkflowDispatch` on it, which requires that workflow's job-level `if` to pass, including the association gate.
2. A human dispatches it from the Actions UI, which requires write access.
3. Another workflow `uses:` it, of which there are none today.

The comment workflow fires on every `issue_comment: created` in the repo, which is unavoidable for this pattern, but its job is skipped unless all of: the comment is on a PR, the author is not a Bot, the author is a trusted collaborator, and the body matches. A non-collaborator who says the trigger phrase now produces a skipped job, not a started runner.

## Self-reviewed risk list

- **The secret-scoping unknown above is the most likely first failure.** It fails loud and early, before any Vercel call, so the failure mode is a red run and no deployment.
- **Preview env vars pointing at production is the most damaging failure**, and it is silent: the deploy would succeed and the URL would look fine. Made worse by the URL being posted publicly. Flagged in the docs section and in items (2) and (3) above, but the repo cannot enforce either.
- **`issue_comment` runs the default branch's copy of the workflow.** That is standard, and it is what makes the authorization check trustworthy, but it means edits to the comment workflow on a branch have no effect until merged. Nobody can test the trigger from within this PR. This also means the association gate added in review is itself untested until merge.
- **The Bot exclusion in the job-level `if` is load-bearing and is a change from the reference.** The deploy workflow's success comment contains the literal string `` `@drasil preview` ``. Without the exclusion, every successful preview posts a comment that re-fires the comment workflow, which would then be gated out, but the association gate alone would not stop `github-actions[bot]` if its association ever resolved to a trusted value. Excluding bots is the direct fix. If `github.event.comment.user.type` is ever absent for some actor the expression evaluates falsy and the trigger silently stops working. I would rather it fail closed than loop.
- **The association gate changes the failure mode for a rejected collaborator from a red run to a skipped run.** Neither produced a PR comment before (the failure-report step requires `steps.pr.outcome == 'success'`), so no feedback was lost, but a legitimate user who is not yet a collaborator now gets silence rather than a red X they can click into. The in-step check is retained so a run that does start still produces the named error.
- **`git_ref` remains unguarded by design**, now stated in a comment at the branch. `repos.getCommit` resolves across the fork network, so a fork SHA handed to a maintainer would be checked out and built with `VERCEL_TOKEN` in scope. Dispatch requires repo write access, so this is a confused-deputy path against a maintainer, not an anonymous one, and the repo currently has 0 forks.
- **`concurrency` with `cancel-in-progress: true`** means a second trigger on the same PR kills the first. Intended, but a canceled run leaves the eyes reaction and no follow-up comment.
- **Least sure about**: whether `vercel pull --environment=preview` on this project returns a usable set of env vars at all. If Preview has never been configured in the Vercel dashboard, the build may fail, or produce a deployment that errors at runtime on the first DB call. I could not test this without Vercel credentials, and I did not try to obtain them.
- Untested end to end. Everything above is static verification plus inference from the production job's run history. The first real preview run is the first real test.

## Declined findings

**From the review panel:**

- **"The `Mark Claude review skipped` 403 on this PR is caused by a repo/org Workflow-permissions restriction."** The reviewer was right to reject this, and the original claim in this PR's history was wrong. Verified: `github-actions[bot]` successfully created comment `5088432289` on PR #202 at 07:19:51Z and updated it at 07:19:59Z, from these same workflows with the same `issues: write` block, five minutes after this PR's first 403. A repo-wide read-only token setting cannot permit two writes there while denying every write here. Nobody should change Settings > Actions > Workflow permissions over this.

  The reviewer's replacement hypothesis, that the failure is transient contention, does not survive either: it has now failed on this PR at 07:14 (Claude Review Control) and 07:33 (Claude Review), across two different workflows, while #202 succeeded in between. It tracks the pull request, not the clock. The next obvious guess, that this PR is the one touching `.github/workflows/`, also fails: PRs #190 and #194 both modified the Claude review workflows and got their sticky comments normally.

  Cause unidentified. Filed as #203 with all three eliminations recorded, and with the fix that does not depend on the diagnosis: this step exists to post a cosmetic comment and should not fail a check when it cannot. Not fixed here because both Claude review workflows are unrelated to this PR's change. **This is the one failing check on this PR.**

- **Adding a real same-repo guard to the `git_ref` path** (via `repos.listBranchesForHeadCommit`). Declined in favour of the comment now at that branch. The path requires repo write access to reach, the repo has 0 forks, and the guard would add an API call and a failure mode to close a hole only a maintainer can walk into. The honest comment is the smaller correct fix; if the repo ever gains forks this should be revisited.

**Things in the PerkCord reference I deliberately did not port:**

- **`target_profile` and the whole second-project code path.** PerkCord has two Vercel projects and a `client-checkout-gate` profile with its own token, org, and project variables. drasil has one project. Porting the switch would have added a `case` statement, six env bindings, and an input, all with exactly one reachable branch.
- **The Convex env plumbing** (`CI_CONVEX_DEPLOY_KEY`, `PLAYWRIGHT_CONVEX_*`, `PERKCORD_REST_*`, `PERKCORD_STATUS_PAGE_HEALTH_KEY`). drasil has no Convex. `DRASIL_WEB_DATA_PROVIDER` mentions a future Convex adapter, but wiring deploy-time secrets for an adapter nobody has selected is scaffolding for a decision nobody has made.
- **The trigger regex inside the comment script.** With `target_profile` gone, its only remaining job was word-boundary strictness on a string the job-level `contains()` had already matched. Replaced with the Bot exclusion, which fixes the actual self-trigger problem the regex was incidentally covering.
- **PerkCord's separate `Deployment failure summary` step.** It duplicated the success summary for the no-PR case. Folded into one summary step with `if: always() && steps.pr.outcome == 'success'` and a `${DEPLOYMENT_URL:-not produced}` fallback.

An earlier draft of this body closed with a line claiming "567 lines of reference became 290." That number was not reproducible from the diff and has been removed. The two workflows total 447 lines, 400 excluding blanks and comments. The list above is the substantive claim; the ratio was not.

## Not merging

Per ship policy this is a PR only. `skip-claude-review` applied.
